### PR TITLE
Update to Spring Boot 2.6.8

### DIFF
--- a/archetypes/camel-archetype-spring-boot/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/pom.xml
@@ -34,7 +34,7 @@
     <packaging>maven-archetype</packaging>
 
     <properties>
-         <spring-boot-version>2.6.7</spring-boot-version>
+        <spring-boot-version>2.6.8</spring-boot-version>
          <archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>2.6.7</spring-boot-version>
+        <spring-boot-version>2.6.8</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>3.14.4-SNAPSHOT</camel-version>


### PR DESCRIPTION
Update to latest Spring Boot 2.6.x GA version before releasing Camel 3.14.4