### PR TITLE
Remove unused imports, simplify asserts

### DIFF
--- a/components-starter/camel-aws2-sns-starter/src/test/java/org/apache/camel/component/aws2/sns/SnsComponentFifoTest.java
+++ b/components-starter/camel-aws2-sns-starter/src/test/java/org/apache/camel/component/aws2/sns/SnsComponentFifoTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperties;

--- a/components-starter/camel-aws2-sns-starter/src/test/java/org/apache/camel/component/aws2/sns/SnsTopicWithKmsEncryptionTest.java
+++ b/components-starter/camel-aws2-sns-starter/src/test/java/org/apache/camel/component/aws2/sns/SnsTopicWithKmsEncryptionTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperties;

--- a/components-starter/camel-bean-validator-starter/src/test/java/org/apache/camel/component/bean/validator/springboot/BeanValidatorRouteTest.java
+++ b/components-starter/camel-bean-validator-starter/src/test/java/org/apache/camel/component/bean/validator/springboot/BeanValidatorRouteTest.java
@@ -16,19 +16,12 @@
  */
 package org.apache.camel.component.bean.validator.springboot;
 
-
-
-
-
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.validation.ConstraintViolation;
-
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
@@ -50,6 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -131,7 +125,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();
@@ -166,7 +160,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();
@@ -201,7 +195,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();
@@ -236,7 +230,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();
@@ -255,7 +249,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();
@@ -306,7 +300,7 @@ public class BeanValidatorRouteTest {
             template.requestBody(url, cars);
             fail("should throw exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(BeanValidationException.class, e.getCause());
+            assertInstanceOf(BeanValidationException.class, e.getCause());
 
             BeanValidationException exception = (BeanValidationException) e.getCause();
             Set<ConstraintViolation<Object>> constraintViolations = exception.getConstraintViolations();

--- a/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallBadIntegerTest.java
+++ b/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallBadIntegerTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.dataformat.bindy.springboot.csv;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -30,6 +27,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -102,7 +100,7 @@ public class BindySimpleCsvUnmarshallBadIntegerTest {
 
         // and check that we have the caused exception stored
         Exception cause = error.getReceivedExchanges().get(0).getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        assertIsInstanceOf(Exception.class, cause.getCause());
+        assertInstanceOf(Exception.class, cause.getCause());
         assertEquals("Parsing error detected for field defined at the position: 1, line: 1", cause.getMessage());
 
     }

--- a/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallPositionModifiedTest.java
+++ b/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallPositionModifiedTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.dataformat.bindy.springboot.csv;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -31,6 +28,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -96,7 +94,7 @@ public class BindySimpleCsvUnmarshallPositionModifiedTest {
 
         // and check that we have the caused exception stored
         Exception cause = error.getReceivedExchanges().get(0).getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        assertIsInstanceOf(FormatException.class, cause.getCause());
+        assertInstanceOf(FormatException.class, cause.getCause());
         assertEquals("Date provided does not fit the pattern defined, position: 11, line: 1", cause.getMessage());
 
     }

--- a/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallTest.java
+++ b/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/csv/BindySimpleCsvUnmarshallTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.dataformat.bindy.springboot.csv;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
 import java.util.List;
 
 import org.apache.camel.EndpointInject;
@@ -34,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -114,7 +113,7 @@ public class BindySimpleCsvUnmarshallTest {
 
         // and check that we have the caused exception stored
         Exception cause = error.getReceivedExchanges().get(0).getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        assertIsInstanceOf(FormatException.class, cause.getCause());
+        assertInstanceOf(FormatException.class, cause.getCause());
         assertEquals("Date provided does not fit the pattern defined, position: 11, line: 1", cause.getMessage());
 
     }

--- a/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/fixed/BindySimpleFixedLengthMarshallWithNoClipTest.java
+++ b/components-starter/camel-bindy-starter/src/test/java/org/apache/camel/dataformat/bindy/springboot/fixed/BindySimpleFixedLengthMarshallWithNoClipTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.dataformat.bindy.springboot.fixed;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -37,6 +35,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,7 +68,7 @@ public class BindySimpleFixedLengthMarshallWithNoClipTest {
         Exception ex = assertThrows(CamelExecutionException.class,
                 () -> template.sendBody("direct:start", model));
 
-        IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, ex.getCause());
+        IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, ex.getCause());
         assertEquals("Length for the firstName must not be larger than allowed, was: 13, allowed: 9",
                 cause.getMessage());
     }

--- a/components-starter/camel-cassandraql-starter/src/test/java/org/apache/camel/component/cassandra/integration/CassandraComponentProducerIT.java
+++ b/components-starter/camel-cassandraql-starter/src/test/java/org/apache/camel/component/cassandra/integration/CassandraComponentProducerIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.cassandra.integration;
 
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,6 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
@@ -101,7 +101,7 @@ public class CassandraComponentProducerIT extends BaseCassandra {
         Object response = noParameterProducerTemplate.requestBody(null);
 
         assertNotNull(response);
-        assertIsInstanceOf(List.class, response);
+        assertInstanceOf(List.class, response);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class CassandraComponentProducerIT extends BaseCassandra {
         Object response = noParameterProducerTemplate.requestBody(Collections.emptyList());
 
         assertNotNull(response);
-        assertIsInstanceOf(List.class, response);
+        assertInstanceOf(List.class, response);
     }
 
     @Test

--- a/components-starter/camel-cassandraql-starter/src/test/java/org/apache/camel/component/cassandra/integration/CassandraComponentProducerUnpreparedIT.java
+++ b/components-starter/camel-cassandraql-starter/src/test/java/org/apache/camel/component/cassandra/integration/CassandraComponentProducerUnpreparedIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.cassandra.integration;
 
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,6 +37,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -88,7 +88,7 @@ public class CassandraComponentProducerUnpreparedIT extends BaseCassandra {
         Object response = noParameterProducerTemplate.requestBody(null);
 
         assertNotNull(response);
-        assertIsInstanceOf(List.class, response);
+        assertInstanceOf(List.class, response);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class CassandraComponentProducerUnpreparedIT extends BaseCassandra {
         Object response = noParameterProducerTemplate.requestBody(null);
 
         assertNotNull(response);
-        assertIsInstanceOf(List.class, response);
+        assertInstanceOf(List.class, response);
     }
 
     @Test

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonConcurrentTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonConcurrentTest.java
@@ -16,21 +16,18 @@
  */
 package org.apache.camel.component.gson.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -72,7 +69,7 @@ public class GsonConcurrentTest {
     private void doSendMessages(int files, int poolSize) throws Exception {
         mock.reset();
         mock.expectedMessageCount(files);
-        mock.assertNoDuplicates(body());
+        mock.assertNoDuplicates(Builder.body());
 
         ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         for (int i = 0; i < files; i++) {

--- a/components-starter/camel-hl7-starter/src/test/java/org/apache/camel/component/hl7/springboot/test/HL7ValidateTest.java
+++ b/components-starter/camel-hl7-starter/src/test/java/org/apache/camel/component/hl7/springboot/test/HL7ValidateTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.camel.component.hl7.springboot.test;
 
-
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-
-
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
@@ -29,6 +25,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -90,8 +87,8 @@ public class HL7ValidateTest extends HL7TestSupport {
             template.sendBody("direct:unmarshalFailed", body);
             fail("Should have thrown exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(HL7Exception.class, e.getCause());
-            assertIsInstanceOf(DataTypeException.class, e.getCause());
+            assertInstanceOf(HL7Exception.class, e.getCause());
+            assertInstanceOf(DataTypeException.class, e.getCause());
             assertTrue(e.getCause().getMessage().startsWith("ca.uhn.hl7v2.validation.ValidationException: Validation failed:"),
                     "Should be a validation error message");
         }
@@ -130,8 +127,8 @@ public class HL7ValidateTest extends HL7TestSupport {
             template.sendBody("direct:start1", message);
             fail("Should have thrown exception");
         } catch (CamelExecutionException e) {
-            assertIsInstanceOf(HL7Exception.class, e.getCause());
-            assertIsInstanceOf(ValidationException.class, e.getCause().getCause());
+            assertInstanceOf(HL7Exception.class, e.getCause());
+            assertInstanceOf(ValidationException.class, e.getCause().getCause());
             System.out.println(e.getCause().getCause().getMessage());
             assertTrue(e.getCause().getCause().getMessage().startsWith("Validation failed:"),
                     "Should be a validation error message");

--- a/components-starter/camel-jackson-starter/src/test/java/org/apache/camel/component/jackson/springboot/test/JacksonConcurrentTest.java
+++ b/components-starter/camel-jackson-starter/src/test/java/org/apache/camel/component/jackson/springboot/test/JacksonConcurrentTest.java
@@ -16,18 +16,15 @@
  */
 package org.apache.camel.component.jackson.springboot.test;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.dataformat.JsonLibrary;
@@ -36,15 +33,12 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.Test;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-
-
 
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @CamelSpringBootTest
@@ -81,7 +75,7 @@ public class JacksonConcurrentTest {
 
     private void doSendMessages(int files, int poolSize) throws Exception {
         mock.expectedMessageCount(files);
-        mock.assertNoDuplicates(body());
+        mock.assertNoDuplicates(Builder.body());
 
         ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         for (int i = 0; i < files; i++) {

--- a/components-starter/camel-jackson-starter/src/test/java/org/apache/camel/component/jackson/springboot/test/JacksonObjectListSplitTest.java
+++ b/components-starter/camel-jackson-starter/src/test/java/org/apache/camel/component/jackson/springboot/test/JacksonObjectListSplitTest.java
@@ -16,12 +16,9 @@
  */
 package org.apache.camel.component.jackson.springboot.test;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -61,7 +58,7 @@ public class JacksonObjectListSplitTest {
     @Test
     public void testJackson() throws InterruptedException {
         mock.expectedMessageCount(2);
-        mock.expectedMessagesMatches(body().isInstanceOf(DummyObject.class));
+        mock.expectedMessagesMatches(Builder.body().isInstanceOf(DummyObject.class));
 
         template.sendBody("direct:start", "[{\"dummy\": \"value1\"}, {\"dummy\": \"value2\"}]");
 

--- a/components-starter/camel-jacksonxml-starter/src/test/java/org/apache/camel/component/jacksonxml/springboot/JacksonConcurrentTest.java
+++ b/components-starter/camel-jacksonxml-starter/src/test/java/org/apache/camel/component/jacksonxml/springboot/JacksonConcurrentTest.java
@@ -16,18 +16,15 @@
  */
 package org.apache.camel.component.jacksonxml.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
@@ -80,7 +77,7 @@ public class JacksonConcurrentTest {
 
     private void doSendMessages(int files, int poolSize) throws Exception {
         mock.expectedMessageCount(files);
-        mock.assertNoDuplicates(body());
+        mock.assertNoDuplicates(Builder.body());
 
         ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         for (int i = 0; i < files; i++) {

--- a/components-starter/camel-jacksonxml-starter/src/test/java/org/apache/camel/component/jacksonxml/springboot/JacksonObjectListSplitTest.java
+++ b/components-starter/camel-jacksonxml-starter/src/test/java/org/apache/camel/component/jacksonxml/springboot/JacksonObjectListSplitTest.java
@@ -16,12 +16,9 @@
  */
 package org.apache.camel.component.jacksonxml.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jacksonxml.JacksonXMLDataFormat;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -61,7 +58,7 @@ public class JacksonObjectListSplitTest {
     @Test
     public void testJackson() throws InterruptedException {
         mock.expectedMessageCount(2);
-        mock.expectedMessagesMatches(body().isInstanceOf(DummyObject.class));
+        mock.expectedMessagesMatches(Builder.body().isInstanceOf(DummyObject.class));
 
         template.sendBody("direct:start", "<list><pojo dummy=\"value1\"/><pojo dummy=\"value2\"/></list>");
 

--- a/components-starter/camel-jaxb-starter/src/test/java/org/apache/camel/converter/jaxb/springboot/JaxbConcurrentDataFormatTest.java
+++ b/components-starter/camel-jaxb-starter/src/test/java/org/apache/camel/converter/jaxb/springboot/JaxbConcurrentDataFormatTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.converter.jaxb.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +23,7 @@ import java.util.concurrent.Executors;
 
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.jaxb.JaxbDataFormat;
@@ -33,7 +31,6 @@ import org.apache.camel.example.PurchaseOrder;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -77,7 +74,7 @@ public class JaxbConcurrentDataFormatTest {
     private void doSendMessages(int files, int poolSize) throws Exception {
         result.reset();
         result.expectedMessageCount(files);
-        result.assertNoDuplicates(body());
+        result.assertNoDuplicates(Builder.body());
 
         ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         for (int i = 0; i < files; i++) {

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueLinkProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueLinkProducerTest.java
@@ -25,8 +25,6 @@ import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithLinks;
 import static org.apache.camel.component.jira.springboot.test.Utils.newIssueLink;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.apache.camel.test.junit5.TestSupport.assertStringContains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -61,8 +59,9 @@ import org.mockito.stubbing.Answer;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -192,8 +191,8 @@ public class AddIssueLinkProducerTest {
             template.sendBodyAndHeaders(comment, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), PARENT_ISSUE_KEY);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(PARENT_ISSUE_KEY));
         }
 
         mockResult.expectedMessageCount(0);
@@ -214,8 +213,8 @@ public class AddIssueLinkProducerTest {
             template.sendBodyAndHeaders(comment, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), CHILD_ISSUE_KEY);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(CHILD_ISSUE_KEY));
         }
 
         mockResult.expectedMessageCount(0);
@@ -235,8 +234,8 @@ public class AddIssueLinkProducerTest {
             template.sendBodyAndHeaders(comment, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), LINK_TYPE);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(LINK_TYPE));
         }
 
         mockResult.expectedMessageCount(0);

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddWorkLogProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddWorkLogProducerTest.java
@@ -23,8 +23,6 @@ import static org.apache.camel.component.jira.JiraConstants.MINUTES_SPENT;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithComments;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithWorkLogs;
 import static org.apache.camel.component.jira.springboot.test.Utils.newWorkLog;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.apache.camel.test.junit5.TestSupport.assertStringContains;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -62,6 +60,8 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.atlassian.util.concurrent.Promises;
 
@@ -168,8 +168,8 @@ public class AddWorkLogProducerTest {
             template.sendBodyAndHeaders(comment, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), ISSUE_KEY);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(ISSUE_KEY));
         }
         mockResult.reset();
         mockResult.expectedMessageCount(0);
@@ -190,8 +190,8 @@ public class AddWorkLogProducerTest {
             template.sendBodyAndHeaders(comment, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), MINUTES_SPENT);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(MINUTES_SPENT));
         }
         
         mockResult.reset();
@@ -213,8 +213,8 @@ public class AddWorkLogProducerTest {
             template.sendBodyAndHeaders(null, headers);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), "Missing exchange body");
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains("Missing exchange body"));
         }
         mockResult.reset();
         mockResult.expectedMessageCount(0);

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchCommentsProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchCommentsProducerTest.java
@@ -20,8 +20,6 @@ package org.apache.camel.component.jira.springboot.test;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.apache.camel.test.junit5.TestSupport.assertStringContains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -48,7 +46,9 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import io.atlassian.util.concurrent.Promises;
 
@@ -139,8 +139,8 @@ public class FetchCommentsProducerTest {
             template.sendBody(null);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), ISSUE_KEY);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(ISSUE_KEY));
         }
 
         mockResult.expectedMessageCount(0);

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchIssueProducerTest.java
@@ -19,8 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.apache.camel.test.junit5.TestSupport.assertStringContains;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -48,7 +46,9 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import io.atlassian.util.concurrent.Promises;
 
@@ -137,8 +137,8 @@ public class FetchIssueProducerTest {
             template.sendBody(null);
             fail("Should have thrown an exception");
         } catch (CamelExecutionException e) {
-            IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
-            assertStringContains(cause.getMessage(), ISSUE_KEY);
+            IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, e.getCause());
+            assertTrue(cause.getMessage().contains(ISSUE_KEY));
         }
 
         mockResult.expectedMessageCount(0);

--- a/components-starter/camel-quartz-starter/src/test/java/org/apache/camel/component/quartz/springboot/QuartzManagementTest.java
+++ b/components-starter/camel-quartz-starter/src/test/java/org/apache/camel/component/quartz/springboot/QuartzManagementTest.java
@@ -16,10 +16,7 @@
  */
 package org.apache.camel.component.quartz.springboot;
 
-
-
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
-
+import java.util.Locale;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -42,7 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -68,7 +64,8 @@ public class QuartzManagementTest extends BaseQuartzTest {
     @Test
     public void testQuartzRoute() throws Exception {
         // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
+        String osName = System.getProperty("os.name").toLowerCase(Locale.US);
+        assumeFalse(osName.contains("aix".toLowerCase(Locale.US)));
 
         mock.expectedMessageCount(2);
 

--- a/components-starter/camel-saxon-starter/src/test/java/org/apache/camel/language/xquery/springboot/XQueryConcurrencyTest.java
+++ b/components-starter/camel-saxon-starter/src/test/java/org/apache/camel/language/xquery/springboot/XQueryConcurrencyTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.camel.language.xquery.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.body;
-
 import java.security.SecureRandom;
 
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,9 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import org.junit.jupiter.api.Test;
 
-
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -88,7 +83,7 @@ public class XQueryConcurrencyTest {
             });
         }
 
-        mock.assertNoDuplicates(body());
+        mock.assertNoDuplicates(Builder.body());
 
         mock.assertIsSatisfied();
         executor.shutdown();

--- a/components-starter/camel-saxon-starter/src/test/java/org/apache/camel/language/xquery/springboot/XQueryURLBasedConcurrencyTest.java
+++ b/components-starter/camel-saxon-starter/src/test/java/org/apache/camel/language/xquery/springboot/XQueryURLBasedConcurrencyTest.java
@@ -16,14 +16,12 @@
  */
 package org.apache.camel.language.xquery.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.bodyAs;
-
 import java.security.SecureRandom;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
@@ -37,7 +35,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 
 import org.junit.jupiter.api.Test;
-
 
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
@@ -99,7 +96,7 @@ public class XQueryURLBasedConcurrencyTest {
         mock.assertIsSatisfied();
         // must use bodyAs(String.class) to force DOM to be converted to String XML
         // for duplication detection
-        mock.assertNoDuplicates(bodyAs(String.class));
+        mock.assertNoDuplicates(Builder.bodyAs(String.class));
         executor.shutdown();
     }
     

--- a/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlProducerExpressionParameterTest.java
+++ b/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlProducerExpressionParameterTest.java
@@ -33,7 +33,7 @@ import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -59,11 +59,11 @@ public class SqlProducerExpressionParameterTest extends BaseSql {
 
         result.assertIsSatisfied();
 
-        List<?> received = assertIsInstanceOf(List.class, result.getReceivedExchanges().get(0).getIn().getBody());
+        List<?> received = assertInstanceOf(List.class, result.getReceivedExchanges().get(0).getIn().getBody());
         assertEquals(2, received.size());
-        Map<?, ?> row = assertIsInstanceOf(Map.class, received.get(0));
+        Map<?, ?> row = assertInstanceOf(Map.class, received.get(0));
         assertEquals("Camel", row.get("PROJECT"));
-        row = assertIsInstanceOf(Map.class, received.get(1));
+        row = assertInstanceOf(Map.class, received.get(1));
         assertEquals("AMQ", row.get("PROJECT"));
     }
 

--- a/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlProducerUseMessageBodyForSqlTest.java
+++ b/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlProducerUseMessageBodyForSqlTest.java
@@ -34,8 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @CamelSpringBootTest
@@ -68,12 +68,12 @@ public class SqlProducerUseMessageBodyForSqlTest extends BaseSql {
 
         template.sendBodyAndHeader("direct:start", null, "lic", "ASF");
 
-        List<?> received = assertIsInstanceOf(List.class, resultEndpoint.getReceivedExchanges().get(0).getIn().getBody());
+        List<?> received = assertInstanceOf(List.class, resultEndpoint.getReceivedExchanges().get(0).getIn().getBody());
         assertEquals(2, received.size());
-        Map<?, ?> row = assertIsInstanceOf(Map.class, received.get(0));
+        Map<?, ?> row = assertInstanceOf(Map.class, received.get(0));
         assertEquals("Camel", row.get("PROJECT"));
 
-        row = assertIsInstanceOf(Map.class, received.get(1));
+        row = assertInstanceOf(Map.class, received.get(1));
         assertEquals("AMQ", row.get("PROJECT"));
     }
 
@@ -97,7 +97,7 @@ public class SqlProducerUseMessageBodyForSqlTest extends BaseSql {
         rows.add(row);
         template.sendBodyAndHeader("direct:insert", null, SqlConstants.SQL_PARAMETERS, rows);
 
-        String origSql = assertIsInstanceOf(String.class, resultInsertEndpoint.getReceivedExchanges().get(0).getIn().getBody());
+        String origSql = assertInstanceOf(String.class, resultInsertEndpoint.getReceivedExchanges().get(0).getIn().getBody());
         assertEquals("insert into projects(id, project, license) values(:?id,:?project,:?lic)", origSql);
 
         assertEquals(null, resultInsertEndpoint.getReceivedExchanges().get(0).getOut().getBody());
@@ -110,12 +110,12 @@ public class SqlProducerUseMessageBodyForSqlTest extends BaseSql {
 
         template.sendBodyAndHeader("direct:start", null, "lic", "OPEN1");
 
-        List<?> received = assertIsInstanceOf(List.class, resultEndpoint.getReceivedExchanges().get(0).getIn().getBody());
+        List<?> received = assertInstanceOf(List.class, resultEndpoint.getReceivedExchanges().get(0).getIn().getBody());
         assertEquals(2, received.size());
-        row = assertIsInstanceOf(Map.class, received.get(0));
+        row = assertInstanceOf(Map.class, received.get(0));
         assertEquals("MyProject1", row.get("PROJECT"));
 
-        row = assertIsInstanceOf(Map.class, received.get(1));
+        row = assertInstanceOf(Map.class, received.get(1));
         assertEquals("MyProject2", row.get("PROJECT"));
     }
 

--- a/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlTransactedRouteTest.java
+++ b/components-starter/camel-sql-starter/src/test/java/org/apache/camel/component/sql/SqlTransactedRouteTest.java
@@ -23,7 +23,6 @@ import org.apache.camel.spi.Registry;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.apache.camel.support.SimpleRegistry;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramChatBotTest.java
+++ b/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramChatBotTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.component.telegram.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.assertCollectionSize;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -32,6 +29,7 @@ import org.apache.camel.component.telegram.model.UpdateResult;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -70,7 +68,7 @@ public class TelegramChatBotTest extends TelegramTestSupport {
                 .map(message -> (OutgoingTextMessage) message)
                 .collect(Collectors.toList());
 
-        assertCollectionSize(msgs, 2);
+        assertEquals(msgs.size(), 2, "List should be of size: " + 2 + " but is: " + msgs.size());
         assertTrue(msgs.stream().anyMatch(m -> "echo from the bot: Hello World!".equals(m.getText())));
         assertTrue(msgs.stream().anyMatch(m -> "echo from the bot: taken".equals(m.getText())));
         assertTrue(msgs.stream().noneMatch(m -> m.getParseMode() != null));

--- a/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramConsumerFallbackConversionTest.java
+++ b/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramConsumerFallbackConversionTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.component.telegram.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.assertCollectionSize;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -74,7 +71,7 @@ public class TelegramConsumerFallbackConversionTest extends TelegramTestSupport 
                 .map(message -> (OutgoingTextMessage) message)
                 .collect(Collectors.toList());
 
-        assertCollectionSize(msgs, 1);
+        assertEquals(msgs.size(), 1, "List should be of size: " + 1 + " but is: " + msgs.size());
         String text = msgs.get(0).getText();
         assertEquals("wrapped message", text);
     }

--- a/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramConsumerMediaPhotoTest.java
+++ b/components-starter/camel-telegram-starter/src/test/java/org/apache/camel/component/telegram/springboot/TelegramConsumerMediaPhotoTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.component.telegram.springboot;
 
-
-import static org.apache.camel.test.junit5.TestSupport.assertCollectionSize;
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -64,7 +61,7 @@ public class TelegramConsumerMediaPhotoTest extends TelegramTestSupport {
         IncomingMessage msg = mediaExchange.getIn().getBody(IncomingMessage.class);
 
         assertNotNull(msg.getPhoto());
-        assertCollectionSize(msg.getPhoto(), 4);
+        assertEquals(msg.getPhoto().size(), 4, "List should be of size: " + 4 + " but is: " + msg.getPhoto().size());
         assertEquals(4, msg.getPhoto().stream().map(ph -> ph.getFileId()).distinct().count());
     }
 


### PR DESCRIPTION
Remove unused imports of org.apache.camel.test.junit5.*, simplify some of the asserts by trying to use junit api asserts