### PR TITLE
Remove unnecessary duplicated property, and change the archetype repository to https

### DIFF
--- a/archetypes/camel-archetype-spring-boot/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/pom.xml
@@ -34,7 +34,6 @@
     <packaging>maven-archetype</packaging>
 
     <properties>
-         <spring-boot-version>2.7.0</spring-boot-version>
          <archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
     </properties>
 

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/settings.xml
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/settings.xml
@@ -30,7 +30,7 @@
             <repositories>
                 <repository>
                     <id>apache-snapshot-repository</id>
-                    <url>http://repository.apache.org/snapshots/</url>
+                    <url>https://repository.apache.org/snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>


### PR DESCRIPTION
Two fixes here :

- Remove unnecessary duplicated property - the archetype spring-boot-version property seems unnecessary due to the parent structure
- Change the repository in the archetype settings.xml to https:// to avoid the maven 3.8.1 "Blocked mirror for repositories" error