### PR TITLE
CAMEL-15624 : Fixing complex types issue on spring starters component Configuration

### DIFF
--- a/components-starter/camel-reactive-streams-starter/src/main/java/org/apache/camel/component/reactive/streams/springboot/ReactiveStreamsServiceAutoConfiguration.java
+++ b/components-starter/camel-reactive-streams-starter/src/main/java/org/apache/camel/component/reactive/streams/springboot/ReactiveStreamsServiceAutoConfiguration.java
@@ -47,7 +47,7 @@ public class ReactiveStreamsServiceAutoConfiguration {
         ReactiveStreamsEngineConfiguration engineConfiguration = new ReactiveStreamsEngineConfiguration();
 
         if (configuration.getReactiveStreamsEngineConfiguration() != null) {
-            engineConfiguration = ac.getBean(configuration.getReactiveStreamsEngineConfiguration(), ReactiveStreamsEngineConfiguration.class);
+            engineConfiguration = configuration.getReactiveStreamsEngineConfiguration();
         } else {
             engineConfiguration.setThreadPoolName(configuration.getThreadPoolName());
             if (configuration.getThreadPoolMinSize() != null) {

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/SpringBootAutoConfigurationMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/SpringBootAutoConfigurationMojo.java
@@ -707,11 +707,11 @@ public class SpringBootAutoConfigurationMojo extends AbstractSpringBootGenerator
                 if ("java.lang.String".equals(option.getJavaType())) {
                     prop.getField().setStringInitializer(option.getDefaultValue().toString());
                 } else if ("duration".equals(option.getType())) {
-                	String value= convertDurationToMillisec(option.getDefaultValue().toString());
-                	// duration is either long or int java type
-                	if ("long".equals(option.getJavaType()) || "java.lang.Long".equals(option.getJavaType())) {
-                		value = value + "L";
-                	}
+                    String value = convertDurationToMillisec(option.getDefaultValue().toString());
+                    // duration is either long or int java type
+                    if ("long".equals(option.getJavaType()) || "java.lang.Long".equals(option.getJavaType())) {
+                        value = value + "L";
+                    }
                     prop.getField().setLiteralInitializer(value);
                 } else if ("long".equals(option.getJavaType()) || "java.lang.Long".equals(option.getJavaType())) {
                     // the value should be a Long number
@@ -733,17 +733,17 @@ public class SpringBootAutoConfigurationMojo extends AbstractSpringBootGenerator
     }
     
     private String convertDurationToMillisec(String pattern) {
-    	String value = null;
-    	pattern = pattern.toLowerCase();
-    	if (pattern.indexOf("ms") != -1) {
-			pattern = pattern.replaceAll("ms", "");
-		}
-    	try {
-    		Duration d = Duration.parse("PT"+pattern);
-    		value = String.valueOf(d.toMillis());
-		} catch (java.time.format.DateTimeParseException e) {
-			value = pattern;
-		}
+        String value = null;
+        pattern = pattern.toLowerCase();
+        if (pattern.indexOf("ms") != -1) {
+            pattern = pattern.replaceAll("ms", "");
+        }
+        try {
+            Duration d = Duration.parse("PT" + pattern);
+            value = String.valueOf(d.toMillis());
+        } catch (java.time.format.DateTimeParseException e) {
+            value = pattern;
+        }
         return value;
     }
 


### PR DESCRIPTION
By fixing complex types in camel-spring-boot-generator-maven-plugin, camel spring starters auto configuration type issues will be resolved not only IDE, but also applying them on runtime. 
By this change, some of modules brought another type errors by java.util.Duration.
It's duration type, but Java type was either Long or Integer. 
So, convertDurationToMillesec() introduced to generate the value correctly.