### PR TITLE
CAMEL-17884 Guava is overriden to an older version in bigquery starter

### DIFF
--- a/components-starter/camel-google-bigquery-starter/pom.xml
+++ b/components-starter/camel-google-bigquery-starter/pom.xml
@@ -35,6 +35,11 @@
       <version>${spring-boot-version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${google-cloud-guava-version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-google-bigquery</artifactId>
       <version>${camel-version}</version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-17884