### PR TITLE
CAMEL-17987 Temporarily disable CamelWebhookTest (log4j-slf4j-impl cannot be present with log4j-to-slf4j)

### DIFF
--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebhookTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelWebhookTest.java
@@ -21,10 +21,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 
 @ExtendWith(ArquillianExtension.class)
+@Disabled
 public class CamelWebhookTest extends AbstractSpringBootTestSupport {
 
     @Deployment


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-17987

Temporarily disable CamelWebhookTest - throwing a log4j-slf4j-impl cannot be present with log4j-to-slf4j error - I think it needs some exclusions or other configuration in createTestConfig() - not sure why this is the only Spring Boot test exhibiting this error