### PR TITLE
Set pom type to parent deps

### DIFF
--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -1981,6 +1981,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2041,6 +2042,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2056,6 +2058,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2181,6 +2184,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2256,6 +2260,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2496,6 +2501,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,6 +2532,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2666,6 +2673,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2746,6 +2754,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2866,6 +2875,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huawei-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2941,6 +2951,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3301,6 +3312,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3396,6 +3408,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo2-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3411,6 +3424,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3611,6 +3625,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3656,6 +3671,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3871,6 +3887,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3991,6 +4008,7 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-parent</artifactId>
         <version>3.17.0-SNAPSHOT</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
@@ -174,6 +174,10 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
                             && dep.getArtifactId().endsWith("-starter"));
             getLog().debug(dep + (accept ? " included in the BOM" : " excluded from BOM"));
 
+            if (dep.getArtifactId().startsWith("camel-") && dep.getArtifactId().endsWith("-parent")) {
+                dep.setType("pom");
+            }
+
             // skip test-jars
             boolean testJar = dep.getType() != null && dep.getType().equals("test-jar");
             boolean sourcesJar = dep.getClassifier() != null && dep.getClassifier().equals("sources");


### PR DESCRIPTION
Set correct type to camel-*-parent flattened dependencies.

@cunningt 

@davsclaus @oscerd Hello, I remember some discussions around camel-spring-boot-dependencies bom deprecation, do you still think that camel-spring-boot-bom should be used instead of -dependencies?