### PR TITLE
✨ CAMEL-18449 platform-http servlet implementation

### DIFF
--- a/components-starter/camel-platform-http-starter/pom.xml
+++ b/components-starter/camel-platform-http-starter/pom.xml
@@ -40,6 +40,22 @@
       <version>${camel-version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-servlet</artifactId>
+      <version>${camel-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-servlet-starter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring-boot-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>${rest-assured-version}</version>

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
+import org.apache.camel.component.servlet.ServletComponent;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Lazy;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBean(type = "org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration")
+@AutoConfigureAfter(name = {
+		"org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration",
+		"org.apache.camel.component.servlet.springboot.ServletComponentConverter"})
+public class ServletPlatformHttpAutoConfiguration {
+
+	private final CamelContext camelContext;
+
+	public ServletPlatformHttpAutoConfiguration(
+			CamelContext camelContext) {
+		this.camelContext = camelContext;
+	}
+
+	@Lazy
+	@Bean(name = "platform-http-engine")
+	@ConditionalOnMissingBean(PlatformHttpEngine.class)
+	@DependsOn("configureServletComponent")
+	public PlatformHttpEngine servletPlatformHttpEngine() {
+		return new ServletPlatformHttpEngine((ServletComponent) camelContext.getComponent("servlet"));
+	}
+}

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpEngine.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpEngine.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.component.platform.http.PlatformHttpEndpoint;
+import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
+import org.apache.camel.component.servlet.ServletComponent;
+import org.apache.camel.component.servlet.ServletConsumer;
+import org.apache.camel.component.servlet.ServletEndpoint;
+
+public class ServletPlatformHttpEngine implements PlatformHttpEngine {
+
+	private final ServletComponent servletComponent;
+
+	public ServletPlatformHttpEngine(ServletComponent servletComponent) {
+		this.servletComponent = servletComponent;
+	}
+
+	@Override
+	public Consumer createConsumer(PlatformHttpEndpoint platformHttpEndpoint, Processor processor) {
+		try {
+			return new ServletConsumer((ServletEndpoint) servletComponent.createEndpoint(platformHttpEndpoint.getEndpointUri()), processor);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("The following  endpoint uri " + platformHttpEndpoint.getEndpointUri() + " is not supported", e);
+		}
+	}
+
+	@Override
+	public int getServerPort() {
+		return PlatformHttpEngine.super.getServerPort();
+	}
+}

--- a/components-starter/camel-platform-http-starter/src/main/resources/META-INF/spring.factories
+++ b/components-starter/camel-platform-http-starter/src/main/resources/META-INF/spring.factories
@@ -17,5 +17,6 @@
 
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.apache.camel.component.platform.http.springboot.PlatformHttpComponentAutoConfiguration,\
-org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConverter
+org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConverter, \
+org.apache.camel.component.platform.http.springboot.ServletPlatformHttpAutoConfiguration
 

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpBase.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpBase.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+public class ServletPlatformHttpBase {
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Test
+	public void testGet() {
+		Assertions.assertThat(
+						restTemplate.getForEntity("/camel/get", String.class).getStatusCodeValue())
+				.isEqualTo(200);
+	}
+
+	@Test
+	public void testPost() {
+		Assertions.assertThat(
+						restTemplate.postForEntity("/camel/post", "test", String.class).getBody())
+				.isEqualTo("TEST");
+	}
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpRestDSLTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpRestDSLTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration;
+import org.apache.camel.component.servlet.springboot.ServletMappingAutoConfiguration;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootApplication
+@DirtiesContext
+@CamelSpringBootTest
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = {
+				CamelAutoConfiguration.class,
+				ServletPlatformHttpRestDSLTest.class,
+				ServletPlatformHttpRestDSLTest.TestConfiguration.class,
+				ServletPlatformHttpAutoConfiguration.class,
+				ServletComponentAutoConfiguration.class,
+				ServletMappingAutoConfiguration.class
+		}
+)
+public class ServletPlatformHttpRestDSLTest extends ServletPlatformHttpBase {
+
+	// *************************************
+	// Config
+	// *************************************
+	@Configuration
+	public static class TestConfiguration {
+
+		@Bean
+		public RouteBuilder servletPlatformHttpRestDSLRouteBuilder() {
+			return new RouteBuilder() {
+				@Override
+				public void configure() throws Exception {
+					rest()
+							.get("get").to("direct:get")
+							.post("post").to("direct:post");
+
+					from("direct:post").transform().body(String.class, b -> b.toUpperCase());
+					from("direct:get").setBody().constant("get");
+				}
+			};
+		}
+	}
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/ServletPlatformHttpTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration;
+import org.apache.camel.component.servlet.springboot.ServletMappingAutoConfiguration;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootApplication
+@DirtiesContext
+@CamelSpringBootTest
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = {
+				CamelAutoConfiguration.class,
+				ServletPlatformHttpTest.class,
+				ServletPlatformHttpTest.TestConfiguration.class,
+				ServletPlatformHttpAutoConfiguration.class,
+				ServletComponentAutoConfiguration.class,
+				ServletMappingAutoConfiguration.class
+		}
+)
+public class ServletPlatformHttpTest extends ServletPlatformHttpBase {
+
+	// *************************************
+	// Config
+	// *************************************
+	@Configuration
+	public static class TestConfiguration {
+
+		@Bean
+		public RouteBuilder servletPlatformHttpRouteBuilder() {
+			return new RouteBuilder() {
+				@Override
+				public void configure() throws Exception {
+					from("platform-http:/get")
+							.setBody().constant("get");
+					from("platform-http:/post")
+							.transform().body(String.class, b -> b.toUpperCase());
+				}
+			};
+		}
+	}
+}


### PR DESCRIPTION
The idea behind this PR is to use camel-platform-http-starter and camel-servlet-starter without any additional configuration.
If camel-servlet is configured in the context (camel-servlet-starter is declared as a dependency), then a PlatformHttpEngine implementation is created using the servlet, I'm not 100% sure about the reflection, if you think it can be done in some other way please let me know.