### PR TITLE
chore: Fix integration test failure by not running test by default

### DIFF
--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAsyncManualCommitIT.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAsyncManualCommitIT.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -50,6 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
                 KafkaConsumerAsyncManualCommitIT.TestConfiguration.class,
         }
 )
+@EnabledIfSystemProperty(named = "enable.kafka.consumer.async", matches = "true",
+                         disabledReason = "Temporarily disabled due to being flaky")
 public class KafkaConsumerAsyncManualCommitIT extends BaseEmbeddedKafkaTestSupport {
 
     public static final String TOPIC = "testManualCommitTest";


### PR DESCRIPTION
Test was annotated out here in camel --

https://github.com/apache/camel/commit/2589086ba6a76083ffc95790621277f45078e7a2

Test is also failing in camel-spring-boot - annotating it out