### PR TITLE
[CAMEL-14565]: Copied fields from parent class to include javadoc description of spring config properties

### DIFF
--- a/components-starter/camel-zookeeper-starter/src/main/docs/zookeeper-starter.adoc
+++ b/components-starter/camel-zookeeper-starter/src/main/docs/zookeeper-starter.adoc
@@ -30,23 +30,23 @@ The component supports 57 options, which are listed below.
 | *camel.component.zookeeper.cluster.service.attributes* | Custom service attributes. |  | Map
 | *camel.component.zookeeper.cluster.service.auth-info-list* | List of AuthInfo objects with scheme and auth. |  | List
 | *camel.component.zookeeper.cluster.service.base-path* | The base path to store in ZooKeeper. |  | String
-| *camel.component.zookeeper.cluster.service.connection-timeout* | Connection timeout. Default is 15000. |  | Long
+| *camel.component.zookeeper.cluster.service.connection-timeout* | Connection timeout. | 15000 | Long
 | *camel.component.zookeeper.cluster.service.connection-timeout-unit* | Connection timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.cluster.service.curator-framework* | Zookeeper CuratorFramework-style client. |  | CuratorFramework
-| *camel.component.zookeeper.cluster.service.enabled* | Sets if the zookeeper cluster service should be enabled or not, default is false. |  | Boolean
+| *camel.component.zookeeper.cluster.service.enabled* | Sets if the zookeeper cluster service should be enabled or not, default is false. | false | Boolean
 | *camel.component.zookeeper.cluster.service.id* | Cluster Service ID |  | String
-| *camel.component.zookeeper.cluster.service.max-close-wait* | Time to wait during close to join background threads. Default is 1000. |  | Long
+| *camel.component.zookeeper.cluster.service.max-close-wait* | Time to wait during close to join background threads. | 1000 | Long
 | *camel.component.zookeeper.cluster.service.max-close-wait-unit* | MaxCloseWait TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.cluster.service.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace. |  | String
 | *camel.component.zookeeper.cluster.service.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma). |  | List
 | *camel.component.zookeeper.cluster.service.order* | Service lookup order/priority. |  | Integer
-| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time* | Initial amount of time to wait between retries. |  | Long
+| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time* | Initial amount of time to wait between retries. | 0 | Long
 | *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time-unit* | ReconnectBaseSleepTime TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
-| *camel.component.zookeeper.cluster.service.reconnect-max-retries* | Max number of times to retry. Default is 3. |  | Integer
+| *camel.component.zookeeper.cluster.service.reconnect-max-retries* | Max number of times to retry. | 3 | Integer
 | *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time* | Max time to sleep on each retry. Default is Integer.MAX_VALUE. |  | Long
 | *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time-unit* | ReconnectMaxSleepTimeUnit TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.cluster.service.retry-policy* | Retry policy to use. |  | RetryPolicy
-| *camel.component.zookeeper.cluster.service.session-timeout* | Session timeout. Default is 60000. |  | Long
+| *camel.component.zookeeper.cluster.service.session-timeout* | Session timeout. | 60000 | Long
 | *camel.component.zookeeper.cluster.service.session-timeout-unit* | Session timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.configuration* | To use a shared ZooKeeperConfiguration. The option is a org.apache.camel.component.zookeeper.ZooKeeperConfiguration type. |  | String
 | *camel.component.zookeeper.create* | Should the endpoint create the node if it does not currently exist. | false | Boolean
@@ -59,26 +59,26 @@ The component supports 57 options, which are listed below.
 | *camel.component.zookeeper.service-registry.attributes* | Custom service attributes. |  | Map
 | *camel.component.zookeeper.service-registry.auth-info-list* | List of AuthInfo objects with scheme and auth. |  | List
 | *camel.component.zookeeper.service-registry.base-path* | The base path to store in ZooKeeper. |  | String
-| *camel.component.zookeeper.service-registry.connection-timeout* | Connection timeout. Default is 15000. |  | Long
+| *camel.component.zookeeper.service-registry.connection-timeout* | Connection timeout. | 15000 | Long
 | *camel.component.zookeeper.service-registry.connection-timeout-unit* | Connection timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.service-registry.curator-framework* | Zookeeper CuratorFramework-style client. |  | CuratorFramework
-| *camel.component.zookeeper.service-registry.deregister-services-on-stop* | Should we remove all the registered services know by this registry on stop ?  Default is true. |  | Boolean
-| *camel.component.zookeeper.service-registry.enabled* | Sets if the zookeeper service registry should be enabled or not, default is false. |  | Boolean
+| *camel.component.zookeeper.service-registry.deregister-services-on-stop* | Should we remove all the registered services know by this registry on stop ?  Default is true. | true | Boolean
+| *camel.component.zookeeper.service-registry.enabled* | Sets if the zookeeper service registry should be enabled or not, default is false. | false | Boolean
 | *camel.component.zookeeper.service-registry.id* | Service Registry ID |  | String
-| *camel.component.zookeeper.service-registry.max-close-wait* | Time to wait during close to join background threads. Default is 1000. |  | Long
+| *camel.component.zookeeper.service-registry.max-close-wait* | Time to wait during close to join background threads. | 1000 | Long
 | *camel.component.zookeeper.service-registry.max-close-wait-unit* | MaxCloseWait TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.service-registry.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace. |  | String
 | *camel.component.zookeeper.service-registry.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma). |  | List
 | *camel.component.zookeeper.service-registry.order* | Service lookup order/priority. |  | Integer
-| *camel.component.zookeeper.service-registry.override-service-host* | Should we override the service host if given ?  Default is true. |  | Boolean
-| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time* | Initial amount of time to wait between retries. |  | Long
+| *camel.component.zookeeper.service-registry.override-service-host* | Should we override the service host if given ?  Default is true. | true | Boolean
+| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time* | Initial amount of time to wait between retries. | 0 | Long
 | *camel.component.zookeeper.service-registry.reconnect-base-sleep-time-unit* | ReconnectBaseSleepTime TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
-| *camel.component.zookeeper.service-registry.reconnect-max-retries* | Max number of times to retry. Default is 3. |  | Integer
+| *camel.component.zookeeper.service-registry.reconnect-max-retries* | Max number of times to retry. | 3 | Integer
 | *camel.component.zookeeper.service-registry.reconnect-max-sleep-time* | Max time to sleep on each retry. Default is Integer.MAX_VALUE. |  | Long
 | *camel.component.zookeeper.service-registry.reconnect-max-sleep-time-unit* | ReconnectMaxSleepTimeUnit TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.service-registry.retry-policy* | Retry policy to use. |  | RetryPolicy
 | *camel.component.zookeeper.service-registry.service-host* | Service host. |  | String
-| *camel.component.zookeeper.service-registry.session-timeout* | Session timeout. Default is 60000. |  | Long
+| *camel.component.zookeeper.service-registry.session-timeout* | Session timeout. | 60000 | Long
 | *camel.component.zookeeper.service-registry.session-timeout-unit* | Session timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.timeout* | The time interval to wait on connection before timing out. | 5000 | Integer
 |===

--- a/components-starter/camel-zookeeper-starter/src/main/docs/zookeeper-starter.adoc
+++ b/components-starter/camel-zookeeper-starter/src/main/docs/zookeeper-starter.adoc
@@ -28,26 +28,26 @@ The component supports 57 options, which are listed below.
 | *camel.component.zookeeper.basic-property-binding* | Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | Boolean
 | *camel.component.zookeeper.bridge-error-handler* | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | Boolean
 | *camel.component.zookeeper.cluster.service.attributes* | Custom service attributes. |  | Map
-| *camel.component.zookeeper.cluster.service.auth-info-list* |  |  | List
-| *camel.component.zookeeper.cluster.service.base-path* |  |  | String
-| *camel.component.zookeeper.cluster.service.connection-timeout* |  |  | Long
-| *camel.component.zookeeper.cluster.service.connection-timeout-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.cluster.service.curator-framework* |  |  | CuratorFramework
-| *camel.component.zookeeper.cluster.service.enabled* | Sets if the zookeeper cluster service should be enabled or not, default is false. | false | Boolean
+| *camel.component.zookeeper.cluster.service.auth-info-list* | List of AuthInfo objects with scheme and auth. |  | List
+| *camel.component.zookeeper.cluster.service.base-path* | The base path to store in ZooKeeper. |  | String
+| *camel.component.zookeeper.cluster.service.connection-timeout* | Connection timeout. Default is 15000. |  | Long
+| *camel.component.zookeeper.cluster.service.connection-timeout-unit* | Connection timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.cluster.service.curator-framework* | Zookeeper CuratorFramework-style client. |  | CuratorFramework
+| *camel.component.zookeeper.cluster.service.enabled* | Sets if the zookeeper cluster service should be enabled or not, default is false. |  | Boolean
 | *camel.component.zookeeper.cluster.service.id* | Cluster Service ID |  | String
-| *camel.component.zookeeper.cluster.service.max-close-wait* |  |  | Long
-| *camel.component.zookeeper.cluster.service.max-close-wait-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.cluster.service.namespace* |  |  | String
-| *camel.component.zookeeper.cluster.service.nodes* |  |  | List
+| *camel.component.zookeeper.cluster.service.max-close-wait* | Time to wait during close to join background threads. Default is 1000. |  | Long
+| *camel.component.zookeeper.cluster.service.max-close-wait-unit* | MaxCloseWait TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.cluster.service.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace. |  | String
+| *camel.component.zookeeper.cluster.service.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma). |  | List
 | *camel.component.zookeeper.cluster.service.order* | Service lookup order/priority. |  | Integer
-| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time* |  |  | Long
-| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.cluster.service.reconnect-max-retries* |  |  | Integer
-| *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time* |  |  | Long
-| *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.cluster.service.retry-policy* |  |  | RetryPolicy
-| *camel.component.zookeeper.cluster.service.session-timeout* |  |  | Long
-| *camel.component.zookeeper.cluster.service.session-timeout-unit* |  |  | TimeUnit
+| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time* | Initial amount of time to wait between retries. |  | Long
+| *camel.component.zookeeper.cluster.service.reconnect-base-sleep-time-unit* | ReconnectBaseSleepTime TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.cluster.service.reconnect-max-retries* | Max number of times to retry. Default is 3. |  | Integer
+| *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time* | Max time to sleep on each retry. Default is Integer.MAX_VALUE. |  | Long
+| *camel.component.zookeeper.cluster.service.reconnect-max-sleep-time-unit* | ReconnectMaxSleepTimeUnit TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.cluster.service.retry-policy* | Retry policy to use. |  | RetryPolicy
+| *camel.component.zookeeper.cluster.service.session-timeout* | Session timeout. Default is 60000. |  | Long
+| *camel.component.zookeeper.cluster.service.session-timeout-unit* | Session timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.configuration* | To use a shared ZooKeeperConfiguration. The option is a org.apache.camel.component.zookeeper.ZooKeeperConfiguration type. |  | String
 | *camel.component.zookeeper.create* | Should the endpoint create the node if it does not currently exist. | false | Boolean
 | *camel.component.zookeeper.create-mode* | The create mode that should be used for the newly created node | EPHEMERAL | String
@@ -57,29 +57,29 @@ The component supports 57 options, which are listed below.
 | *camel.component.zookeeper.repeat* | Should changes to the znode be 'watched' and repeatedly processed. | false | Boolean
 | *camel.component.zookeeper.send-empty-message-on-delete* | Upon the delete of a znode, should an empty message be send to the consumer | true | Boolean
 | *camel.component.zookeeper.service-registry.attributes* | Custom service attributes. |  | Map
-| *camel.component.zookeeper.service-registry.auth-info-list* |  |  | List
-| *camel.component.zookeeper.service-registry.base-path* |  |  | String
-| *camel.component.zookeeper.service-registry.connection-timeout* |  |  | Long
-| *camel.component.zookeeper.service-registry.connection-timeout-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.service-registry.curator-framework* |  |  | CuratorFramework
-| *camel.component.zookeeper.service-registry.deregister-services-on-stop* |  |  | Boolean
-| *camel.component.zookeeper.service-registry.enabled* | Sets if the zookeeper service registry should be enabled or not, default is false. | false | Boolean
+| *camel.component.zookeeper.service-registry.auth-info-list* | List of AuthInfo objects with scheme and auth. |  | List
+| *camel.component.zookeeper.service-registry.base-path* | The base path to store in ZooKeeper. |  | String
+| *camel.component.zookeeper.service-registry.connection-timeout* | Connection timeout. Default is 15000. |  | Long
+| *camel.component.zookeeper.service-registry.connection-timeout-unit* | Connection timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.service-registry.curator-framework* | Zookeeper CuratorFramework-style client. |  | CuratorFramework
+| *camel.component.zookeeper.service-registry.deregister-services-on-stop* | Should we remove all the registered services know by this registry on stop ?  Default is true. |  | Boolean
+| *camel.component.zookeeper.service-registry.enabled* | Sets if the zookeeper service registry should be enabled or not, default is false. |  | Boolean
 | *camel.component.zookeeper.service-registry.id* | Service Registry ID |  | String
-| *camel.component.zookeeper.service-registry.max-close-wait* |  |  | Long
-| *camel.component.zookeeper.service-registry.max-close-wait-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.service-registry.namespace* |  |  | String
-| *camel.component.zookeeper.service-registry.nodes* |  |  | List
+| *camel.component.zookeeper.service-registry.max-close-wait* | Time to wait during close to join background threads. Default is 1000. |  | Long
+| *camel.component.zookeeper.service-registry.max-close-wait-unit* | MaxCloseWait TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.service-registry.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace. |  | String
+| *camel.component.zookeeper.service-registry.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma). |  | List
 | *camel.component.zookeeper.service-registry.order* | Service lookup order/priority. |  | Integer
-| *camel.component.zookeeper.service-registry.override-service-host* |  |  | Boolean
-| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time* |  |  | Long
-| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.service-registry.reconnect-max-retries* |  |  | Integer
-| *camel.component.zookeeper.service-registry.reconnect-max-sleep-time* |  |  | Long
-| *camel.component.zookeeper.service-registry.reconnect-max-sleep-time-unit* |  |  | TimeUnit
-| *camel.component.zookeeper.service-registry.retry-policy* |  |  | RetryPolicy
-| *camel.component.zookeeper.service-registry.service-host* |  |  | String
-| *camel.component.zookeeper.service-registry.session-timeout* |  |  | Long
-| *camel.component.zookeeper.service-registry.session-timeout-unit* |  |  | TimeUnit
+| *camel.component.zookeeper.service-registry.override-service-host* | Should we override the service host if given ?  Default is true. |  | Boolean
+| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time* | Initial amount of time to wait between retries. |  | Long
+| *camel.component.zookeeper.service-registry.reconnect-base-sleep-time-unit* | ReconnectBaseSleepTime TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.service-registry.reconnect-max-retries* | Max number of times to retry. Default is 3. |  | Integer
+| *camel.component.zookeeper.service-registry.reconnect-max-sleep-time* | Max time to sleep on each retry. Default is Integer.MAX_VALUE. |  | Long
+| *camel.component.zookeeper.service-registry.reconnect-max-sleep-time-unit* | ReconnectMaxSleepTimeUnit TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
+| *camel.component.zookeeper.service-registry.retry-policy* | Retry policy to use. |  | RetryPolicy
+| *camel.component.zookeeper.service-registry.service-host* | Service host. |  | String
+| *camel.component.zookeeper.service-registry.session-timeout* | Session timeout. Default is 60000. |  | Long
+| *camel.component.zookeeper.service-registry.session-timeout-unit* | Session timeout TimeUnit. Default is TimeUnit.MILLISECONDS. |  | TimeUnit
 | *camel.component.zookeeper.timeout* | The time interval to wait on connection before timing out. | 5000 | Integer
 |===
 // spring-boot-auto-configure options: END

--- a/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cloud/ZooKeeperServiceRegistryConfiguration.java
+++ b/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cloud/ZooKeeperServiceRegistryConfiguration.java
@@ -129,7 +129,6 @@ public class ZooKeeperServiceRegistryConfiguration extends org.apache.camel.comp
 
     /**
      * Max number of times to retry.
-     * Default is 3.
      */
     private int reconnectMaxRetries = 3;
 
@@ -147,9 +146,8 @@ public class ZooKeeperServiceRegistryConfiguration extends org.apache.camel.comp
     
     /**
      * Session timeout.
-     * Default is 60000.
      */
-    private long sessionTimeout = 60 * 1000;
+    private long sessionTimeout = 60000;
 
     /**
      * Session timeout TimeUnit.
@@ -159,9 +157,8 @@ public class ZooKeeperServiceRegistryConfiguration extends org.apache.camel.comp
 
     /**
      * Connection timeout.
-     * Default is 15000.
      */
-    private long connectionTimeout = 15 * 1000;
+    private long connectionTimeout = 15000;
 
     /**
      * Connection timeout TimeUnit.
@@ -171,7 +168,6 @@ public class ZooKeeperServiceRegistryConfiguration extends org.apache.camel.comp
     
     /**
      * Time to wait during close to join background threads.
-     * Default is 1000.
      */
     private long maxCloseWait = 1000;
     

--- a/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cloud/ZooKeeperServiceRegistryConfiguration.java
+++ b/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cloud/ZooKeeperServiceRegistryConfiguration.java
@@ -16,8 +16,13 @@
  */
 package org.apache.camel.component.zookeeper.springboot.cloud;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.AuthInfo;
+import org.apache.curator.framework.CuratorFramework;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.component.zookeeper.service-registry")
@@ -73,4 +78,121 @@ public class ZooKeeperServiceRegistryConfiguration extends org.apache.camel.comp
     public void setOrder(Integer order) {
         this.order = order;
     }
+
+    //
+    // Fields copied from ZooKeeperServiceRegistryConfiguration to add
+    // javadoc which is used by spring-boot-configuration-processor
+    // to generate descritpions for inherited properties
+    // ------------------------------------------
+    /**
+     * Should we remove all the registered services know by this registry on stop ? 
+     * Default is true.
+     */
+    private boolean deregisterServicesOnStop = true;
+
+    /**
+     * Should we override the service host if given ? 
+     * Default is true.
+     */
+    private boolean overrideServiceHost = true;
+
+    /**
+     * Service host.
+     */
+    private String serviceHost;
+
+    /**
+     * The Zookeeper server hosts (multiple servers can be separated by comma).
+     */
+    private List<String> nodes;
+
+    /**
+     * The base path to store in ZooKeeper.
+     */
+    private String basePath;
+
+    /**
+     * ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace.
+     */
+    private String namespace;
+
+    /**
+     * Initial amount of time to wait between retries.
+     */
+    private long reconnectBaseSleepTime;
+
+    /**
+     * ReconnectBaseSleepTime TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit reconnectBaseSleepTimeUnit = TimeUnit.MILLISECONDS;
+
+    /**
+     * Max number of times to retry.
+     * Default is 3.
+     */
+    private int reconnectMaxRetries = 3;
+
+    /**
+     * Max time to sleep on each retry.
+     * Default is Integer.MAX_VALUE.
+     */
+    private long reconnectMaxSleepTime = Integer.MAX_VALUE;
+    
+    /**
+     * ReconnectMaxSleepTimeUnit TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit reconnectMaxSleepTimeUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Session timeout.
+     * Default is 60000.
+     */
+    private long sessionTimeout = 60 * 1000;
+
+    /**
+     * Session timeout TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit sessionTimeoutUnit =  TimeUnit.MILLISECONDS;
+
+    /**
+     * Connection timeout.
+     * Default is 15000.
+     */
+    private long connectionTimeout = 15 * 1000;
+
+    /**
+     * Connection timeout TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit connectionTimeoutUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Time to wait during close to join background threads.
+     * Default is 1000.
+     */
+    private long maxCloseWait = 1000;
+    
+    /**
+     * MaxCloseWait TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit maxCloseWaitUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Zookeeper CuratorFramework-style client.
+     */
+    private CuratorFramework curatorFramework;
+
+    /**
+     * List of AuthInfo objects with scheme and auth.
+     */
+    private List<AuthInfo> authInfoList;
+
+    /** 
+     * Retry policy to use.
+     */
+    private RetryPolicy retryPolicy;
 }

--- a/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cluster/ZooKeeperClusterServiceConfiguration.java
+++ b/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cluster/ZooKeeperClusterServiceConfiguration.java
@@ -115,7 +115,6 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
 
     /**
      * Max number of times to retry.
-     * Default is 3.
      */
     private int reconnectMaxRetries = 3;
 
@@ -133,9 +132,8 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
     
     /**
      * Session timeout.
-     * Default is 60000.
      */
-    private long sessionTimeout = 60 * 1000;
+    private long sessionTimeout = 60000;
 
     /**
      * Session timeout TimeUnit.
@@ -145,9 +143,8 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
 
     /**
      * Connection timeout.
-     * Default is 15000.
      */
-    private long connectionTimeout = 15 * 1000;
+    private long connectionTimeout = 15000;
 
     /**
      * Connection timeout TimeUnit.
@@ -157,7 +154,6 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
     
     /**
      * Time to wait during close to join background threads.
-     * Default is 1000.
      */
     private long maxCloseWait = 1000;
     

--- a/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cluster/ZooKeeperClusterServiceConfiguration.java
+++ b/components-starter/camel-zookeeper-starter/src/main/java/org/apache/camel/component/zookeeper/springboot/cluster/ZooKeeperClusterServiceConfiguration.java
@@ -16,9 +16,14 @@
  */
 package org.apache.camel.component.zookeeper.springboot.cluster;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.component.zookeeper.ZooKeeperCuratorConfiguration;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.AuthInfo;
+import org.apache.curator.framework.CuratorFramework;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.component.zookeeper.cluster.service")
@@ -26,7 +31,7 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
     /**
      * Sets if the zookeeper cluster service should be enabled or not, default is false.
      */
-    private boolean enabled;
+    private boolean enabled = false;
 
     /**
      * Cluster Service ID
@@ -74,4 +79,107 @@ public class ZooKeeperClusterServiceConfiguration extends ZooKeeperCuratorConfig
     public void setOrder(Integer order) {
         this.order = order;
     }
+
+
+    //
+    // Fields copied from ZooKeeperCuratorConfiguration to add
+    // javadoc which is used by spring-boot-configuration-processor
+    // to generate descritpions for inherited properties
+    // ------------------------------------------
+
+    /**
+     * The Zookeeper server hosts (multiple servers can be separated by comma).
+     */
+    private List<String> nodes;
+
+    /**
+     * The base path to store in ZooKeeper.
+     */
+    private String basePath;
+
+    /**
+     * ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace.
+     */
+    private String namespace;
+
+    /**
+     * Initial amount of time to wait between retries.
+     */
+    private long reconnectBaseSleepTime;
+
+    /**
+     * ReconnectBaseSleepTime TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit reconnectBaseSleepTimeUnit = TimeUnit.MILLISECONDS;
+
+    /**
+     * Max number of times to retry.
+     * Default is 3.
+     */
+    private int reconnectMaxRetries = 3;
+
+    /**
+     * Max time to sleep on each retry.
+     * Default is Integer.MAX_VALUE.
+     */
+    private long reconnectMaxSleepTime = Integer.MAX_VALUE;
+    
+    /**
+     * ReconnectMaxSleepTimeUnit TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit reconnectMaxSleepTimeUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Session timeout.
+     * Default is 60000.
+     */
+    private long sessionTimeout = 60 * 1000;
+
+    /**
+     * Session timeout TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit sessionTimeoutUnit =  TimeUnit.MILLISECONDS;
+
+    /**
+     * Connection timeout.
+     * Default is 15000.
+     */
+    private long connectionTimeout = 15 * 1000;
+
+    /**
+     * Connection timeout TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit connectionTimeoutUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Time to wait during close to join background threads.
+     * Default is 1000.
+     */
+    private long maxCloseWait = 1000;
+    
+    /**
+     * MaxCloseWait TimeUnit.
+     * Default is TimeUnit.MILLISECONDS.
+     */
+    private TimeUnit maxCloseWaitUnit = TimeUnit.MILLISECONDS;
+    
+    /**
+     * Zookeeper CuratorFramework-style client.
+     */
+    private CuratorFramework curatorFramework;
+
+    /**
+     * List of AuthInfo objects with scheme and auth.
+     */
+    private List<AuthInfo> authInfoList;
+
+    /** 
+     * Retry policy to use.
+     */
+    private RetryPolicy retryPolicy;
+
 }


### PR DESCRIPTION
Copied properties from parent classes to include javadoc because
spring-boot-configuration-processor detects inherited properties by their public
getters/setters but can not find the corresponding javadoc used for generated adoc
in the parent class.

This is the first possible solution for issue CAMEL-14565. Another is to add  a metadata
file **META-INF/additional-spring-configuration-metadata.json** with the proper description.

I created a second pull request for **camel-consul-starter** using the second solution.

Please advise on which solution is better.
