### PR TITLE
[CAMEL-14565]: Copied fields from parent class to include javadoc description of spring config properties

### DIFF
--- a/components-starter/camel-consul-starter/src/main/docs/consul-starter.adoc
+++ b/components-starter/camel-consul-starter/src/main/docs/consul-starter.adoc
@@ -29,31 +29,34 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.basic-property-binding* | Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities | false | Boolean
 | *camel.component.consul.block-seconds* | The second to wait for a watch event, default 10 seconds | 10 | Integer
 | *camel.component.consul.bridge-error-handler* | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored. | false | Boolean
-| *camel.component.consul.cluster.service.acl-token* |  |  | String
+| *camel.component.consul.cluster.service.acl-token* | Sets the ACL token to be used with Consul |  | String
 | *camel.component.consul.cluster.service.attributes* | Custom service attributes. |  | Map
-| *camel.component.consul.cluster.service.block-seconds* |  |  | Integer
-| *camel.component.consul.cluster.service.connect-timeout* |  |  | Duration
-| *camel.component.consul.cluster.service.consistency-mode* |  |  | ConsistencyMode
-| *camel.component.consul.cluster.service.datacenter* |  |  | String
+| *camel.component.consul.cluster.service.block-seconds* | The time (in seconds) to wait for a watch event, default 10 seconds | 10 | Integer
+| *camel.component.consul.cluster.service.connect-timeout* | Connect timeout for OkHttpClient |  | Duration
+| *camel.component.consul.cluster.service.connect-timeout-millis* | Use connectTimeout instead |  | Long
+| *camel.component.consul.cluster.service.consistency-mode* | The consistencyMode used for queries, default ConsistencyMode.DEFAULT |  | ConsistencyMode
+| *camel.component.consul.cluster.service.datacenter* | The data center |  | String
 | *camel.component.consul.cluster.service.enabled* | Sets if the consul cluster service should be enabled or not, default is false. | false | Boolean
-| *camel.component.consul.cluster.service.first-index* |  |  | BigInteger
+| *camel.component.consul.cluster.service.first-index* | The first index for watch for, default 0 | 0 | BigInteger
 | *camel.component.consul.cluster.service.id* | Cluster Service ID |  | String
-| *camel.component.consul.cluster.service.near-node* |  |  | String
-| *camel.component.consul.cluster.service.node-meta* |  |  | List
+| *camel.component.consul.cluster.service.near-node* | The near node to use for queries. |  | String
+| *camel.component.consul.cluster.service.node-meta* | The note meta-data to use for queries. |  | List
 | *camel.component.consul.cluster.service.order* | Service lookup order/priority. |  | Integer
-| *camel.component.consul.cluster.service.password* |  |  | String
-| *camel.component.consul.cluster.service.ping-instance* |  |  | Boolean
-| *camel.component.consul.cluster.service.read-timeout* |  |  | Duration
-| *camel.component.consul.cluster.service.recursive* |  |  | Boolean
-| *camel.component.consul.cluster.service.root-path* |  |  | String
-| *camel.component.consul.cluster.service.session-lock-delay* |  |  | Integer
-| *camel.component.consul.cluster.service.session-refresh-interval* |  |  | Integer
-| *camel.component.consul.cluster.service.session-ttl* |  |  | Integer
-| *camel.component.consul.cluster.service.ssl-context-parameters* |  |  | SSLContextParameters
-| *camel.component.consul.cluster.service.tags* |  |  | Set
-| *camel.component.consul.cluster.service.url* |  |  | String
-| *camel.component.consul.cluster.service.user-name* |  |  | String
-| *camel.component.consul.cluster.service.write-timeout* |  |  | Duration
+| *camel.component.consul.cluster.service.password* | Sets the password to be used for basic authentication |  | String
+| *camel.component.consul.cluster.service.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
+| *camel.component.consul.cluster.service.read-timeout* | Read timeout for OkHttpClient |  | Duration
+| *camel.component.consul.cluster.service.read-timeout-millis* | Use readTimeout instead. |  | Long
+| *camel.component.consul.cluster.service.recursive* | Recursively watch, default false | false | Boolean
+| *camel.component.consul.cluster.service.root-path* | Consul root path | /camel | String
+| *camel.component.consul.cluster.service.session-lock-delay* | The value for lockDelay | 5 | Integer
+| *camel.component.consul.cluster.service.session-refresh-interval* | The value of wait attribute | 5 | Integer
+| *camel.component.consul.cluster.service.session-ttl* | The value of TTL | 60 | Integer
+| *camel.component.consul.cluster.service.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. |  | SSLContextParameters
+| *camel.component.consul.cluster.service.tags* | Set tags. You can separate multiple tags by comma. |  | Set
+| *camel.component.consul.cluster.service.url* | The Consul agent URL |  | String
+| *camel.component.consul.cluster.service.user-name* | Sets the username to be used for basic authentication |  | String
+| *camel.component.consul.cluster.service.write-timeout* | Write timeout for OkHttpClient |  | Duration
+| *camel.component.consul.cluster.service.write-timeout-millis* | Use writeTimeout instead. |  | Long
 | *camel.component.consul.configuration* | Consul configuration. The option is a org.apache.camel.component.consul.ConsulConfiguration type. |  | String
 | *camel.component.consul.connect-timeout* | Connect timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
 | *camel.component.consul.consistency-mode* | The consistencyMode used for queries, default ConsistencyMode.DEFAULT |  | ConsistencyMode
@@ -69,33 +72,36 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
 | *camel.component.consul.read-timeout* | Read timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
 | *camel.component.consul.recursive* | Recursively watch, default false | false | Boolean
-| *camel.component.consul.service-registry.acl-token* |  |  | String
+| *camel.component.consul.service-registry.acl-token* | Sets the ACL token to be used with Consul |  | String
 | *camel.component.consul.service-registry.attributes* | Custom service attributes. |  | Map
-| *camel.component.consul.service-registry.block-seconds* |  |  | Integer
-| *camel.component.consul.service-registry.check-interval* |  |  | Integer
-| *camel.component.consul.service-registry.check-ttl* |  |  | Integer
-| *camel.component.consul.service-registry.connect-timeout* |  |  | Duration
-| *camel.component.consul.service-registry.consistency-mode* |  |  | ConsistencyMode
-| *camel.component.consul.service-registry.datacenter* |  |  | String
-| *camel.component.consul.service-registry.deregister-after* |  |  | Integer
-| *camel.component.consul.service-registry.deregister-services-on-stop* |  |  | Boolean
+| *camel.component.consul.service-registry.block-seconds* | The time (in seconds) to wait for a watch event, default 10 seconds | 10 | Integer
+| *camel.component.consul.service-registry.check-interval* | How often (in seconds) a service has to be marked as healthy if its check is TTL or how often the check should run. Default is 5 seconds. | 5 | Integer
+| *camel.component.consul.service-registry.check-ttl* | The time (in seconds) to live for TTL checks. Default is 1 minute. | 60 | Integer
+| *camel.component.consul.service-registry.connect-timeout* | Connect timeout for OkHttpClient |  | Duration
+| *camel.component.consul.service-registry.connect-timeout-millis* | Use connectTimeout instead |  | Long
+| *camel.component.consul.service-registry.consistency-mode* | The consistencyMode used for queries, default ConsistencyMode.DEFAULT |  | ConsistencyMode
+| *camel.component.consul.service-registry.datacenter* | The data center |  | String
+| *camel.component.consul.service-registry.deregister-after* | How long (in seconds) to wait to deregister a service in case of unclean shutdown. Default is 1 hour. | 3600 | Integer
+| *camel.component.consul.service-registry.deregister-services-on-stop* | Should we remove all the registered services know by this registry on stop? | true | Boolean
 | *camel.component.consul.service-registry.enabled* | Sets if the consul service registry should be enabled or not, default is false. | false | Boolean
-| *camel.component.consul.service-registry.first-index* |  |  | BigInteger
+| *camel.component.consul.service-registry.first-index* | The first index for watch for, default 0 | 0 | BigInteger
 | *camel.component.consul.service-registry.id* | Service Registry ID |  | String
-| *camel.component.consul.service-registry.near-node* |  |  | String
-| *camel.component.consul.service-registry.node-meta* |  |  | List
+| *camel.component.consul.service-registry.near-node* | The near node to use for queries. |  | String
+| *camel.component.consul.service-registry.node-meta* | The note meta-data to use for queries. |  | List
 | *camel.component.consul.service-registry.order* | Service lookup order/priority. |  | Integer
-| *camel.component.consul.service-registry.override-service-host* |  |  | Boolean
-| *camel.component.consul.service-registry.password* |  |  | String
-| *camel.component.consul.service-registry.ping-instance* |  |  | Boolean
-| *camel.component.consul.service-registry.read-timeout* |  |  | Duration
-| *camel.component.consul.service-registry.recursive* |  |  | Boolean
-| *camel.component.consul.service-registry.service-host* |  |  | String
-| *camel.component.consul.service-registry.ssl-context-parameters* |  |  | SSLContextParameters
-| *camel.component.consul.service-registry.tags* |  |  | Set
-| *camel.component.consul.service-registry.url* |  |  | String
-| *camel.component.consul.service-registry.user-name* |  |  | String
-| *camel.component.consul.service-registry.write-timeout* |  |  | Duration
+| *camel.component.consul.service-registry.override-service-host* | Should we override the service host if given ? | true | Boolean
+| *camel.component.consul.service-registry.password* | Sets the password to be used for basic authentication |  | String
+| *camel.component.consul.service-registry.ping-instance* | Configure if the AgentClient should attempt a ping before returning the Consul instance | true | Boolean
+| *camel.component.consul.service-registry.read-timeout* | Read timeout for OkHttpClient |  | Duration
+| *camel.component.consul.service-registry.read-timeout-millis* | Use readTimeout instead. |  | Long
+| *camel.component.consul.service-registry.recursive* | Recursively watch, default false | false | Boolean
+| *camel.component.consul.service-registry.service-host* | Service host. |  | String
+| *camel.component.consul.service-registry.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. |  | SSLContextParameters
+| *camel.component.consul.service-registry.tags* | Set tags. You can separate multiple tags by comma. |  | Set
+| *camel.component.consul.service-registry.url* | The Consul agent URL |  | String
+| *camel.component.consul.service-registry.user-name* | Sets the username to be used for basic authentication |  | String
+| *camel.component.consul.service-registry.write-timeout* | Write timeout for OkHttpClient |  | Duration
+| *camel.component.consul.service-registry.write-timeout-millis* | Use writeTimeout instead. |  | Long
 | *camel.component.consul.ssl-context-parameters* | SSL configuration using an org.apache.camel.support.jsse.SSLContextParameters instance. The option is a org.apache.camel.support.jsse.SSLContextParameters type. |  | String
 | *camel.component.consul.tags* | Set tags. You can separate multiple tags by comma. |  | String
 | *camel.component.consul.url* | The Consul agent URL |  | String
@@ -103,16 +109,10 @@ The component supports 90 options, which are listed below.
 | *camel.component.consul.user-name* | Sets the username to be used for basic authentication |  | String
 | *camel.component.consul.value-as-string* | Default to transform values retrieved from Consul i.e. on KV endpoint to string. | false | Boolean
 | *camel.component.consul.write-timeout* | Write timeout for OkHttpClient. The option is a java.time.Duration type. |  | String
-| *camel.component.consul.cluster.service.connect-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.cluster.service.dc* | *Deprecated*  |  | String
-| *camel.component.consul.cluster.service.read-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.cluster.service.write-timeout-millis* | *Deprecated*  |  | Long
+| *camel.component.consul.cluster.service.dc* | *Deprecated* Use datacenter instead |  | String
 | *camel.component.consul.connect-timeout-millis* | *Deprecated* Connect timeout for OkHttpClient. Deprecation note: Use connectTimeout instead |  | Long
 | *camel.component.consul.read-timeout-millis* | *Deprecated* Read timeout for OkHttpClient. Deprecation note: Use readTimeout instead |  | Long
-| *camel.component.consul.service-registry.connect-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.service-registry.dc* | *Deprecated*  |  | String
-| *camel.component.consul.service-registry.read-timeout-millis* | *Deprecated*  |  | Long
-| *camel.component.consul.service-registry.write-timeout-millis* | *Deprecated*  |  | Long
+| *camel.component.consul.service-registry.dc* | *Deprecated* Use datacenter instead |  | String
 | *camel.component.consul.write-timeout-millis* | *Deprecated* Write timeout for OkHttpClient. Deprecation note: Use writeTimeout instead. The option is a java.lang.Long type. |  | String
 |===
 // spring-boot-auto-configure options: END

--- a/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/cloud/ConsulServiceRegistryConfiguration.java
+++ b/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/cloud/ConsulServiceRegistryConfiguration.java
@@ -16,8 +16,15 @@
  */
 package org.apache.camel.component.consul.springboot.cloud;
 
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.orbitz.consul.option.ConsistencyMode;
+
+import org.apache.camel.support.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.component.consul.service-registry")
@@ -73,4 +80,179 @@ public class ConsulServiceRegistryConfiguration extends org.apache.camel.compone
     public void setOrder(Integer order) {
         this.order = order;
     }
+
+
+
+    //
+    // Fields copied from org.apache.camel.component.consul.cloud.ConsulServiceRegistryConfiguration
+    // to add javadoc which is used by spring-boot-configuration-processor
+    // to generate descritpions for inherited properties
+    // ----------------
+
+    /**
+     * Should we remove all the registered services know by this registry on
+     * stop?
+     */
+    private boolean deregisterServicesOnStop = true;
+
+    /**
+     * Should we override the service host if given ?
+     */
+    private boolean overrideServiceHost = true;
+
+    /**
+     * Service host.
+     */
+    private String serviceHost;
+
+    /**
+     * The time (in seconds) to live for TTL checks. Default is 1 minute.
+     */
+    private int checkTtl = 60;
+
+    /**
+     * How often (in seconds) a service has to be marked as healthy if its check
+     * is TTL or how often the check should run. Default is 5 seconds.
+     */
+    private int checkInterval = 5;
+
+    /**
+     * How long (in seconds) to wait to deregister a service in case of unclean
+     * shutdown. Default is 1 hour.
+     */
+    private int deregisterAfter = 3600;
+
+    //
+    // Fields copied from org.apache.camel.component.consul.cluster.ConsulClusterConfiguration
+    // ------------------------------------------
+    /**
+     * 
+     */
+    private int sessionTtl = 60;
+
+    /**
+     * 
+     */
+    private int sessionLockDelay = 5;
+
+    /**
+     * 
+     */
+    private int sessionRefreshInterval = 5;
+
+    /**
+     * 
+     */
+    private String rootPath = "/camel";
+
+    // 
+    // Fields copied from org.apache.camel.component.consul.ConsulClientConfiguration
+    // ---------------
+
+    /**
+     * The Consul agent URL
+     */
+    private String url;
+
+    /**
+     * Use datacenter instead
+     */
+    private String dc;
+
+    /**
+     * The data center
+     */
+    private String datacenter;
+
+    /**
+     * The near node to use for queries.
+     */
+    private String nearNode;
+
+    /**
+     * The note meta-data to use for queries.
+     */
+    private List<String> nodeMeta;
+
+    /**
+     * The consistencyMode used for queries, default ConsistencyMode.DEFAULT
+     */
+    private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
+
+    /**
+     * Set tags. You can separate multiple tags by comma.
+     */
+    private Set<String> tags;
+
+    /**
+     * SSL configuration using an
+     * org.apache.camel.support.jsse.SSLContextParameters instance.
+     */
+    private SSLContextParameters sslContextParameters;
+
+    /**
+     * Sets the ACL token to be used with Consul
+     */
+    private String aclToken;
+
+    /**
+     * Sets the username to be used for basic authentication
+     */
+    private String userName;
+
+    /**
+     * Sets the password to be used for basic authentication
+     */
+    private String password;
+
+    /**
+     * Use connectTimeout instead
+     */
+    private Long connectTimeoutMillis;
+
+    /**
+     * Connect timeout for OkHttpClient
+     */
+    private Duration connectTimeout;
+
+    /**
+     * Use readTimeout instead.
+     */
+    private Long readTimeoutMillis;
+
+    /**
+     * Read timeout for OkHttpClient
+     */
+    private Duration readTimeout;
+
+    /**
+     * Use writeTimeout instead.
+     */
+    private Long writeTimeoutMillis;
+
+    /**
+     * Write timeout for OkHttpClient
+     */
+    private Duration writeTimeout;
+
+    /**
+     * Configure if the AgentClient should attempt a ping before returning the
+     * Consul instance
+     */
+    private boolean pingInstance = true;
+
+    /**
+     * The time (in seconds) to wait for a watch event, default 10 seconds
+     */
+    private Integer blockSeconds = 10;
+
+    /**
+     * The first index for watch for, default 0
+     */
+    private BigInteger firstIndex = BigInteger.valueOf(0L);
+
+    /**
+     * Recursively watch, default false
+     */
+    private boolean recursive;
 }

--- a/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/cluster/ConsulClusterServiceConfiguration.java
+++ b/components-starter/camel-consul-starter/src/main/java/org/apache/camel/component/consul/springboot/cluster/ConsulClusterServiceConfiguration.java
@@ -16,9 +16,16 @@
  */
 package org.apache.camel.component.consul.springboot.cluster;
 
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import com.orbitz.consul.option.ConsistencyMode;
 
 import org.apache.camel.component.consul.cluster.ConsulClusterConfiguration;
+import org.apache.camel.support.jsse.SSLContextParameters;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.component.consul.cluster.service")
@@ -74,4 +81,143 @@ public class ConsulClusterServiceConfiguration extends ConsulClusterConfiguratio
     public void setOrder(Integer order) {
         this.order = order;
     }
+
+
+    //
+    // Fields copied from org.apache.camel.component.consul.cluster.ConsulClusterConfiguration
+    // to add javadoc which is used by spring-boot-configuration-processor
+    // to generate descritpions for inherited properties
+    // ------------------------------------------
+    /**
+     * The value of TTL
+     */
+    private int sessionTtl = 60;
+
+    /**
+     * The value for lockDelay
+     */
+    private int sessionLockDelay = 5;
+
+    /**
+     * The value of wait attribute
+     */
+    private int sessionRefreshInterval = 5;
+
+    /**
+     * Consul root path
+     */
+    private String rootPath = "/camel";
+
+    // 
+    // Fields copied from 
+    // org.apache.camel.component.consul.ConsulClientConfiguration
+    // ---------------
+
+    /**
+     * The Consul agent URL
+     */
+    private String url;
+
+    /**
+     * Use datacenter instead
+     */
+    private String dc;
+
+    /**
+     * The data center
+     */
+    private String datacenter;
+
+    /**
+     * The near node to use for queries.
+     */
+    private String nearNode;
+
+    /**
+     * The note meta-data to use for queries.
+     */
+    private List<String> nodeMeta;
+
+    /**
+     * The consistencyMode used for queries, default ConsistencyMode.DEFAULT
+     */
+    private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
+
+    /**
+     * Set tags. You can separate multiple tags by comma.
+     */
+    private Set<String> tags;
+
+    /**
+     * SSL configuration using an
+     * org.apache.camel.support.jsse.SSLContextParameters instance.
+     */
+    private SSLContextParameters sslContextParameters;
+
+    /**
+     * Sets the ACL token to be used with Consul
+     */
+    private String aclToken;
+
+    /**
+     * Sets the username to be used for basic authentication
+     */
+    private String userName;
+
+    /**
+     * Sets the password to be used for basic authentication
+     */
+    private String password;
+
+    /**
+     * Use connectTimeout instead
+     */
+    private Long connectTimeoutMillis;
+
+    /**
+     * Connect timeout for OkHttpClient
+     */
+    private Duration connectTimeout;
+
+    /**
+     * Use readTimeout instead.
+     */
+    private Long readTimeoutMillis;
+
+    /**
+     * Read timeout for OkHttpClient
+     */
+    private Duration readTimeout;
+
+    /**
+     * Use writeTimeout instead.
+     */
+    private Long writeTimeoutMillis;
+
+    /**
+     * Write timeout for OkHttpClient
+     */
+    private Duration writeTimeout;
+
+    /**
+     * Configure if the AgentClient should attempt a ping before returning the
+     * Consul instance
+     */
+    private boolean pingInstance = true;
+
+    /**
+     * The time (in seconds) to wait for a watch event, default 10 seconds
+     */
+    private Integer blockSeconds = 10;
+
+    /**
+     * The first index for watch for, default 0
+     */
+    private BigInteger firstIndex = BigInteger.valueOf(0L);
+
+    /**
+     * Recursively watch, default false
+     */
+    private boolean recursive;
 }
+


### PR DESCRIPTION
Copied properties from parent classes to include javadoc because
spring-boot-configuration-processor detects inherited properties by their public
getters/setters but can not find the corresponding javadoc used for descriptions in
generated adoc

