### PR TITLE
Use ${project.version} of the undertow-starter for testing rather than ${camel-version}

### DIFF
--- a/components-starter/camel-slack-starter/pom.xml
+++ b/components-starter/camel-slack-starter/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-undertow-starter</artifactId>
-      <version>${camel-version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->


### PR DESCRIPTION
Use `${project.version}` of the undertow-starter for testing rather than ${camel-version} - `${camel-version}` should only apply to camel project artifacts