### PR TITLE
CAMEL-17964: Fix the link to the doc page main.adoc

### DIFF
--- a/core/camel-spring-boot/src/main/docs/starter-configuration.adoc
+++ b/core/camel-spring-boot/src/main/docs/starter-configuration.adoc
@@ -42,7 +42,7 @@ public JmsTransactionManager myjtaTransactionManager(PooledConnectionFactory poo
 }
 ----
 
-Beans can also be created in xref:others:main.adoc#_specifying_custom_beans[configuration files] but it isn't recommended for complex use cases.
+Beans can also be created in xref:components:others:main.adoc#_specifying_custom_beans[configuration files] but it isn't recommended for complex use cases.
 
 == Using Beans
 


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17964 (part 2)

## Motivation

The build of the [website fails](https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/827/console) due to an incorrect link [even with the latest fix ](https://github.com/apache/camel-spring-boot/commit/73338c94297f1b0d5137b946874290e2f1f3549c)

## Modifications:

* Add missing sub section components to the link