### PR TITLE
CAMEL-15334 Camel-CassandraQL Spring Boot integration test is failing…

### DIFF
--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
@@ -20,11 +20,9 @@ import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-@Ignore("To review, doesn't work after upgrade to 4.x")
 @RunWith(Arquillian.class)
 public class CamelCassandraqlTest extends AbstractSpringBootTestSupport {
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/ArquillianPackager.java
@@ -302,6 +302,8 @@ public final class ArquillianPackager {
         ignore.add("com.github.jnr");
         ignore.add("com.sun.xml.bind:jaxb-xjc");
         ignore.add("com.azure:azure");
+        ignore.add("com.datastax.oss:java");
+        ignore.add("com.jcabi:jcabi");
         ignore.add("commons-beanutils:commons-beanutils");
         ignore.add("io.dropwizard.metrics:metrics-json"); // PR to spring-boot
         ignore.add("io.dropwizard.metrics:metrics-jvm"); // PR to spring-boot

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/resources/spring-boot-fix-dependencies.properties
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/resources/spring-boot-fix-dependencies.properties
@@ -24,7 +24,7 @@ global=org.apache.camel.springboot:camel-core-starter,org.apache.camel.springboo
 # we need spring-boot in camel-core-starter
 camel-core=org.apache.camel.springboot:camel-spring-boot
 
-camel-cassandraql=com.google.guava:guava:${cassandra-driver-guava-version}
+camel-cassandraql=com.datastax.oss:java-driver-core:${cassandra-driver-version},com.datastax.oss:java-driver-query-builder:${cassandra-driver-version}
 
 camel-github=org.eclipse.mylyn.github:org.eclipse.egit.github.core:${egit-github-core-version}
 camel-guava-eventbus=com.google.guava:guava:${google-guava-version}


### PR DESCRIPTION
… after upgrade to Cassandra driver 4.x

Issue: https://issues.apache.org/jira/browse/CAMEL-15334

Version of datastax driver came from spring-boot BOM, with value 4.6.1
Camel is using 4.7.2. It has to be overwritten.