### PR TITLE
Widget gadget example

### DIFF
--- a/examples/camel-example-spring-boot-widget-gadget/pom.xml
+++ b/examples/camel-example-spring-boot-widget-gadget/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>examples</artifactId>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-example-spring-boot-widget-gadget</artifactId>
+    <name>Camel SB Examples :: </name>
+    <description>The widget and gadget example from EIP book, running on Spring Boot</description>
+
+    <properties>
+        <category>Messaging</category>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+    </properties>
+
+    <dependencyManagement>
+
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Camel BOM -->
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-dependencies</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-amqp-starter</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-amqp</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jsonpath</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring</artifactId>
+            <version>${camel-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/data/order1.json
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/data/order1.json
@@ -1,0 +1,7 @@
+{ "__comment__": "Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
+  "order" : {
+    "customerId": "123",
+    "product": "widget",
+    "amount": "2"
+  }
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/data/order2.json
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/data/order2.json
@@ -1,0 +1,7 @@
+{ "__comment__": "Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
+  "order" : {
+    "customerId": "456",
+    "product": "gadget",
+    "amount": "3"
+  }
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/AmqpConfig.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/AmqpConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmqpConfig {
+
+    @Value("${AMQP_SERVICE_USERNAME}")
+    private String userName;
+    @Value("${AMQP_SERVICE_PASSWORD}")
+    private String pass;
+    @Value("${AMQP_REMOTE_URI}")
+    private String remoteUri;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPass() {
+        return pass;
+    }
+
+    public void setPass(String pass) {
+        this.pass = pass;
+    }
+
+    public String getRemoteUri() {
+        return remoteUri;
+    }
+
+    public void setRemoteUri(String remoteUri) {
+        this.remoteUri = remoteUri;
+    }
+
+    @Bean
+    public JmsConnectionFactory amqpConnectionFactory() {
+        JmsConnectionFactory jmsConnectionFactory = new JmsConnectionFactory();
+        jmsConnectionFactory.setRemoteURI(remoteUri);
+        jmsConnectionFactory.setUsername(userName);
+        jmsConnectionFactory.setPassword(pass);
+        return jmsConnectionFactory;
+    }
+
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/OrderRoute.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/OrderRoute.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderRoute extends RouteBuilder {
+
+    @Autowired
+    JmsConnectionFactory amqpConnectionFactory;
+
+    @Override
+    public void configure() throws Exception {
+        from("file:src/main/data?noop=true")
+                .to("amqp:queue:order.queue");
+    }
+
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetApp.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetApp.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package sample.camel;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetApp.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetApp.java
@@ -1,0 +1,11 @@
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class WidgetGadgetApp {
+    public static void main(String[] args) {
+        SpringApplication.run(WidgetGadgetApp.class, args);
+    }
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetRoute.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetRoute.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package sample.camel;
 
 import org.apache.camel.builder.RouteBuilder;

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetRoute.java
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/java/sample/camel/WidgetGadgetRoute.java
@@ -1,0 +1,26 @@
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WidgetGadgetRoute extends RouteBuilder {
+
+    @Autowired
+    JmsConnectionFactory amqpConnectionFactory;
+
+    @Override
+    public void configure() throws Exception {
+        from("amqp:queue:order.queue")
+                .choice()
+                    .when().jsonpath("$.order[?(@.product=='widget')]")
+                        .to("log:widget")
+                        .to("amqp:queue:widget.queue")
+                    .otherwise()
+                        .to("log:gadget")
+                        .to("amqp:queue:gadget.queue");
+    }
+
+}

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/resources/application.properties
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.artemis.mode=native
+AMQP_REMOTE_URI=amqp://localhost:5672
+AMQP_SERVICE_USERNAME=admin
+AMQP_SERVICE_PASSWORD=admin

--- a/examples/camel-example-spring-boot-widget-gadget/src/main/resources/application.properties
+++ b/examples/camel-example-spring-boot-widget-gadget/src/main/resources/application.properties
@@ -1,3 +1,20 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
 spring.artemis.mode=native
 AMQP_REMOTE_URI=amqp://localhost:5672
 AMQP_SERVICE_USERNAME=admin

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -74,6 +74,7 @@
         <module>camel-example-spring-boot-strimzi</module>
         <module>camel-example-spring-cloud-servicecall</module>
         <module>camel-example-spring-cloud-serviceregistry</module>
+        <module>camel-example-spring-boot-widget-gadget</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Classical widget-gadget integration example from the EIP book, running on SpringBoot and using AMQP and JSONPath.