### PR TITLE
Remove camel-test-junit5 - components-starter already brings in camel-spring-test-junit5

### DIFF
--- a/components-starter/camel-master-starter/pom.xml
+++ b/components-starter/camel-master-starter/pom.xml
@@ -41,12 +41,6 @@
     </dependency>
     <!-- test dependencies -->
     <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test-junit5</artifactId>
-      <version>${camel-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/components-starter/camel-telegram-starter/pom.xml
+++ b/components-starter/camel-telegram-starter/pom.xml
@@ -51,12 +51,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test-junit5</artifactId>
-      <version>${camel-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-health</artifactId>
       <version>${camel-version}</version>
       <scope>test</scope>

--- a/components-starter/camel-webhook-starter/pom.xml
+++ b/components-starter/camel-webhook-starter/pom.xml
@@ -41,12 +41,6 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test-junit5</artifactId>
-      <version>${camel-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
I think we can remove the references to camel-test-junit5 in the few components that bring it in.     components-starter brings in camel-spring-test-junit5 already, which all of the components starters inherit from.

Ran the tests on these components, saw no errors.