### PR TITLE
[CAMEL-14565] Add additional metadata json file to include description docs for spring properties

### DIFF
--- a/components-starter/camel-consul-starter/src/main/docs/consul-starter.adoc
+++ b/components-starter/camel-consul-starter/src/main/docs/consul-starter.adoc
@@ -29,31 +29,31 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.basic-property-binding* | Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | Boolean
 | *camel.component.consul.block-seconds* | The second to wait for a watch event, default 10 seconds | 10 | Integer
 | *camel.component.consul.bridge-error-handler* | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | Boolean
-| *camel.component.consul.cluster.service.acl-token* |  |  | String
+| *camel.component.consul.cluster.service.acl-token* | The ACL token to be used with Consul |  | String
 | *camel.component.consul.cluster.service.attributes* | Custom service attributes. |  | Map
-| *camel.component.consul.cluster.service.block-seconds* |  |  | Integer
-| *camel.component.consul.cluster.service.connect-timeout* |  |  | Duration
-| *camel.component.consul.cluster.service.consistency-mode* |  |  | ConsistencyMode
-| *camel.component.consul.cluster.service.datacenter* |  |  | String
+| *camel.component.consul.cluster.service.block-seconds* | The ACL token to be used with Consul |  | Integer
+| *camel.component.consul.cluster.service.connect-timeout* | Connect timeout for OkHttpClient |  | Duration
+| *camel.component.consul.cluster.service.consistency-mode* | The consistencyMode used for queries. | ConsistencyMode.DEFAULT | ConsistencyMode
+| *camel.component.consul.cluster.service.datacenter* | The data center |  | String
 | *camel.component.consul.cluster.service.enabled* | Sets if the consul cluster service should be enabled or not, default is false. | false | Boolean
-| *camel.component.consul.cluster.service.first-index* |  |  | BigInteger
+| *camel.component.consul.cluster.service.first-index* | The first index for watch for | 0 | BigInteger
 | *camel.component.consul.cluster.service.id* | Cluster Service ID |  | String
-| *camel.component.consul.cluster.service.near-node* |  |  | String
-| *camel.component.consul.cluster.service.node-meta* |  |  | List
+| *camel.component.consul.cluster.service.near-node* | The near node to use for queries. |  | String
+| *camel.component.consul.cluster.service.node-meta* | The note meta-data to use for queries. |  | List
 | *camel.component.consul.cluster.service.order* | Service lookup order/priority. |  | Integer
-| *camel.component.consul.cluster.service.password* |  |  | String
-| *camel.component.consul.cluster.service.ping-instance* |  |  | Boolean
-| *camel.component.consul.cluster.service.read-timeout* |  |  | Duration
-| *camel.component.consul.cluster.service.recursive* |  |  | Boolean
-| *camel.component.consul.cluster.service.root-path* |  |  | String
-| *camel.component.consul.cluster.service.session-lock-delay* |  |  | Integer
-| *camel.component.consul.cluster.service.session-refresh-interval* |  |  | Integer
-| *camel.component.consul.cluster.service.session-ttl* |  |  | Integer
-| *camel.component.consul.cluster.service.ssl-context-parameters* |  |  | SSLContextParameters
-| *camel.component.consul.cluster.service.tags* |  |  | Set
-| *camel.component.consul.cluster.service.url* |  |  | String
-| *camel.component.consul.cluster.service.user-name* |  |  | String
-| *camel.component.consul.cluster.service.write-timeout* |  |  | Duration
+| *camel.component.consul.cluster.service.password* | The password to be used for basic authentication |  | String
+| *camel.component.consul.cluster.service.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
+| *camel.component.consul.cluster.service.read-timeout* | Read timeout for OkHttpClient |  | Duration
+| *camel.component.consul.cluster.service.recursive* | Recursively watch | false | Boolean
+| *camel.component.consul.cluster.service.root-path* | Consul root path | /camel | String
+| *camel.component.consul.cluster.service.session-lock-delay* | The value for lockDelay | 5 | Integer
+| *camel.component.consul.cluster.service.session-refresh-interval* | The value of wait attribute | 5 | Integer
+| *camel.component.consul.cluster.service.session-ttl* | The value of TTL | 60 | Integer
+| *camel.component.consul.cluster.service.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. |  | SSLContextParameters
+| *camel.component.consul.cluster.service.tags* | Set tags. You can separate multiple tags by comma. |  | Set
+| *camel.component.consul.cluster.service.url* | The Consul agent URL |  | String
+| *camel.component.consul.cluster.service.user-name* | The username to be used for basic authentication |  | String
+| *camel.component.consul.cluster.service.write-timeout* | Write timeout for OkHttpClient |  | Duration
 | *camel.component.consul.configuration* | Consul configuration. The option is a org.apache.camel.component.consul.ConsulConfiguration type. |  | String
 | *camel.component.consul.connect-timeout* | Connect timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
 | *camel.component.consul.consistency-mode* | The consistencyMode used for queries, default ConsistencyMode.DEFAULT |  | ConsistencyMode
@@ -69,33 +69,33 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
 | *camel.component.consul.read-timeout* | Read timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
 | *camel.component.consul.recursive* | Recursively watch, default false | false | Boolean
-| *camel.component.consul.service-registry.acl-token* |  |  | String
+| *camel.component.consul.service-registry.acl-token* | The ACL token to be used with Consul |  | String
 | *camel.component.consul.service-registry.attributes* | Custom service attributes. |  | Map
-| *camel.component.consul.service-registry.block-seconds* |  |  | Integer
-| *camel.component.consul.service-registry.check-interval* |  |  | Integer
-| *camel.component.consul.service-registry.check-ttl* |  |  | Integer
-| *camel.component.consul.service-registry.connect-timeout* |  |  | Duration
-| *camel.component.consul.service-registry.consistency-mode* |  |  | ConsistencyMode
-| *camel.component.consul.service-registry.datacenter* |  |  | String
-| *camel.component.consul.service-registry.deregister-after* |  |  | Integer
-| *camel.component.consul.service-registry.deregister-services-on-stop* |  |  | Boolean
+| *camel.component.consul.service-registry.block-seconds* | The ACL token to be used with Consul |  | Integer
+| *camel.component.consul.service-registry.check-interval* | How often (in seconds) a service has to be marked as healthy if its check is TTL or how often the check should run | 5 | Integer
+| *camel.component.consul.service-registry.check-ttl* | The time (in seconds) to live for TTL checks | 60 | Integer
+| *camel.component.consul.service-registry.connect-timeout* | Connect timeout for OkHttpClient |  | Duration
+| *camel.component.consul.service-registry.consistency-mode* | The consistencyMode used for queries. | ConsistencyMode.DEFAULT | ConsistencyMode
+| *camel.component.consul.service-registry.datacenter* | The data center |  | String
+| *camel.component.consul.service-registry.deregister-after* | How long (in seconds) to wait to deregister a service in case of unclean shutdown. | 3600 | Integer
+| *camel.component.consul.service-registry.deregister-services-on-stop* | Should we remove all the registered services know by this registry on stop? | true | Boolean
 | *camel.component.consul.service-registry.enabled* | Sets if the consul service registry should be enabled or not, default is false. | false | Boolean
-| *camel.component.consul.service-registry.first-index* |  |  | BigInteger
+| *camel.component.consul.service-registry.first-index* | The first index for watch for | 0 | BigInteger
 | *camel.component.consul.service-registry.id* | Service Registry ID |  | String
-| *camel.component.consul.service-registry.near-node* |  |  | String
-| *camel.component.consul.service-registry.node-meta* |  |  | List
+| *camel.component.consul.service-registry.near-node* | The near node to use for queries. |  | String
+| *camel.component.consul.service-registry.node-meta* | The note meta-data to use for queries. |  | List
 | *camel.component.consul.service-registry.order* | Service lookup order/priority. |  | Integer
-| *camel.component.consul.service-registry.override-service-host* |  |  | Boolean
-| *camel.component.consul.service-registry.password* |  |  | String
-| *camel.component.consul.service-registry.ping-instance* |  |  | Boolean
-| *camel.component.consul.service-registry.read-timeout* |  |  | Duration
-| *camel.component.consul.service-registry.recursive* |  |  | Boolean
-| *camel.component.consul.service-registry.service-host* |  |  | String
-| *camel.component.consul.service-registry.ssl-context-parameters* |  |  | SSLContextParameters
-| *camel.component.consul.service-registry.tags* |  |  | Set
-| *camel.component.consul.service-registry.url* |  |  | String
-| *camel.component.consul.service-registry.user-name* |  |  | String
-| *camel.component.consul.service-registry.write-timeout* |  |  | Duration
+| *camel.component.consul.service-registry.override-service-host* | Should we override the service host if given ? | true | Boolean
+| *camel.component.consul.service-registry.password* | The password to be used for basic authentication |  | String
+| *camel.component.consul.service-registry.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
+| *camel.component.consul.service-registry.read-timeout* | Read timeout for OkHttpClient |  | Duration
+| *camel.component.consul.service-registry.recursive* | Recursively watch | false | Boolean
+| *camel.component.consul.service-registry.service-host* | Service host. |  | String
+| *camel.component.consul.service-registry.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. |  | SSLContextParameters
+| *camel.component.consul.service-registry.tags* | Set tags. You can separate multiple tags by comma. |  | Set
+| *camel.component.consul.service-registry.url* | The Consul agent URL |  | String
+| *camel.component.consul.service-registry.user-name* | The username to be used for basic authentication |  | String
+| *camel.component.consul.service-registry.write-timeout* | Write timeout for OkHttpClient |  | Duration
 | *camel.component.consul.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. The option is a org.apache.camel.support.jsse.SSLContextParameters type. |  | String
 | *camel.component.consul.tags* | Set tags. You can separate multiple tags by comma. |  | String
 | *camel.component.consul.url* | The Consul agent URL |  | String
@@ -103,16 +103,16 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.user-name* | Sets the username to be used for basic authentication |  | String
 | *camel.component.consul.value-as-string* | Default to transform values retrieved from Consul i.e. on KV endpoint to string. | false | Boolean
 | *camel.component.consul.write-timeout* | Write timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
-| *camel.component.consul.cluster.service.connect-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.cluster.service.dc* | *Deprecated*  |  | String
-| *camel.component.consul.cluster.service.read-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.cluster.service.write-timeout-millis* | *Deprecated*  |  | Long
+| *camel.component.consul.cluster.service.connect-timeout-millis* | *Deprecated* Use connectTimeout instead. |  | Long
+| *camel.component.consul.cluster.service.dc* | *Deprecated* Use datacenter instead. |  | String
+| *camel.component.consul.cluster.service.read-timeout-millis* | *Deprecated* Use readTimeout instead. |  | Long
+| *camel.component.consul.cluster.service.write-timeout-millis* | *Deprecated* Use writeTimeout instead. |  | Long
 | *camel.component.consul.connect-timeout-millis* | *Deprecated* Connect timeout for OkHttpClient. Deprecation note: Use connectTimeout instead |  | Long
 | *camel.component.consul.read-timeout-millis* | *Deprecated* Read timeout for OkHttpClient. Deprecation note: Use readTimeout instead |  | Long
-| *camel.component.consul.service-registry.connect-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.service-registry.dc* | *Deprecated*  |  | String
-| *camel.component.consul.service-registry.read-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.service-registry.write-timeout-millis* | *Deprecated*  |  | Long
+| *camel.component.consul.service-registry.connect-timeout-millis* | *Deprecated* Use connectTimeout instead. |  | Long
+| *camel.component.consul.service-registry.dc* | *Deprecated* Use datacenter instead. |  | String
+| *camel.component.consul.service-registry.read-timeout-millis* | *Deprecated* Use readTimeout instead. |  | Long
+| *camel.component.consul.service-registry.write-timeout-millis* | *Deprecated* Use writeTimeout instead. |  | Long
 | *camel.component.consul.write-timeout-millis* | *Deprecated* Write timeout for OkHttpClient. Deprecation note: Use writeTimeout instead. The option is a java.lang.Long type. |  | String
 |===
 // spring-boot-auto-configure options: END

--- a/components-starter/camel-consul-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/components-starter/camel-consul-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,355 @@
+{
+    "properties": [
+        {
+            "name": "camel.component.consul.cluster.service.acl-token",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The ACL token to be used with Consul"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.block-seconds",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The ACL token to be used with Consul"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.connect-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Connect timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.consistency-mode",
+            "type": "com.orbitz.consul.option.ConsistencyMode",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The consistencyMode used for queries.",
+            "defaultValue": "ConsistencyMode.DEFAULT"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.datacenter",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The data center"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.first-index",
+            "type": "java.math.BigInteger",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The first index for watch for",
+            "defaultValue": "0"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.near-node",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The near node to use for queries."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.node-meta",
+            "type": "java.util.List<java.lang.String>",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The note meta-data to use for queries."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.password",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The password to be used for basic authentication"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.ping-instance",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Configure if the AgentClient should attempt a ping before returning the Consul instance",
+            "defaultValue": "true"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.read-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Read timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.recursive",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Recursively watch",
+            "defaultValue": "false"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.ssl-context-parameters",
+            "type": "org.apache.camel.support.jsse.SSLContextParameters",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.tags",
+            "type": "java.util.Set<java.lang.String>",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Set tags. You can separate multiple tags by comma."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.url",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The Consul agent URL"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.user-name",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The username to be used for basic authentication"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.write-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Write timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.connect-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use connectTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.dc",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use datacenter instead."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.read-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use readTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.write-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use writeTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.cluster.service.root-path",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "Consul root path",
+            "defaultValue": "/camel"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.session-lock-delay",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The value for lockDelay",
+            "defaultValue": "5"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.session-refresh-interval",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The value of wait attribute",
+            "defaultValue": "5"
+        },
+        {
+            "name": "camel.component.consul.cluster.service.session-ttl",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cluster.ConsulClusterServiceConfiguration",
+            "description": "The value of TTL",
+            "defaultValue": "60"
+        },
+
+
+
+
+
+
+        {
+            "name": "camel.component.consul.service-registry.acl-token",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The ACL token to be used with Consul"
+        },
+        {
+            "name": "camel.component.consul.service-registry.block-seconds",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The ACL token to be used with Consul"
+        },
+        {
+            "name": "camel.component.consul.service-registry.connect-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Connect timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.service-registry.consistency-mode",
+            "type": "com.orbitz.consul.option.ConsistencyMode",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The consistencyMode used for queries.",
+            "defaultValue": "ConsistencyMode.DEFAULT"
+        },
+        {
+            "name": "camel.component.consul.service-registry.datacenter",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The data center"
+        },
+        {
+            "name": "camel.component.consul.service-registry.first-index",
+            "type": "java.math.BigInteger",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The first index for watch for",
+            "defaultValue": "0"
+        },
+        {
+            "name": "camel.component.consul.service-registry.near-node",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The near node to use for queries."
+        },
+        {
+            "name": "camel.component.consul.service-registry.node-meta",
+            "type": "java.util.List<java.lang.String>",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The note meta-data to use for queries."
+        },
+        {
+            "name": "camel.component.consul.service-registry.password",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The password to be used for basic authentication"
+        },
+        {
+            "name": "camel.component.consul.service-registry.ping-instance",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Configure if the AgentClient should attempt a ping before returning the Consul instance",
+            "defaultValue": "true"
+        },
+        {
+            "name": "camel.component.consul.service-registry.read-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Read timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.service-registry.recursive",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Recursively watch",
+            "defaultValue": "false"
+        },
+        {
+            "name": "camel.component.consul.service-registry.ssl-context-parameters",
+            "type": "org.apache.camel.support.jsse.SSLContextParameters",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance."
+        },
+        {
+            "name": "camel.component.consul.service-registry.tags",
+            "type": "java.util.Set<java.lang.String>",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Set tags. You can separate multiple tags by comma."
+        },
+        {
+            "name": "camel.component.consul.service-registry.url",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The Consul agent URL"
+        },
+        {
+            "name": "camel.component.consul.service-registry.user-name",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The username to be used for basic authentication"
+        },
+        {
+            "name": "camel.component.consul.service-registry.write-timeout",
+            "type": "java.time.Duration",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Write timeout for OkHttpClient"
+        },
+        {
+            "name": "camel.component.consul.service-registry.connect-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use connectTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.service-registry.dc",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use datacenter instead."
+        },
+        {
+            "name": "camel.component.consul.service-registry.read-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use readTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.service-registry.write-timeout-millis",
+            "type": "java.lang.Long",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "deprecated": true,
+            "deprecation": {},
+            "description": "Use writeTimeout instead."
+        },
+        {
+            "name": "camel.component.consul.service-registry.check-interval",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "How often (in seconds) a service has to be marked as healthy if its check is TTL or how often the check should run",
+            "defaultValue": "5"
+        },
+        {
+            "name": "camel.component.consul.service-registry.check-ttl",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "The time (in seconds) to live for TTL checks",
+            "defaultValue": "60"
+        },
+        {
+            "name": "camel.component.consul.service-registry.deregister-after",
+            "type": "java.lang.Integer",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "How long (in seconds) to wait to deregister a service in case of unclean shutdown.",
+            "defaultValue": "3600"
+        },
+        {
+            "name": "camel.component.consul.service-registry.deregister-services-on-stop",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Should we remove all the registered services know by this registry on stop?",
+            "defaultValue": "true"
+        },
+        {
+            "name": "camel.component.consul.service-registry.override-service-host",
+            "type": "java.lang.Boolean",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Should we override the service host if given ?",
+            "defaultValue": "true"
+        },
+        {
+            "name": "camel.component.consul.service-registry.service-host",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.camel.component.consul.springboot.cloud.ConsulServiceRegistryConfiguration",
+            "description": "Service host."
+        }
+    ]
+}


### PR DESCRIPTION
Created additional-spring-configuration-metadata.json to add description
to properties inherited from parent configuration classes.
This is because spring-boot-configuration-processor detects inherited
properties by their public getters/setters but can not find the corresponding
javadoc used for generated adoc in the parent classes.

This is the second possible solution for issue CAMEL-14565. Another is copy fields from
parent classes to include the javadoc (and default values)

I created a second pull request for **camel-zookeeper-starter** using the other solution.

Please advise on which solution is better.
