### PR TITLE
Update to SB 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>2.7.0</spring-boot-version>
+        <spring-boot-version>2.7.1</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>3.18.0-SNAPSHOT</camel-version>


### PR DESCRIPTION
https://spring.io/blog/2022/06/23/spring-boot-2-7-1-available-now was released