### PR TITLE
Align guava version used by starter with camel-guava-eventbus component

### DIFF
--- a/components-starter/camel-guava-eventbus-starter/pom.xml
+++ b/components-starter/camel-guava-eventbus-starter/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${google-guava-version}</version>
+      <version>${guava-eventbus-version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/resources/spring-boot-fix-dependencies.properties
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/resources/spring-boot-fix-dependencies.properties
@@ -28,7 +28,7 @@ camel-core-engine=org.apache.camel.springboot:camel-spring-boot
 camel-cassandraql=com.datastax.oss:java-driver-core:${cassandra-driver-version},com.datastax.oss:java-driver-query-builder:${cassandra-driver-version}
 
 camel-github=org.eclipse.mylyn.github:org.eclipse.egit.github.core:${egit-github-core-version}
-camel-guava-eventbus=com.google.guava:guava:${google-guava-version}
+camel-guava-eventbus=com.google.guava:guava:${guava-eventbus-version}
 
 # Defaulting to netty in the starter
 camel-hl7=org.apache.camel:camel-netty:${camel-version}


### PR DESCRIPTION
camel-guava-eventbus-starter should be using the same version the camel-guava-eventbus component is using --

https://github.com/apache/camel/blob/main/components/camel-guava-eventbus/pom.xml#L45