### PR TITLE
CAMEL-14481: camel-spring-boot: Remove camel-management to disable JM…

### DIFF
--- a/camel-spring-boot/pom.xml
+++ b/camel-spring-boot/pom.xml
@@ -77,11 +77,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-main</artifactId>
         </dependency>
-        <!-- JMX is enabled by default -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-management</artifactId>
-        </dependency>
 
         <!-- Optional Spring web support -->
         <dependency>


### PR DESCRIPTION
…X by default

Test and examples will not be able to detect anything broken by this change because `camel-test-spring` has a dependency on `camel-management`.