### PR TITLE
CAMEL-18341 - Upgrade from Codehaus Groovy 3.0.12 to Apache Groovy 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <asciidoctorj-version>2.3.0</asciidoctorj-version>
         <avro-version>1.11.0</avro-version>
         <glassfish-jaxb-runtime-version>${jakarta-jaxb-version}</glassfish-jaxb-runtime-version>
-        <groovy-version>3.0.10</groovy-version>
+        <groovy-version>4.0.4</groovy-version>
         <hadoop2-version>2.10.0</hadoop2-version>
         <jakarta-jaxb-version>2.3.2</jakarta-jaxb-version>
         <jaxb-version>2.3.0</jaxb-version>

--- a/tooling/camel-spring-boot-dependencies-generator/pom.xml
+++ b/tooling/camel-spring-boot-dependencies-generator/pom.xml
@@ -138,7 +138,7 @@
                             <exclude>org.apache.logging.log4j:*</exclude>
                             <exclude>org.assertj:assertj-core:*</exclude>
 
-                            <exclude>org.codehaus.groovy:*</exclude>
+                            <exclude>org.apache.groovy:*</exclude>
                             <exclude>org.hibernate:hibernate-entitymanager</exclude>
                             <exclude>org.hsqldb:*</exclude>
                             <exclude>org.mockito:*</exclude>


### PR DESCRIPTION
Currently have this build error:
```
[ERROR] Failed to execute goal org.apache.camel.springboot:camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:generate-dependencies-bom (default) on project camel-spring-boot-dependencies-generator: Found 4 conflicts between the current managed dependencies and the external BOMS:
[ERROR]  - org.codehaus.groovy:groovy-ant:jar
[ERROR]  - org.codehaus.groovy:groovy-jsr223:jar
[ERROR]  - org.codehaus.groovy:groovy-xml:jar
[ERROR]  - org.codehaus.groovy:groovy:jar
[ERROR] -> [Help 1]
```
I do not find other references in this project. Can it be that it needs to be updated in apache/camel project first? But it will break the build if we start merging the apache/camel and not apache/camel-spring-boot . Wondering how I can test locally with new version of apache/camel, run in offlien mode locally after build of apache/camel? (even if I would have expected that it picked the latest locally built) Or is it a real problem in another project?