### PR TITLE
CAMEL-15541: Add auto-configuration to camel-jasypt-starter

### DIFF
--- a/components-starter/camel-jasypt-starter/pom.xml
+++ b/components-starter/camel-jasypt-starter/pom.xml
@@ -50,4 +50,20 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <JASYPT_ENCRYPTION_PASSWORD>mainpassword</JASYPT_ENCRYPTION_PASSWORD>
+          </systemProperties>
+          <environmentVariables>
+            <JASYPT_ENCRYPTION_PASSWORD>mainpassword</JASYPT_ENCRYPTION_PASSWORD>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/components-starter/camel-jasypt-starter/src/main/docs/jasypt-starter.adoc
+++ b/components-starter/camel-jasypt-starter/src/main/docs/jasypt-starter.adoc
@@ -1,0 +1,34 @@
+// spring-boot-auto-configure options: START
+:page-partial:
+:doctitle: Camel Spring Boot Starter for jasypt
+
+== Spring Boot Auto-Configuration
+
+When using jasypt with Spring Boot make sure to use the following Maven dependency to have support for auto configuration:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.apache.camel.springboot</groupId>
+  <artifactId>camel-jasypt-starter</artifactId>
+  <version>x.x.x</version>
+  <!-- use the same version as your Camel core version -->
+</dependency>
+----
+
+
+The component supports 6 options, which are listed below.
+
+
+
+[width="100%",cols="2,5,^1,2",options="header"]
+|===
+| Name | Description | Default | Type
+| *camel.component.jasypt.enabled* | Enable the component | true | Boolean
+| *camel.component.jasypt.algorithm* | The algorithm to be used for decryption. | PBEWithMD5AndDES | String
+| *camel.component.jasypt.iv-generator-class-name* | The initialization vector (IV) generator applied in decryption operations. | org.jasypt.iv.NoIvGenerator if the algorithm does not require an initialization vector, org.jasypt.iv.RandomIvGenerator otherwise | String
+| *camel.component.jasypt.salt-generator-class-name* | The salt generator applied in decryption operations. | org.jasypt.salt.RandomSaltGenerator | String
+| *camel.component.jasypt.password* | The master password used by Jasypt for decrypting the values. This option supports prefixes which influence the master password lookup behaviour: sysenv: means to lookup the OS system environment with the given key. sys: means to lookup a JVM system property. |  | String
+| *camel.component.jasypt.provider-class-name* | The class name of the security provider to be used for obtaining the encryption algorithm. | com.sun.crypto.provider.SunJCE | String
+|===
+// spring-boot-auto-configure options: END

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/EncryptablePropertySourcesPlaceholderConfigurer.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/EncryptablePropertySourcesPlaceholderConfigurer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.env.ConfigurablePropertyResolver;
+import org.springframework.util.StringValueResolver;
+
+
+import static org.jasypt.properties.PropertyValueEncryptionUtils.decrypt;
+import static org.jasypt.properties.PropertyValueEncryptionUtils.isEncryptedValue;
+
+
+public class EncryptablePropertySourcesPlaceholderConfigurer
+        extends PropertySourcesPlaceholderConfigurer {
+    /**
+     * The encryptor.
+     */
+    private StringEncryptor stringEncryptor;
+
+    /**
+     * PropertySourcesPlaceholderConfigurer  constructor
+     * @param stringEncryptor the encryptor
+     */
+    @Autowired
+    public EncryptablePropertySourcesPlaceholderConfigurer(StringEncryptor stringEncryptor){
+        this.stringEncryptor = stringEncryptor;
+    }
+
+
+    /**
+     * Visit each bean definition in the given bean factory and attempt to replace ${...} property
+     * placeholders with values from the given properties. If a property is encrypted, it decrypt first
+     * and then replace.
+     *
+     * @param beanFactory the bean factory to process.
+     * @param propertyResolver used to resolve the properties
+     * @throws BeansException If an error occurs.
+     */
+    @Override
+    protected void processProperties(ConfigurableListableBeanFactory beanFactory,
+                final ConfigurablePropertyResolver propertyResolver) throws BeansException {
+
+        propertyResolver.setPlaceholderPrefix(this.placeholderPrefix);
+        propertyResolver.setPlaceholderSuffix(this.placeholderSuffix);
+        propertyResolver.setValueSeparator(this.valueSeparator);
+
+        StringValueResolver valueResolver = strVal -> {
+            String resolved = this.ignoreUnresolvablePlaceholders ?
+                    propertyResolver.resolvePlaceholders(strVal) :
+                    propertyResolver.resolveRequiredPlaceholders(strVal);
+            if (this.trimValues) {
+                resolved = resolved.trim();
+            }
+            if(isEncryptedValue(resolved)){
+                resolved = decrypt(resolved, stringEncryptor);
+            }
+            return (resolved.equals(this.nullValue) ? null : resolved);
+        };
+        doProcessProperties(beanFactory, valueResolver);
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.component.properties.PropertiesParser;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
+import org.jasypt.exceptions.EncryptionInitializationException;
+import org.jasypt.iv.IvGenerator;
+import org.jasypt.iv.NoIvGenerator;
+import org.jasypt.iv.RandomIvGenerator;
+import org.jasypt.salt.RandomSaltGenerator;
+import org.jasypt.salt.SaltGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
+import org.springframework.boot.context.properties.bind.handler.IgnoreErrorsBindHandler;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertyResolver;
+
+import java.lang.annotation.Annotation;
+
+import static org.apache.camel.component.jasypt.springboot.JasyptEncryptedPropertiesConfiguration.PREFIX;
+import static org.apache.camel.component.jasypt.springboot.JasyptEncryptedPropertiesUtils.isIVNeeded;
+import static org.apache.camel.util.ObjectHelper.isNotEmpty;
+import static org.apache.camel.util.StringHelper.after;
+import static org.springframework.boot.context.properties.source.ConfigurationPropertySources.from;
+import static org.springframework.core.ResolvableType.forClass;
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "camel.component.jasypt.enabled", matchIfMissing = true)
+@AutoConfigureBefore(CamelAutoConfiguration.class)
+public class JasyptEncryptedPropertiesAutoconfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JasyptEncryptedPropertiesAutoconfiguration.class);
+
+    private static final String SYSTEM_ENVIRONMENT_PREFIX = "sysenv:";
+
+    private static final String SYSTEM_PROPERTIES_PREFIX = "sys:";
+
+    @Bean
+    public JasyptEncryptedPropertiesConfiguration JasyptEncryptedPropertiesAutoconfiguration(final ConfigurableEnvironment environment) {
+        JasyptEncryptedPropertiesConfiguration config = new JasyptEncryptedPropertiesConfiguration();
+        final BindHandler handler = new IgnoreErrorsBindHandler(BindHandler.DEFAULT);
+        final MutablePropertySources propertySources = environment.getPropertySources();
+        PropertySourcesPlaceholdersResolver propertyResolver = new PropertySourcesPlaceholdersResolver(propertySources);
+        Iterable<ConfigurationPropertySource> configurationPropertySources = from(propertySources);
+        ConversionService conversionService = ApplicationConversionService.getSharedInstance();
+        final Binder binder = new Binder(configurationPropertySources, propertyResolver, conversionService);
+        final ResolvableType type = forClass(JasyptEncryptedPropertiesConfiguration.class);
+        final Annotation annotation = findAnnotation(JasyptEncryptedPropertiesConfiguration.class, ConfigurationProperties.class);
+        final Annotation[] annotations = new Annotation[]{annotation};
+        final Bindable<?> target = Bindable.of(type).withExistingValue(config).withAnnotations(annotations);
+        binder.bind(PREFIX, target, handler);
+        return config;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EnvironmentStringPBEConfig.class)
+    public EnvironmentStringPBEConfig environmentVariablesConfiguration(JasyptEncryptedPropertiesConfiguration configuration) {
+        EnvironmentStringPBEConfig environmentStringPBEConfig = new EnvironmentStringPBEConfig();
+        environmentStringPBEConfig.setAlgorithm(configuration.getAlgorithm());
+        environmentStringPBEConfig.setIvGenerator(getIVGenerator(configuration));
+        environmentStringPBEConfig.setSaltGenerator(getSaltGenerator(configuration));
+        environmentStringPBEConfig.setProviderClassName(configuration.getProviderClassName());
+        parsePassword(environmentStringPBEConfig, configuration);
+        return environmentStringPBEConfig;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(StringEncryptor.class)
+    public StringEncryptor stringEncryptor(EnvironmentStringPBEConfig environmentVariablesConfiguration) {
+        StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
+        standardPBEStringEncryptor.setConfig(environmentVariablesConfiguration);
+        return standardPBEStringEncryptor;
+    }
+
+    @Bean
+    public EncryptablePropertySourcesPlaceholderConfigurer propertyConfigurer(StringEncryptor stringEncryptor) {
+        return new EncryptablePropertySourcesPlaceholderConfigurer(stringEncryptor);
+    }
+
+    /*
+        This bean override the default org.apache.camel.spring.boot.SpringPropertiesParser
+        and allow the use of encrypted properties inside the camel context.
+     */
+    @Bean
+    public PropertiesParser encryptedPropertiesParser(PropertyResolver propertyResolver, StringEncryptor stringEncryptor) {
+        return new JasyptSpringEncryptedPropertiesParser(propertyResolver, stringEncryptor);
+    }
+
+    public SaltGenerator getSaltGenerator(JasyptEncryptedPropertiesConfiguration configuration) {
+        String saltGeneratorClassName = configuration.getSaltGeneratorClassName();
+        SaltGenerator saltGenerator = loadClass(saltGeneratorClassName);
+        if (saltGenerator != null) {
+            return saltGenerator;
+        }
+        return new RandomSaltGenerator();
+    }
+
+    private IvGenerator getIVGenerator(JasyptEncryptedPropertiesConfiguration configuration) {
+        String ivGeneratorClassName = configuration.getIvGeneratorClassName();
+        IvGenerator ivGenerator = loadClass(ivGeneratorClassName);
+        if (ivGenerator != null) {
+            return ivGenerator;
+        }
+        String algorithm = configuration.getAlgorithm();
+        return isIVNeeded(algorithm) ? new RandomIvGenerator() : new NoIvGenerator();
+    }
+
+    private <T> T loadClass(String className) {
+        try {
+            final Class clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
+            return (T) clazz.newInstance();
+        } catch (Exception e) {
+            throw new EncryptionInitializationException(e);
+        }
+    }
+
+    private void parsePassword(EnvironmentStringPBEConfig environmentStringPBEConfig, JasyptEncryptedPropertiesConfiguration configuration) {
+        String passwordReference = configuration.getPassword();
+        if (isNotEmpty(passwordReference) && passwordReference.startsWith(SYSTEM_ENVIRONMENT_PREFIX)) {
+            environmentStringPBEConfig.setPasswordEnvName(after(passwordReference, SYSTEM_ENVIRONMENT_PREFIX));
+            return;
+        }
+        if (isNotEmpty(passwordReference) && passwordReference.startsWith(SYSTEM_PROPERTIES_PREFIX)) {
+            environmentStringPBEConfig.setPasswordSysPropertyName(after(passwordReference, SYSTEM_PROPERTIES_PREFIX));
+            return;
+        }
+        environmentStringPBEConfig.setPassword(passwordReference);
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesConfiguration.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class JasyptEncryptedPropertiesConfiguration {
+
+    static final String PREFIX = "camel.component.jasypt";
+
+    /**
+     * Enable the component
+     */
+    @Value("${camel.component.jasypt.enabled}")
+    private boolean enabled;
+
+    /**
+     * The algorithm to be used for decryption. Default: PBEWithMD5AndDES
+     */
+    @Value("${camel.component.jasypt.algorithm}")
+    private String algorithm = "PBEWithMD5AndDES";
+
+    /**
+     * The master password used by Jasypt for decrypting the values.
+     * This option supports prefixes which influence the master password lookup behaviour:
+     * sysenv: means to lookup the OS system environment with the given key.
+     * sys: means to lookup a JVM system property.
+     */
+    @Value("${camel.component.jasypt.password}")
+    private String password;
+
+    /**
+     * The initialization vector (IV) generator applied in decryption operations.
+     * Default: org.jasypt.iv.
+     */
+    @Value("${camel.component.jasypt.iv-generator-class-name}")
+    private String ivGeneratorClassName;
+
+    /**
+     * The salt generator applied in decryption operations. Default: org.jasypt.salt.RandomSaltGenerator
+     */
+    @Value("${camel.component.jasypt.salt-generator-class-name}")
+    private String saltGeneratorClassName = "org.jasypt.salt.RandomSaltGenerator";
+
+    /**
+     * The class name of the security provider to be used for obtaining the encryption
+     * algorithm.
+     */
+    @Value("${camel.component.jasypt.provider-class-name}")
+    private String providerClassName = "com.sun.crypto.provider.SunJCE";
+
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getIvGeneratorClassName() {
+        return ivGeneratorClassName;
+    }
+
+    public void setIvGeneratorClassName(String ivGeneratorClassName) {
+        this.ivGeneratorClassName = ivGeneratorClassName;
+    }
+
+    public String getSaltGeneratorClassName() {
+        return saltGeneratorClassName;
+    }
+
+    public void setSaltGeneratorClassName(String saltGeneratorClassName) {
+        this.saltGeneratorClassName = saltGeneratorClassName;
+    }
+
+    public String getProviderClassName() {
+        return providerClassName;
+    }
+
+    public void setProviderClassName(String providerClassName) {
+        this.providerClassName = providerClassName;
+    }
+}
+

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesUtils.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class JasyptEncryptedPropertiesUtils {
+
+    static final Set<String> ALGORITHMS_THAT_REQUIRE_IV = new HashSet<>(
+            Arrays.asList(
+                    "PBEWITHHMACSHA1ANDAES_128",
+                    "PBEWITHHMACSHA1ANDAES_256",
+                    "PBEWITHHMACSHA224ANDAES_128",
+                    "PBEWITHHMACSHA224ANDAES_256",
+                    "PBEWITHHMACSHA256ANDAES_128",
+                    "PBEWITHHMACSHA256ANDAES_256",
+                    "PBEWITHHMACSHA384ANDAES_128",
+                    "PBEWITHHMACSHA384ANDAES_256",
+                    "PBEWITHHMACSHA512ANDAES_128",
+                    "PBEWITHHMACSHA512ANDAES_256"
+            )
+    );
+
+    static boolean isIVNeeded(String algorithm) {
+        return ALGORITHMS_THAT_REQUIRE_IV.contains(algorithm.toUpperCase());
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptSpringEncryptedPropertiesParser.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptSpringEncryptedPropertiesParser.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.component.properties.DefaultPropertiesParser;
+import org.apache.camel.component.properties.PropertiesLookup;
+import org.jasypt.encryption.StringEncryptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.PropertyResolver;
+
+import static org.jasypt.properties.PropertyValueEncryptionUtils.isEncryptedValue;
+import static  org.jasypt.properties.PropertyValueEncryptionUtils.decrypt;
+
+
+public class JasyptSpringEncryptedPropertiesParser extends DefaultPropertiesParser {
+
+    private PropertyResolver propertyResolver;
+
+    private StringEncryptor stringEncryptor;
+
+    @Autowired
+    public JasyptSpringEncryptedPropertiesParser(PropertyResolver propertyResolver, StringEncryptor stringEncryptor){
+        this.propertyResolver = propertyResolver;
+        this.stringEncryptor = stringEncryptor;
+    }
+
+    @Override
+    public String parseProperty(String key, String value, PropertiesLookup properties) {
+        String originalValue = this.propertyResolver.getProperty(key);
+        return isEncryptedValue(originalValue) ? decrypt(originalValue, this.stringEncryptor) : originalValue;
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/main/resources/META-INF/spring.factories
+++ b/components-starter/camel-jasypt-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.apache.camel.component.jasypt.springboot.JasyptEncryptedPropertiesAutoconfiguration

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/Constants.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/Constants.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+public class Constants {
+
+    public static final String MOCK_URI = "mock:out";
+    public static final String START_URI_TEST_ENCRYPTED_PROPS_IN_CC = "direct:startEncInCC";
+    public static final String START_URI_TEST_ENCRYPTED_PROPS_OUT_CC = "direct:startEncOUTCC";
+    public static final String START_URI_TEST_UNENCRYPTED_PROPS_IN_CC = "direct:startUnencInCC";
+    public static final String START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC = "direct:startUnencOutCC";
+
+
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedProperiesTestBase.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedProperiesTestBase.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.apache.camel.ExchangePattern.InOut;
+import static org.apache.camel.component.jasypt.springboot.Constants.MOCK_URI;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC;
+import static org.junit.Assert.assertEquals;
+
+public abstract class EncryptedProperiesTestBase {
+
+
+    @EndpointInject(MOCK_URI)
+    protected MockEndpoint mock;
+
+    @Produce
+    protected ProducerTemplate producer;
+
+    @Autowired
+    protected ApplicationContext context;
+
+
+    @Test
+    public void testUnencryptedPropsInsideCamelContext() {
+        testEncryption(START_URI_TEST_UNENCRYPTED_PROPS_IN_CC, "unEncrYpteD");
+    }
+
+    @Test
+    public void testUnencryptedPropsOutsideCamelcontext() {
+        testEncryption(START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC, "unEncrYpteD");
+    }
+
+
+    public void testEncryption(String uri, String expected){
+        Object o =  producer.sendBody(uri, InOut,"Hi from Camel!");
+        assertEquals(expected, mock.assertExchangeReceived(0).getIn().getBody());
+        mock.reset();
+    }
+
+
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesBean.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesBean.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.Exchange;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_OUT_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC;
+
+@Component("encryptedPropertiesBean")
+public class EncryptedPropertiesBean {
+
+    Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    @Value("${encrypted.password}")
+    private String encryptedPassword;
+
+    @Value("${unencrypted.property}")
+    private String unencryptedPassword;
+
+
+    public void testEncryptedProperty(Exchange exchange) {
+        LOG.info("test properties decryption outside camel context: test.password        = {}", encryptedPassword);
+        exchange.getIn().setBody(encryptedPassword);
+    }
+
+    public void testUnencryptedProperty(Exchange exchange) {
+        LOG.info("test unencrypted properties outside camel context: encrypted.property  = {}", unencryptedPassword);
+        exchange.getIn().setBody(unencryptedPassword);
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesCustomConfigurationBeansTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesCustomConfigurationBeansTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.component.properties.PropertiesParser;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
+import org.jasypt.iv.RandomIvGenerator;
+import org.jasypt.salt.RandomSaltGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.PropertyResolver;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootApplication
+@SpringBootTest(
+        classes = {EncryptedPropertiesCustomConfigurationBeansTest.TestConfiguration.class},
+        properties = {"encrypted.password=ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)"})
+public class EncryptedPropertiesCustomConfigurationBeansTest extends EncryptedProperiesTestBase {
+
+
+
+    @Test
+    public void testCustomEnvironmentVariablesConfiguration() {
+        Assert.assertFalse(context.containsBean("environmentVariablesConfiguration"));
+        Assert.assertTrue(context.containsBean("customEnvironmentStringPBEConfig"));
+
+        Assert.assertTrue(context.containsBean("customStringEncryptor"));
+        Assert.assertFalse(context.containsBean("stringEncryptor"));
+
+    }
+
+    @Configuration
+    @Import(Routes.class)
+    @AutoConfigureBefore(CamelAutoConfiguration.class)
+    public static class TestConfiguration {
+
+        @Bean("customEnvironmentStringPBEConfig")
+        public EnvironmentStringPBEConfig environmentVariablesConfiguration() {
+            EnvironmentStringPBEConfig environmentStringPBEConfig = new EnvironmentStringPBEConfig();
+            environmentStringPBEConfig.setAlgorithm("PBEWITHHMACSHA512ANDAES_256");
+            environmentStringPBEConfig.setIvGenerator(new RandomIvGenerator("NativePRNG"));
+            environmentStringPBEConfig.setSaltGenerator(new RandomSaltGenerator("NativePRNG"));
+            environmentStringPBEConfig.setPassword("mainpassword");
+            return environmentStringPBEConfig;
+        }
+
+        @Bean("customStringEncryptor")
+        public StandardPBEStringEncryptor stringEncryptor(EnvironmentStringPBEConfig environmentVariablesConfiguration) {
+            StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
+            standardPBEStringEncryptor.setConfig(environmentVariablesConfiguration);
+            return standardPBEStringEncryptor;
+        }
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledCustomConfigurationBeansTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledCustomConfigurationBeansTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
+import org.jasypt.iv.RandomIvGenerator;
+import org.jasypt.salt.RandomSaltGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_OUT_CC;
+
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootApplication
+@SpringBootTest(
+        classes = {EncryptedPropertiesDisabledCustomConfigurationBeansTest.TestConfiguration.class},
+        properties = {
+                "camel.component.jasypt.enabled = false",
+                "encrypted.password=ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)"})
+public class EncryptedPropertiesDisabledCustomConfigurationBeansTest extends EncryptedProperiesTestBase {
+
+    @Test
+    public void testCustomEnvironmentVariablesConfiguration() {
+        Assert.assertFalse(context.containsBean("environmentVariablesConfiguration"));
+        Assert.assertTrue(context.containsBean("customEnvironmentStringPBEConfig"));
+        Assert.assertTrue(context.containsBean("customStringEncryptor"));
+        Assert.assertFalse(context.containsBean("stringEncryptor"));
+        Assert.assertFalse(context.containsBean("propertyConfigurer"));
+        Assert.assertFalse(context.containsBean("encryptedPropertiesParser"));
+    }
+
+    @Test
+    public void testEncryptionInsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_IN_CC, "ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)");
+    }
+
+    @Test
+    public void testEncryptionOutsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_OUT_CC, "ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)");
+    }
+
+    @Configuration
+    @Import({Routes.class,EncryptedPropertiesCustomConfigurationBeansTest.TestConfiguration.class})
+    public static class TestConfiguration {}
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_OUT_CC;
+
+
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootApplication
+@SpringBootTest(
+        properties = {"camel.component.jasypt.enabled = false"},
+        classes = {EncryptedPropertiesCustomConfigurationBeansTest.TestConfiguration.class})
+public class EncryptedPropertiesDisabledTest extends EncryptedProperiesTestBase{
+
+
+    /**
+     * Disabling the encryption, properties will not fm decrypted
+     */
+    @Test
+    public void testEncryptionInsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_IN_CC, "ENC(ngTGZvEjfnNnKMTrbRCR3tHEnFShMGdBSgfW5K9mlg23u+ygbtNCgJGmDriQBVcB)");
+    }
+
+    @Test
+    public void testEncryptionOutsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_OUT_CC, "ENC(ngTGZvEjfnNnKMTrbRCR3tHEnFShMGdBSgfW5K9mlg23u+ygbtNCgJGmDriQBVcB)");
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_ENCRYPTED_PROPS_OUT_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_IN_CC;
+import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC;
+
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootApplication
+@SpringBootTest(classes = {EncryptedPropertiesTest.TestConfiguration.class})
+public class EncryptedPropertiesTest extends EncryptedProperiesTestBase {
+
+    @Test
+    public void testEncryptionInsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_IN_CC, "mysecret");
+    }
+
+    @Test
+    public void testEncryptionOutsideCamelContext() {
+        testEncryption(START_URI_TEST_ENCRYPTED_PROPS_OUT_CC, "mysecret");
+    }
+
+    @Test
+    public void testUnencryptedPropsInsideCamelContext() {
+        testEncryption(START_URI_TEST_UNENCRYPTED_PROPS_IN_CC, "unEncrYpteD");
+    }
+
+    @Test
+    public void testUnencryptedPropsOutsideCamelcontext() {
+        testEncryption(START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC, "unEncrYpteD");
+    }
+
+
+    @Configuration
+    @Import(Routes.class)
+    @AutoConfigureBefore(CamelAutoConfiguration.class)
+    public static class TestConfiguration {}
+
+}

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/Routes.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/Routes.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jasypt.springboot;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.apache.camel.component.jasypt.springboot.Constants.*;
+
+@Configuration
+public class Routes {
+
+    @Bean
+    public RouteBuilder encryptedPropertiesTestRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(START_URI_TEST_ENCRYPTED_PROPS_IN_CC)
+                        .routeId("encrypted-properties-route-test-inside-camel-context")
+                        .log("test properties decryption inside camel context ...")
+                        .setBody(simple("{{encrypted.password}}"))
+                        .to(MOCK_URI);
+
+                from(START_URI_TEST_ENCRYPTED_PROPS_OUT_CC)
+                        .routeId("encrypted-properties-route-test-outside-camel-context")
+                        .log("test properties decryption  outside camel context ...")
+                        .to("bean:encryptedPropertiesBean?method=testEncryptedProperty")
+                        .to(MOCK_URI);
+
+                from(START_URI_TEST_UNENCRYPTED_PROPS_IN_CC)
+                        .routeId("unencrypted-properties-route-test-inside-camel-context")
+                        .log("test unencrypted properties inside camel context ...")
+                        .setBody(simple("{{unencrypted.property}}"))
+                        .to(MOCK_URI);
+
+                from(START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC)
+                        .routeId("unecrypted-properties-route-test-inside-camel-context")
+                        .log("test unencrypted properties outside camel context ...")
+                        .to("bean:encryptedPropertiesBean?method=testUnencryptedProperty")
+                        .to(MOCK_URI);
+            }
+        };
+    }
+}

--- a/components-starter/camel-jasypt-starter/src/test/resources/application.properties
+++ b/components-starter/camel-jasypt-starter/src/test/resources/application.properties
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+spring.main.banner-mode = off
+# unencryped properties
+
+unencrypted.property = unEncrYpteD
+
+# encrypted properties
+encrypted.password = ENC(ngTGZvEjfnNnKMTrbRCR3tHEnFShMGdBSgfW5K9mlg23u+ygbtNCgJGmDriQBVcB)
+
+
+camel.component.jasypt.enabled = true
+camel.component.jasypt.algorithm= PBEWITHHMACSHA256ANDAES_256
+camel.component.jasypt.password = sysenv:JASYPT_ENCRYPTION_PASSWORD
+camel.component.jasypt.iv-generator-class-name = org.jasypt.iv.RandomIvGenerator
+camel.component.jasypt.salt-generator-class-name = org.jasypt.salt.RandomSaltGenerator
+camel.component.jasypt.provider-class-name = com.sun.crypto.provider.SunJCE

--- a/components-starter/camel-jasypt-starter/src/test/resources/logback.xml
+++ b/components-starter/camel-jasypt-starter/src/test/resources/logback.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+    <file>target/camel-jasypt-starter-test.log</file>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.apache.camel.component.jasypt.springboot" level="DEBUG"/>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -224,6 +224,7 @@ public class CamelAutoConfiguration {
     // SpringCamelContext integration
 
     @Bean
+    @ConditionalOnMissingBean(PropertiesParser.class)
     PropertiesParser propertiesParser() {
         return new SpringPropertiesParser();
     }


### PR DESCRIPTION
Added auto-configuration that registers the necessary beans to allow properties decryption inside and outside the camel context.