### PR TITLE
CAMEL-16945: Upgrade the spring-boot integration tests module to use JUnit5.

### DIFF
--- a/components-starter/camel-hazelcast-starter/src/main/resources/META-INF/spring.factories
+++ b/components-starter/camel-hazelcast-starter/src/main/resources/META-INF/spring.factories
@@ -16,27 +16,16 @@
 ## ---------------------------------------------------------------------------
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.apache.camel.component.hazelcast.list.springboot.HazelcastListComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.list.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.map.springboot.HazelcastMapComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.map.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.replicatedmap.springboot.HazelcastReplicatedmapComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.replicatedmap.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.queue.springboot.HazelcastQueueComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.queue.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.set.springboot.HazelcastSetComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.set.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.topic.springboot.HazelcastTopicComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.topic.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.seda.springboot.HazelcastSedaComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.seda.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.multimap.springboot.HazelcastMultimapComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.multimap.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.ringbuffer.springboot.HazelcastRingbufferComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.ringbuffer.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.instance.springboot.HazelcastInstanceComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.instance.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.atomicnumber.springboot.HazelcastAtomicnumberComponentAutoConfiguration,\
-org.apache.camel.component.hazelcast.atomicnumber.springboot.customizer.HazelcastInstanceCustomizer,\
 org.apache.camel.component.hazelcast.list.springboot.HazelcastListComponentConverter,\
 org.apache.camel.component.hazelcast.replicatedmap.springboot.HazelcastReplicatedmapComponentConverter,\
 org.apache.camel.component.hazelcast.queue.springboot.HazelcastQueueComponentConverter,\

--- a/components-starter/camel-hystrix-starter/pom.xml
+++ b/components-starter/camel-hystrix-starter/pom.xml
@@ -48,10 +48,16 @@
       <!--END OF GENERATED CODE-->
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${spring-boot-version}</version>
       <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>

--- a/components-starter/camel-jasypt-starter/src/test/resources/application.properties
+++ b/components-starter/camel-jasypt-starter/src/test/resources/application.properties
@@ -26,7 +26,7 @@ encrypted.password = ENC(ngTGZvEjfnNnKMTrbRCR3tHEnFShMGdBSgfW5K9mlg23u+ygbtNCgJG
 
 camel.component.jasypt.enabled = true
 camel.component.jasypt.algorithm= PBEWITHHMACSHA256ANDAES_256
-camel.component.jasypt.password = sysenv:JASYPT_ENCRYPTION_PASSWORD
+camel.component.jasypt.password = sys:JASYPT_ENCRYPTION_PASSWORD
 camel.component.jasypt.iv-generator-class-name = org.jasypt.iv.RandomIvGenerator
 camel.component.jasypt.salt-generator-class-name = org.jasypt.salt.RandomSaltGenerator
 camel.component.jasypt.provider-name = SunJCE

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
-        <arquillian-version>1.6.0.Final</arquillian-version>
+        <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <asciidoctorj-version>2.3.0</asciidoctorj-version>
         <avro-version>1.8.1</avro-version>
         <glassfish-jaxb-runtime-version>${jakarta-jaxb-version}</glassfish-jaxb-runtime-version>

--- a/tests/camel-itest-spring-boot/pom.xml
+++ b/tests/camel-itest-spring-boot/pom.xml
@@ -33,10 +33,6 @@
     <name>Camel SB :: Integration Tests</name>
     <description>Spring-Boot Camel test</description>
 
-    <properties>
-        <!-- Upgrading to 2.20 activates this bug: https://issues.apache.org/jira/browse/SUREFIRE-1382 -->
-        <maven-surefire-plugin-version>2.19</maven-surefire-plugin-version>
-    </properties>
 
     <dependencies>
 
@@ -66,10 +62,14 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+      
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.eclipse.aether</groupId>
@@ -97,8 +97,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <version>${arquillian-version}</version>
             <scope>test</scope>
         </dependency>
@@ -191,7 +191,7 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <!-- Test configuration -->
                         <!--
                         It is better disabling unit testing in surefire, as some of them fail for various reasons
@@ -200,24 +200,11 @@
                         Tests are enabled when running from IDE. See org.apache.camel.itest.springboot.ITestConfigBuilder
                         for property names and defaults values.
                         -->
-                        <property>
-                            <name>itest.springboot.unitTestEnabled</name>
-                            <value>false</value>
-                        </property>
-                        <property>
-                            <name>itest.springboot.includeTestDependencies</name>
-                            <value>false</value>
-                        </property>
-                        <property>
-                            <name>itest.springboot.mavenOfflineResolution</name>
-                            <value>false</value>
-                        </property>
-                        <property>
-                            <name>itest.springboot.springBootVersion</name>
-                            <value>${spring-boot-version}</value>
-                        </property>
-
-                    </systemProperties>
+                        <itest.springboot.unitTestEnabled>true</itest.springboot.unitTestEnabled>
+                        <itest.springboot.includeTestDependencies>true</itest.springboot.includeTestDependencies>
+                        <itest.springboot.mavenOfflineResolution>false</itest.springboot.mavenOfflineResolution>
+                        <itest.springboot.springBootVersion>${spring-boot-version}</itest.springboot.springBootVersion>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfigBuilder.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/ITestConfigBuilder.java
@@ -169,6 +169,11 @@ public class ITestConfigBuilder {
         config.setSpringBootVersion(springBootVersion);
         return this;
     }
+    
+    public ITestConfigBuilder mavenOfflineResolution(Boolean offlineResolution) {
+        config.setMavenOfflineResolution(offlineResolution);
+        return this;
+    }
 
     public ITestConfig build() {
 

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/AbstractTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/AbstractTestCommand.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Future;
 
 import org.apache.camel.itest.springboot.Command;
 import org.apache.camel.itest.springboot.ITestConfig;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 
@@ -32,15 +32,17 @@ public abstract class AbstractTestCommand implements Command {
     @Async // needs to run on a spring background thread
     @Override
     public Future<Object> execute(Object[] parameters) throws Exception {
-        Assert.assertNotNull("Parameters cannot be null", parameters);
-        Assert.assertEquals("Parameters should contain two elements", 2, parameters.length);
+        Assertions.assertNotNull(parameters, "Parameters cannot be null");
+        Assertions.assertEquals(2, parameters.length, "Parameters should contain two elements");
         Object configObj = parameters[0];
-        Assert.assertNotNull("The first parameter cannot be null", configObj);
-        Assert.assertTrue("First parameter should be of type ITestConfig, found type " + configObj.getClass().getName(), configObj instanceof ITestConfig);
+        Assertions.assertNotNull(configObj, "The first parameter cannot be null");
+        Assertions.assertTrue(configObj instanceof ITestConfig,
+            "First parameter should be of type ITestConfig, found type " + configObj.getClass().getName());
 
         Object compNameObj = parameters[1];
-        Assert.assertNotNull("The second parameter cannot be null", compNameObj);
-        Assert.assertTrue("Second parameter should be of type String, found type " + compNameObj.getClass().getName(), compNameObj instanceof String);
+        Assertions.assertNotNull(compNameObj, "The second parameter cannot be null");
+        Assertions.assertTrue(compNameObj instanceof String,
+            "Second parameter should be of type String, found type " + compNameObj.getClass().getName());
 
         String compName = (String) compNameObj;
 

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/ComponentTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/ComponentTestCommand.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * A command that tries to lookup a camel component.
@@ -44,7 +44,7 @@ public class ComponentTestCommand extends AbstractTestCommand implements Command
 
         org.apache.camel.Component comp = context.getComponent(component, true, config.getAutoStartComponent());
 
-        assertNotNull("Cannot get module with name: " + component, comp);
+        assertNotNull(comp, "Cannot get module with name: " + component);
 
         logger.info("Found Camel module: {} instance: {} with className: {}", component, comp, comp.getClass());
         return true;

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/DataFormatTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/DataFormatTestCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * A command that tries to lookup a camel data-format.
@@ -44,7 +44,7 @@ public class DataFormatTestCommand extends AbstractTestCommand implements Comman
         logger.info("Getting Camel dataFormat: {}", dataFormat);
 
         DataFormat df = context.resolveDataFormat(dataFormat);
-        assertNotNull("Cannot get dataformat with name: " + dataFormat, df);
+        assertNotNull(df, "Cannot get dataformat with name: " + dataFormat);
 
         logger.info("Found Camel dataformat: {} instance: {} with className: {}", dataFormat, df, df.getClass());
         return true;

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/LanguageTestCommand.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/LanguageTestCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * A command that tries to lookup a camel language.
@@ -44,7 +44,7 @@ public class LanguageTestCommand extends AbstractTestCommand implements Command 
         logger.info("Getting Camel language: {}", language);
 
         Language lan = context.resolveLanguage(language);
-        assertNotNull("Cannot get language with name: " + language, lan);
+        assertNotNull(lan, "Cannot get language with name: " + language);
 
         logger.info("Found Camel language: {} instance: {} with className: {}", language, lan, lan.getClass());
         return true;

--- a/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestResult.java
+++ b/tests/camel-itest-spring-boot/src/main/java/org/apache/camel/itest/springboot/command/UnitTestResult.java
@@ -18,7 +18,7 @@ package org.apache.camel.itest.springboot.command;
 
 import java.io.Serializable;
 
-import org.junit.runner.Result;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 /**
  * Contains the result of the execution of a test suite.
@@ -41,12 +41,12 @@ public class UnitTestResult implements Serializable {
     public UnitTestResult() {
     }
 
-    public UnitTestResult(Result jr) {
-        this.runCount = jr.getRunCount();
-        this.failureCount = jr.getFailureCount();
-        this.runTime = jr.getRunTime();
-        this.ignoreCount = jr.getIgnoreCount();
-        this.successful = jr.wasSuccessful();
+    public UnitTestResult(TestExecutionSummary jr) {
+        this.runCount = (int) jr.getTestsStartedCount();
+        this.failureCount = (int) jr.getTestsFailedCount();
+        this.runTime = jr.getTimeFinished()-jr.getTimeStarted();
+        this.ignoreCount = (int) jr.getTestsSkippedCount();
+        this.successful = jr.getTestsFailedCount()==0;
     }
 
     public int getRunCount() {

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/AbstractSpringBootTestSupport.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/AbstractSpringBootTestSupport.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 
 import org.apache.camel.itest.springboot.arquillian.ArquillianSyncBootJarLauncher;
 import org.apache.camel.itest.springboot.util.SpringBootContainerFacade;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * This is the base class of all spring-boot integration tests.
@@ -36,7 +36,7 @@ public abstract class AbstractSpringBootTestSupport {
      *
      * @throws Exception
      */
-    @Before
+    @BeforeEach
     public void startSpringBoot() throws Exception {
         this.config = retrieveConfig();
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelActivemqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelActivemqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelActivemqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcTest.java
@@ -16,15 +16,16 @@
  */
 package org.apache.camel.itest.springboot;
 
+
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAhcTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcWsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAhcWsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAhcWsTest extends AbstractSpringBootTestSupport {
 
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAmqpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAmqpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAmqpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAny23Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAny23Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAny23Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelArangodbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelArangodbTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelArangodbTest extends AbstractSpringBootTestSupport{
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAs2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAs2Test.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAs2Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAsn1Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAsn1Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAsn1Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAsteriskTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAsteriskTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAsteriskTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtlasmapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtlasmapTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAtlasmapTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAtmosTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosphereWebsocketTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtmosphereWebsocketTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAtmosphereWebsocketTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAtomTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomixTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAtomixTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAtomixTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroRpcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroRpcTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAvroRpcTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAvroTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAvroTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2AthenaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2AthenaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2AthenaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2CwTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2CwTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2CwTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2DdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2DdbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2DdbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2Ec2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2Ec2Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2Ec2Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EcsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EcsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2EcsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EksTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EksTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2EksTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EventbridgeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2EventbridgeTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2EventbridgeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2IamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2IamTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2IamTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2KinesisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2KinesisTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2KinesisTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2KmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2KmsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2KmsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2LambdaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2LambdaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2LambdaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2MqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2MqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2MqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2MskTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2MskTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2MskTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2S3Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2S3Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2S3Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SesTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SesTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2SesTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SnsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SnsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2SnsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SqsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2SqsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2SqsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2StsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2StsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2StsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2TranslateTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAws2TranslateTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAws2TranslateTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAwsSecretsManagerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAwsSecretsManagerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAwsSecretsManagerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureCosmosdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureCosmosdbTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureCosmosdbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureEventhubsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureEventhubsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureEventhubsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureServicebusTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureServicebusTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureServicebusTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageBlobTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageBlobTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureStorageBlobTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageDatalakeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageDatalakeTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureStorageDatalakeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageQueueTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelAzureStorageQueueTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelAzureStorageQueueTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBarcodeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBarcodeTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBarcodeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBase64Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBase64Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBase64Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanValidatorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanValidatorTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBeanValidatorTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanioTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanioTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBeanioTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanstalkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBeanstalkTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBeanstalkTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBindyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBindyTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBindyTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBonitaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBonitaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBonitaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBoxTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBoxTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBraintreeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelBraintreeTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelBraintreeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCaffeineTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCaffeineTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCaffeineTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCassandraqlTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCassandraqlTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,8 +35,6 @@ public class CamelCassandraqlTest extends AbstractSpringBootTestSupport {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelCassandraqlTest.class))
                 .unitTestExclusionPattern(".*(\\.integration\\..*|IntegrationTest$|CassandraComponentProducerTest$|CassandraComponentBeanRefTest$|CassandraComponentConsumerTest$)")
-                .includeTestDependencies(false)
-                .unitTestsEnabled(false)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCborTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCborTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCborTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChatscriptTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChatscriptTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelChatscriptTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChunkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelChunkTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelChunkTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmSmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmSmsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCmSmsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCmisTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCmisTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCoapTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCoapTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCometdTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCometdTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCometdTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelConsulTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelConsulTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelConsulTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,8 +35,6 @@ public class CamelConsulTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelConsulTest.class))
-                .unitTestsEnabled(false)
-                .includeTestDependencies(false)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCordaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCordaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCordaTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -39,6 +39,7 @@ public class CamelCordaTest extends AbstractSpringBootTestSupport {
                 // artemis-server is pulled in from corda as it has a dependency on that
                 .dependency("org.apache.activemq:artemis-jms-server")
                 .dependency("org.apache.geronimo.specs:geronimo-json_1.0_spec:jar:1.0-alpha-1")
+                .ignoreLibraryMismatch("org.objenesis")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCouchdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCouchdbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCouchdbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCronTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCronTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCronTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCryptoTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCryptoTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCryptoTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCsvTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCsvTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCsvTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCxfTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTransportTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelCxfTransportTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelCxfTransportTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumCommonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumCommonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDebeziumCommonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumMongodbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumMongodbTest.java
@@ -18,14 +18,14 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore("MongoDB driver 3.x is not supported in SB 2.3.0")
-@RunWith(Arquillian.class)
+@Disabled("MongoDB driver 3.x is not supported in SB 2.3.0")
+@ExtendWith(ArquillianExtension.class)
 public class CamelDebeziumMongodbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumMysqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumMysqlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDebeziumMysqlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumPostgresTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumPostgresTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDebeziumPostgresTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumSqlserverTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDebeziumSqlserverTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDebeziumSqlserverTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDigitaloceanTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDigitaloceanTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDigitaloceanTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDisruptorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDisruptorTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDisruptorTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDjlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDjlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDjlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDnsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDnsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDnsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDockerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDockerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDockerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDozerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDozerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDozerTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,6 +35,7 @@ public class CamelDozerTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelDozerTest.class))
+                .ignoreLibraryMismatch("org.objenesis")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDrillTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDrillTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDrillTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDropboxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelDropboxTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelDropboxTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEhcacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEhcacheTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelEhcacheTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElasticsearchRestTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElasticsearchRestTest.java
@@ -18,14 +18,14 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore
-@RunWith(Arquillian.class)
+@Disabled
+@ExtendWith(ArquillianExtension.class)
 public class CamelElasticsearchRestTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElsqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelElsqlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelElsqlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEtcd3Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelEtcd3Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelEtcd3Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelExecTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelExecTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelExecTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFacebookTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFacebookTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFacebookTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFastjsonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFastjsonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFastjsonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFhirTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFhirTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFhirTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFileWatchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFileWatchTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFileWatchTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlatpackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlatpackTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFlatpackTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlinkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFlinkTest.java
@@ -18,15 +18,15 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@Ignore("It doesn't work with Flink 1.11.0")
-@RunWith(Arquillian.class)
+@Disabled("It doesn't work with Flink 1.11.0")
+@ExtendWith(ArquillianExtension.class)
 public class CamelFlinkTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFopTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFopTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFopTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFreemarkerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFreemarkerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFreemarkerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFtpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelFtpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelFtpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGangliaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGangliaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGangliaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGeocoderTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGeocoderTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGeocoderTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGitTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGitTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGitTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGithubTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGithubTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGithubTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleBigqueryTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleBigqueryTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleBigqueryTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleCalendarTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleCalendarTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleCalendarTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleDriveTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleDriveTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleDriveTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleFunctionsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleFunctionsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleFunctionsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleMailTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleMailTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleMailTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGooglePubsubTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGooglePubsubTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGooglePubsubTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleSheetsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleSheetsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleSheetsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleStorageTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoogleStorageTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoogleStorageTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoraTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGoraTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGoraTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -36,6 +36,7 @@ public class CamelGoraTest extends AbstractSpringBootTestSupport {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelGoraTest.class))
                 .ignoreLibraryMismatch("com.sun.jersey")
+                .ignoreLibraryMismatch("org.objenesis")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrapeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrapeTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGrapeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGraphqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGraphqlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGraphqlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrokTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrokTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGrokTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGroovyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGroovyTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGroovyTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrpcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGrpcTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGrpcTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGsonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGsonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGsonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuavaEventbusTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelGuavaEventbusTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelGuavaEventbusTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHazelcastTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHazelcastTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHazelcastTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHbaseTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHbaseTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHbaseTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,15 +35,14 @@ public class CamelHbaseTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelHbaseTest.class))
-                .unitTestsEnabled(false)
-                .includeTestDependencies(false)
                 .build();
     }
 
     @Test
     public void componentTests() throws Exception {
         this.runComponentTest(config);
-        this.runModuleUnitTestsIfEnabled(config);
+//        No unit tests for this starter
+//        this.runModuleUnitTestsIfEnabled(config);
     }
 
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHdfsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHdfsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHl7Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHl7Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHl7Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpCommonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpCommonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHttpCommonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHttpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHttpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHuaweicloudSmnTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHuaweicloudSmnTest.java
@@ -18,13 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHuaweicloudSmnTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHystrixTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelHystrixTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelHystrixTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIcalTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIcalTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelIcalTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIec60870Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIec60870Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelIec60870Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIgniteTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIgniteTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.itest.springboot;
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.apache.camel.itest.springboot.util.DependencyResolver;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelIgniteTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfinispanTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfinispanTest.java
@@ -18,14 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelInfinispanTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfluxdbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelInfluxdbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelInfluxdbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIotaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIotaTest.java
@@ -18,15 +18,15 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@Ignore("MongoDB driver 3.x is not supported in SB 2.3.0")
-@RunWith(Arquillian.class)
+@Disabled("MongoDB driver 3.x is not supported in SB 2.3.0")
+@ExtendWith(ArquillianExtension.class)
 public class CamelIotaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIrcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIrcTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelIrcTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIronmqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelIronmqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelIronmqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJacksonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonxmlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJacksonxmlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJacksonxmlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJasyptTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJasyptTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJasyptTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -36,6 +36,7 @@ public class CamelJasyptTest extends AbstractSpringBootTestSupport {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelJasyptTest.class))
                 .unitTestExclusionPattern(".*(\\.integration\\..*|IntegrationTest$|\\.Test$|\\.SpringTest$|Blueprint.*Test$)")
+                .systemProperty("JASYPT_ENCRYPTION_PASSWORD", "mainpassword")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJaxbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJaxbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJaxbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJbpmTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJbpmTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJbpmTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcacheTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJcacheTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcloudsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcloudsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJcloudsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcrTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJcrTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJcrTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJdbcTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJdbcTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJdbcTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyCommonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyCommonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJettyCommonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJettyTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJettyTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsRaftTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsRaftTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJgroupsRaftTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJgroupsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJgroupsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJingTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJingTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJingTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJiraTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJiraTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJiraTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJmsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJmxTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJmxTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJohnzonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJohnzonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJohnzonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJoltTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJoltTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJoltTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJooqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJooqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJooqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJpaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJpaTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.itest.springboot;
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.apache.camel.itest.springboot.util.DependencyResolver;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJpaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJschTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJschTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJschTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsltTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsltTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsltTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonPatchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonPatchTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsonPatchTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonValidatorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonValidatorTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsonValidatorTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonapiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonapiTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsonapiTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonataTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonataTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.itest.springboot;
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.apache.camel.itest.springboot.util.DependencyResolver;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsonataTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonpathTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJsonpathTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJsonpathTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJt400Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelJt400Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelJt400Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKafkaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKafkaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelKafkaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKubernetesTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKubernetesTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelKubernetesTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKuduTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelKuduTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelKuduTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdapTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLdapTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdifTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLdifTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLdifTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLeveldbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLeveldbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLeveldbTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLuceneTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLuceneTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLuceneTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLumberjackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLumberjackTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLumberjackTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLzfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelLzfTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelLzfTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMailTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMailTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMailTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMetricsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMetricsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMetricsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMicrometerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMicrometerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMicrometerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMiloTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMiloTest.java
@@ -18,15 +18,15 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@Ignore("Guava classpath hell")
-@RunWith(Arquillian.class)
+@Disabled("Guava classpath hell")
+@ExtendWith(ArquillianExtension.class)
 public class CamelMiloTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMinaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinioTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMinioTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMinioTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMllpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMllpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMllpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMongodbGridfsTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -37,8 +37,6 @@ public class CamelMongodbGridfsTest extends AbstractSpringBootTestSupport {
                 .module(inferModuleName(CamelMongodbGridfsTest.class))
                 .dependency("org.mongodb:mongodb-driver-sync:4.0.4")
                 .dependency("org.mongodb:mongodb-driver-core:4.0.4")
-                .includeTestDependencies(false)
-                .unitTestsEnabled(false)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMongodbTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -37,8 +37,6 @@ public class CamelMongodbTest extends AbstractSpringBootTestSupport {
                 .module(inferModuleName(CamelMongodbTest.class))
                 .dependency("org.mongodb:mongodb-driver-sync:4.0.4")
                 .dependency("org.mongodb:mongodb-driver-core:4.0.4")
-                .includeTestDependencies(false)
-                .unitTestsEnabled(false)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMsvTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMsvTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMsvTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMustacheTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMustacheTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMustacheTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMvelTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMvelTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMvelTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMybatisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMybatisTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelMybatisTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNagiosTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNagiosTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNagiosTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNatsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNatsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNatsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyHttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyHttpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNettyHttpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNettyTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNettyTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNitriteTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNitriteTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNitriteTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,6 +35,7 @@ public class CamelNitriteTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelNitriteTest.class))
+                .ignoreLibraryMismatch("org.objenesis")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNsqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelNsqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelNsqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOgnlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOgnlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOgnlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo2Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOlingo2Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo4Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOlingo4Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOlingo4Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenapiJavaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenapiJavaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOpenapiJavaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenstackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpenstackTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOpenstackTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpentelemetryTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpentelemetryTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOpentelemetryTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpentracingTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOpentracingTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOpentracingTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOptaplannerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelOptaplannerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelOptaplannerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPahoTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPahoTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPahoTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPdfTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPdfTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPdfTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgReplicationSlotTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgReplicationSlotTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPgReplicationSlotTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgeventTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPgeventTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPgeventTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPrinterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPrinterTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPrinterTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelProtobufTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelProtobufTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelProtobufTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPubnubTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPubnubTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPubnubTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPulsarTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelPulsarTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelPulsarTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartzTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuartzTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelQuartzTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuickfixTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelQuickfixTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelQuickfixTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRabbitmqTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRabbitmqTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRabbitmqTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelReactiveStreamsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelReactiveStreamsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelReactiveStreamsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelReactorTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelReactorTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelReactorTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelResilience4jTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelResilience4jTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelResilience4jTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestOpenapiTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestOpenapiTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRestOpenapiTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestSwaggerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRestSwaggerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRestSwaggerTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,8 +35,7 @@ public class CamelRestSwaggerTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelRestSwaggerTest.class))
-                .unitTestsEnabled(false)
-                .includeTestDependencies(false)
+                .includeTestDependencies(true)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelResteasyTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelResteasyTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelResteasyTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRibbonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRibbonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRibbonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRobotframeworkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRobotframeworkTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRobotframeworkTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRssTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelRssTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelRssTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSalesforceTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSalesforceTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.itest.springboot;
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.apache.camel.itest.springboot.util.DependencyResolver;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSalesforceTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -36,10 +36,8 @@ public class CamelSalesforceTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelSalesforceTest.class))
-//                .basePath("../../components/camel-salesforce/camel-salesforce-component")
                 .unitTestExclusionPattern(".*(\\.integration\\..*|IntegrationTest.*|MSPTest$)")
                 .autostart(false) // needs configuration
-                .dependency("org.codehaus.groovy:groovy:" + DependencyResolver.resolveParentProperty("${groovy-version}"))
                 .build();
     }
 
@@ -47,7 +45,7 @@ public class CamelSalesforceTest extends AbstractSpringBootTestSupport {
     public void componentTests() throws Exception {
         this.runComponentTest(config);
         // unit tests is too complex to run
-        // this.runModuleUnitTestsIfEnabled(config);
+        this.runModuleUnitTestsIfEnabled(config);
     }
 
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSapNetweaverTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSapNetweaverTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSapNetweaverTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSaxonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSaxonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSaxonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSchematronTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSchematronTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSchematronTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServicenowTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServicenowTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelServicenowTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelServletTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelServletTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelShiroTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelShiroTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelShiroTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSipTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSipTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSipTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjms2Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjms2Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSjms2Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjmsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSjmsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSjmsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSlackTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSlackTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSlackTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSmppTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSmppTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSmppTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnakeyamlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnakeyamlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSnakeyamlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnmpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSnmpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSnmpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoapTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSoapTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSolrTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSolrTest.java
@@ -18,14 +18,14 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore("Don't run this on CI")
-@RunWith(Arquillian.class)
+@Disabled("Don't run this on CI")
+@ExtendWith(ArquillianExtension.class)
 public class CamelSolrTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoroushTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSoroushTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSoroushTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSparkTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSparkTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -37,6 +37,7 @@ public class CamelSparkTest extends AbstractSpringBootTestSupport {
                 .module(inferModuleName(CamelSparkTest.class))
                 .ignoreLibraryMismatch("org.scala-lang.modules:scala-parser-combinators_2.11")
                 .ignoreLibraryMismatch("org.scala-lang.modules:scala-xml_2.11")
+                .ignoreLibraryMismatch("org.objenesis")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSplunkTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSplunkTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSplunkTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBatchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringBatchTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringBatchTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringIntegrationTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringIntegrationTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringIntegrationTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringJavaconfigTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringJavaconfigTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringJavaconfigTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringLdapTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringLdapTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringLdapTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringRedisTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringRedisTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringRedisTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringSecurityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringSecurityTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringSecurityTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.itest.springboot;
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.apache.camel.itest.springboot.util.DependencyResolver;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringWsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSpringWsTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSpringWsTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSqlTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSqlTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSqlTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSshTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSshTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSshTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStaxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStaxTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelStaxTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStitchTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStitchTest.java
@@ -18,12 +18,12 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelStitchTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStompTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStompTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelStompTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStreamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStreamTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelStreamTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStringtemplateTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelStringtemplateTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelStringtemplateTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerJavaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSwaggerJavaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSwaggerJavaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSyslogTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelSyslogTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelSyslogTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTagsoupTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTagsoupTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTagsoupTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTarfileTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTarfileTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTarfileTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTelegramTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTelegramTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTelegramTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelThriftTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelThriftTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelThriftTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTikaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTikaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTikaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwilioTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwilioTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTwilioTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwitterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelTwitterTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelTwitterTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUndertowTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUndertowTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelUndertowTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelUnivocityParsersTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVelocityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVelocityTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelVelocityTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxHttpTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxHttpTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelVertxHttpTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxKafkaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxKafkaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelVertxKafkaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelVertxTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxWebsocketTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelVertxWebsocketTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelVertxWebsocketTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeatherTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeatherTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWeatherTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeb3jTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWeb3jTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWeb3jTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebhookTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebhookTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWebhookTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketJsr356Test.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketJsr356Test.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWebsocketJsr356Test extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebsocketTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWebsocketTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWekaTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWekaTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWekaTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWordpressTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWordpressTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWordpressTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWorkdayTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWorkdayTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelWorkdayTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXchangeTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXchangeTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXchangeTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXjTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXjTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXjTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlsecurityTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmlsecurityTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXmlsecurityTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmppTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXmppTest.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXmppTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXsltSaxonTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXsltSaxonTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXsltSaxonTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXstreamTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelXstreamTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelXstreamTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelYammerTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelYammerTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelYammerTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZendeskTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZendeskTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelZendeskTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipfileTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipfileTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelZipfileTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZipkinTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelZipkinTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperMasterTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperMasterTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelZookeeperMasterTest extends AbstractSpringBootTestSupport {
 
     @Deployment

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelZookeeperTest.java
@@ -18,13 +18,13 @@ package org.apache.camel.itest.springboot;
 
 import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CamelZookeeperTest extends AbstractSpringBootTestSupport {
 
     @Deployment
@@ -35,8 +35,6 @@ public class CamelZookeeperTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelZookeeperTest.class))
-                .includeTestDependencies(false)
-                .unitTestsEnabled(false)
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/container/ManagedSEDeployableContainer.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/arquillian/container/ManagedSEDeployableContainer.java
@@ -112,10 +112,17 @@ public class ManagedSEDeployableContainer implements DeployableContainer<Managed
     }
 
     private void configureLogging(ManagedSEContainerConfiguration configuration) {
-        ConsoleHandler consoleHandler = new ConsoleHandler();
-        consoleHandler.setLevel(configuration.getLogLevel());
-        LOGGER.setUseParentHandlers(false);
-        LOGGER.addHandler(consoleHandler);
+        final String loggingConfigFile = System.getProperty("java.util.logging.config.file");
+        if (loggingConfigFile==null) {
+          ConsoleHandler consoleHandler = new ConsoleHandler();
+          consoleHandler.setLevel(configuration.getLogLevel());
+          LOGGER.setUseParentHandlers(false);
+          LOGGER.addHandler(consoleHandler);
+          LOGGER.info("No logging configured, using console");
+        } else {
+            // suppose that logging has been configured using the specified file 
+            LOGGER.info("Logging configured using file " + loggingConfigFile);
+        }
         LOGGER.setLevel(configuration.getLogLevel());
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/JarExporter.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/util/JarExporter.java
@@ -21,7 +21,7 @@ import java.io.File;
 import org.apache.camel.itest.springboot.ITestConfigBuilder;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Utility to export a spring-boot jar and check the content.

--- a/tests/camel-itest-spring-boot/src/test/resources/application-pom-sb2.xml
+++ b/tests/camel-itest-spring-boot/src/test/resources/application-pom-sb2.xml
@@ -63,10 +63,17 @@
             <artifactId>#{module}-starter</artifactId>
         </dependency>
 
-        <!-- Required by the integration tests to run -->
+	 <!-- Required by the integration tests to run in Junit5 -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+        	<groupId>org.junit.jupiter</groupId>
+        	<artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--  Required for UnitTestCommand -->
+        <dependency>
+        	<groupId>org.junit.platform</groupId>
+        	<artifactId>junit-platform-launcher</artifactId>
+             <scope>test</scope>
         </dependency>
 
         <!-- DEPENDENCIES -->
@@ -88,7 +95,7 @@
         <repository>
             <id>apache-snapshots</id>
             <name>Apache Snapshots</name>
-            <url>http://repository.apache.org/snapshots/</url>
+            <url>https://repository.apache.org/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/tests/camel-itest-spring-boot/src/test/resources/arquillian.xml
+++ b/tests/camel-itest-spring-boot/src/test/resources/arquillian.xml
@@ -27,6 +27,8 @@
             <property name="debug">false</property>
 
             <property name="librariesPath">${user.dir}/target</property>
+            <!--  Avoid exceptions during Spring shutdown after container undeploy. -->
+            <property name="keepDeploymentArchives">true</property>
         </configuration>
 
     </container>

--- a/tests/camel-itest-spring-boot/src/test/resources/jul.properties
+++ b/tests/camel-itest-spring-boot/src/test/resources/jul.properties
@@ -1,0 +1,72 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+#handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= java.util.logging.FileHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = target/jul.log
+java.util.logging.FileHandler.limit = 5000000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+#java.util.logging.ConsoleHandler.level = FINEST
+#java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+org.apache.camel.itest.level = FINE
+

--- a/tests/camel-itest-spring-boot/src/test/resources/logback-spring.xml
+++ b/tests/camel-itest-spring-boot/src/test/resources/logback-spring.xml
@@ -20,20 +20,25 @@
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
+      	<encoder>
+      		<pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    	</encoder>
+  </appender>
+  
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+    <file>target/camel-spring-boot-itest.log</file>
   </appender>
 
   <logger name="org.apache.camel.component" level="info"
           additivity="false">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE"/>
   </logger>
 
   <root level="info">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE"/>
   </root>
 
 </configuration>

--- a/tests/camel-itest-spring-boot/src/test/resources/logging.properties
+++ b/tests/camel-itest-spring-boot/src/test/resources/logging.properties
@@ -1,0 +1,74 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+#handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= java.util.logging.FileHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+java.util.logging.SimpleFormatter.format=%1$tc %4$s %2$s : %5$s%n
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = target/test.log
+java.util.logging.FileHandler.limit = 5000000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+#java.util.logging.ConsoleHandler.level = FINEST
+#java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+org.apache.camel.itest.level = FINE
+


### PR DESCRIPTION
This required upgrading the Arquillian Junit extension to 1.7.0.Alpha10
which is not yet officially released but appears to be stable.
Remove the usage of a surefire plugin version 2.19 which did not support JUnit5.
Modified the UnitTestCommand to use the JUnit5 launcher and listener architecture.
Enable the unit tests and make minor modifications to ArquillianPackager, ITestApplication
and various test cases to ensure that they all function.
Modify the handling of the logging to avoid the Arquillian container logging to the console
since this causes the current surefire to report an error.
Configure Arquillian to retain the deployment artifacts to avoid classpath exceptions
in the shutdown handlers when the container undeploys the test jar.
Remove non-existent Customizer classes in camel-hazelcast-starter/spring.factories which caused the integration test to fail.