### PR TITLE
Camel spring boot 3.12.x local build v2

### DIFF
--- a/docs/README_local_build.adoc
+++ b/docs/README_local_build.adoc
@@ -1,0 +1,22 @@
+= Local/partial build of docs
+
+See https://camel.apache.org/manual/improving-the-documentation.html for initial setup instructions and more details.
+
+After initial setup, there are three local build options:
+
+== Quick: `./local-build.sh quick`
+
+This will build this project only.
+Links out of this component will go to the published Camel website, and there will be no links back.
+This is primarily intended to check for errors.
+
+== Full: `./local-build.sh full`
+
+This will build the full site locally, with your changes in this project.
+Running this (at least) once is a prerequisite for the partial build.
+This should show the site exactly as it would be should your changes be merged.
+
+== Partial: `./local-build.sh`
+
+This will build this project only, replacing this component in the locally built "full" build, and start a local server to view with, rebuild the project when file changes are detected, and sync your browser with the rebuilt site.
+This is intended for documentation development.

--- a/docs/local-build.sh
+++ b/docs/local-build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CW=./../../camel-website
+LOCAL=./../camel-spring-boot
+
+cd $CW || (echo 'camel-website not in expected location $CW' && exit)
+./antora-local-build.sh $LOCAL $*

--- a/docs/source-map.yml
+++ b/docs/source-map.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-map'
+#      log_level: trace
+      source_map:
+        - url: 'https://github.com/apache/camel-spring-boot.git'
+          mapped_url: './../camel-spring-boot'
+          branches:
+            - branch: camel-spring-boot-3.12.x
+              mapped_branch: HEAD

--- a/docs/source-watch.yml
+++ b/docs/source-watch.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-watch'
+#      log_level: trace
+      sources:
+        - url: ./../camel-spring-boot
+
+        - url: https://github.com/apache/camel.git
+          branch_includes: camel-3.12.x
+          start_path_includes: core/camel-core-engine/src/main/docs,docs/components


### PR DESCRIPTION
Sets up new docs local-build for camel-spring-boot 3.12.x. See apache/camel-website#731