### PR TITLE
Use commons-lang for aws2-sqs-starter

### DIFF
--- a/components-starter/camel-aws2-sqs-starter/pom.xml
+++ b/components-starter/camel-aws2-sqs-starter/pom.xml
@@ -48,6 +48,11 @@
       <!--END OF GENERATED CODE-->
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang-version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-infra-aws-v2</artifactId>
       <version>${camel-version}</version>

--- a/components-starter/camel-aws2-sqs-starter/pom.xml
+++ b/components-starter/camel-aws2-sqs-starter/pom.xml
@@ -48,9 +48,10 @@
       <!--END OF GENERATED CODE-->
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>${commons-lang-version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3-version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsOperationsTest.java
+++ b/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsOperationsTest.java
@@ -32,7 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;

--- a/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsOperationsTest.java
+++ b/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsOperationsTest.java
@@ -32,7 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.RandomStringUtils;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;


### PR DESCRIPTION
Was getting a class not found error on org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils - replace with commons-lang version and add in commons-lang dependency