### PR TITLE
Use camel-version for Camel core dependencies

### DIFF
--- a/dsl-starter/camel-java-joor-dsl-starter/pom.xml
+++ b/dsl-starter/camel-java-joor-dsl-starter/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-java-joor-dsl</artifactId>
-            <version>${project.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/dsl-starter/camel-xml-io-dsl-starter/pom.xml
+++ b/dsl-starter/camel-xml-io-dsl-starter/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-io-dsl</artifactId>
-            <version>${project.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/dsl-starter/camel-xml-jaxb-dsl-starter/pom.xml
+++ b/dsl-starter/camel-xml-jaxb-dsl-starter/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxb-dsl</artifactId>
-            <version>${project.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/dsl-starter/camel-yaml-dsl-starter/pom.xml
+++ b/dsl-starter/camel-yaml-dsl-starter/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-yaml-dsl</artifactId>
-            <version>${project.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Use `camel-version` for Camel core dependencies to avoid issues during the release process.