### PR TITLE
CAMEL-16055: Add spring-boot-parent pom.xml

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -23,9 +23,9 @@
 
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>spring-boot</artifactId>
+        <artifactId>spring-boot-parent</artifactId>
         <version>3.4.6-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,9 +23,9 @@
 
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>spring-boot</artifactId>
+        <artifactId>spring-boot-parent</artifactId>
         <version>3.4.6-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>spring-boot</artifactId>
+        <version>3.4.6-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>spring-boot-parent</artifactId>
+    <version>3.4.6-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Camel SB :: Parent</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-core-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-parent</artifactId>
+                <version>${camel-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${google-guava-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     </prerequisites>
 
     <modules>
+        <module>parent</module>
         <module>tooling</module>
         <module>core</module>
         <module>components-starter</module>
@@ -166,38 +167,6 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-core-starter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-spring-boot-starter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-spring-boot</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel</groupId>
-                <artifactId>camel-parent</artifactId>
-                <version>${camel-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${google-guava-version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <defaultGoal>install</defaultGoal>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,9 +23,9 @@
 
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>spring-boot</artifactId>
+        <artifactId>spring-boot-parent</artifactId>
         <version>3.4.6-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-bom-generator/target-template-pom.xml
+++ b/tooling/camel-spring-boot-bom-generator/target-template-pom.xml
@@ -23,6 +23,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>spring-boot</artifactId>
+        <version>${project.version}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
     <groupId>org.apache.camel.springboot</groupId>
     <artifactId>camel-spring-boot-bom</artifactId>
     <version>${project.version}</version>

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -19,6 +19,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>spring-boot</artifactId>
+    <version>3.4.6-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
   <groupId>org.apache.camel.springboot</groupId>
   <artifactId>camel-spring-boot-bom</artifactId>
   <version>3.4.6-SNAPSHOT</version>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -23,8 +23,9 @@
 
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>spring-boot</artifactId>
+        <artifactId>spring-boot-parent</artifactId>
         <version>3.4.6-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>tooling</artifactId>


### PR DESCRIPTION
When attempting to release Camel Spring Boot 3.4.6, I hit the same issue regarding the parent pom restructuring as we previously faced with the 3.7.1 release.

In this PR, I applied the relevant changes from PR https://github.com/apache/camel-spring-boot/pull/262 onto the `camel-spring-boot-3.4.x` branch.