### PR TITLE
Fixing name of package and use of property instead of constant

### DIFF
--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityAutoConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityAutoConfiguration.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.example.undertow.spring.boot;
+package org.apache.camel.undertow.spring.boot;
 
 import org.apache.camel.component.spring.security.SpringSecurityConfiguration;
 import org.apache.camel.component.spring.security.keycloak.KeycloakUsernameSubClaimAdapter;
 import org.apache.camel.component.undertow.UndertowComponent;
-import org.apache.camel.example.undertow.spring.boot.providers.AbstractProviderConfiguration;
+import org.apache.camel.undertow.spring.boot.providers.AbstractProviderConfiguration;
 import org.apache.camel.spring.boot.ComponentConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -88,8 +88,7 @@ public class UndertowSpringSecurityAutoConfiguration {
     public JwtDecoder jwtDecoderByIssuerUri() {
         final String jwkSetUri = getClientRegistration().getProviderDetails().getJwkSetUri();
         final NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
-        // Use preferred_username from claims as authentication name, instead of UUID subject
-        jwtDecoder.setClaimSetConverter(new KeycloakUsernameSubClaimAdapter("preferred_username"));
+        jwtDecoder.setClaimSetConverter(new KeycloakUsernameSubClaimAdapter(getProvider().getUserNameAttribute()));;
         return jwtDecoder;
     }
 

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityConfiguration.java
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.example.undertow.spring.boot;
+package org.apache.camel.undertow.spring.boot;
 
 import org.apache.camel.component.undertow.UndertowComponent;
-import org.apache.camel.example.undertow.spring.boot.providers.KeycloakProviderConfiguration;
+import org.apache.camel.undertow.spring.boot.providers.KeycloakProviderConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/AbstractProviderConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/AbstractProviderConfiguration.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.example.undertow.spring.boot.providers;
+package org.apache.camel.undertow.spring.boot.providers;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -35,6 +35,8 @@ public abstract class AbstractProviderConfiguration {
     abstract TYPE getType();
 
     public abstract ClientRegistration getClientRegistration() throws URISyntaxException;
+
+    public abstract String getUserNameAttribute();
 
     public Converter<Jwt, ? extends AbstractAuthenticationToken> getJwtAuthenticationConverter() {
         throw new IllegalArgumentException("Not implemented");

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/KeycloakProviderConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/KeycloakProviderConfiguration.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.example.undertow.spring.boot.providers;
+package org.apache.camel.undertow.spring.boot.providers;
 
 import org.apache.camel.component.spring.security.keycloak.KeycloakJwtAuthenticationConverter;
 import org.springframework.core.convert.converter.Converter;
@@ -99,6 +99,7 @@ public class KeycloakProviderConfiguration extends AbstractProviderConfiguration
         this.realmId = realmId;
     }
 
+    @Override
     public String getUserNameAttribute() {
         return userNameAttribute;
     }

--- a/examples/camel-example-spring-boot-undertow-spring-security/src/main/java/org/apache/camel/undertow/spring/boot/Application.java
+++ b/examples/camel-example-spring-boot-undertow-spring-security/src/main/java/org/apache/camel/undertow/spring/boot/Application.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.example.undertow.spring.boot;
+package org.apache.camel.undertow.spring.boot;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.spring.security.SpringSecurityProvider;


### PR DESCRIPTION
Replaces usage of constant "preferred_username" with getProvider().getUserNameAttribute().
Renames package name in starter by omitting "example".

