### PR TITLE
Archive surefire logs to try to diagnose integration test failures

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -46,3 +46,12 @@ jobs:
       with:
         name: build.log
         path: build.log
+    - name: Archive Surefire Logs
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: integration-test-surefire-logs
+        path: |
+          tests/camel-itest-spring-boot/target/surefire-reports
+          tests/camel-spring-boot-integration-tests/infinispan/target/surefire-reports
+        retention-days: 2 


### PR DESCRIPTION
We're getting failures in some of the integration tests but the build.log stored by the PR job does not have a lot of detail to go on -

Example, from CamelSqlTest failure in one of the recent PR build runs -
```
[ERROR] org.apache.camel.itest.springboot.CamelSqlTest.componentTests  Time elapsed: 25.465 s  <<< ERROR!
java.lang.Exception: 
Caused by: org.opentest4j.AssertionFailedError: Some unit tests failed (1/25), check the logs for more details
```

I'd like to temporarily start archiving the surefire logs to see if we could diagnose the failures - I'm not sure whether this is going to give us additional information or not.    I haven't been able to reproduce these failures locally.     

I think we can expire the logs pretty quickly so that they don't take up a lot of space.