### PR TITLE
CAMEL-17136 : Migration to Jakarta EE 8

### DIFF
--- a/components-starter/camel-servlet-starter/pom.xml
+++ b/components-starter/camel-servlet-starter/pom.xml
@@ -46,8 +46,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- Test dependencies -->

--- a/tooling/camel-spring-boot-dependencies-generator/pom.xml
+++ b/tooling/camel-spring-boot-dependencies-generator/pom.xml
@@ -168,6 +168,8 @@
 
                             <exclude>com.google.code.gson:*</exclude>
                             <exclude>javax.servlet:javax.servlet-api</exclude>
+                            <exclude>javax.annotation:jsr250-api</exclude>
+                            <exclude>javax.xml.soap:javax.xml.soap-api</exclude>
                             <exclude>junit:*</exclude>
                             <exclude>org.junit.jupiter:*</exclude>
                             <exclude>org.junit.vintage:*</exclude>
@@ -209,8 +211,10 @@
 
                             <!-- Modified on Camel due to CAMEL-17435 -->
                             <exclude>com.sun.xml.messaging.saaj:saaj-impl:*</exclude>
+                            <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
+                            <exclude>jakarta.servlet:jakarta.servlet-api</exclude>
                             <exclude>jakarta.xml.bind:jakarta.xml.bind-api:*</exclude>
-                            <exclude>javax.annotation:javax.annotation-api:*</exclude>
+                            <exclude>jakarta.xml.soap:jakarta.xml.soap-api</exclude>
                             <exclude>javax.xml.ws:jaxws-api:*</exclude>
                             <exclude>org.glassfish.jaxb:jaxb-runtime:*</exclude>
 


### PR DESCRIPTION
Tested the changes in https://github.com/apache/camel/pull/7116 (bvfalcon's jakarta-ee-8 branch) against camel-spring-boot, minor changes are needed in camel-spring-boot if https://github.com/apache/camel/pull/7116 is merged to camel.      This PR should not be merged until https://github.com/apache/camel/pull/7116 goes in.

After this PR is merged, a regen is probably needed.