### PR TITLE
Remove driver version from mongodb dependencies in tests

### DIFF
--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbGridfsTest.java
@@ -35,8 +35,8 @@ public class CamelMongodbGridfsTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelMongodbGridfsTest.class))
-                .dependency("org.mongodb:mongodb-driver-sync:4.0.4")
-                .dependency("org.mongodb:mongodb-driver-core:4.0.4")
+                .dependency("org.mongodb:mongodb-driver-sync")
+                .dependency("org.mongodb:mongodb-driver-core")
                 .build();
     }
 

--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelMongodbTest.java
@@ -35,8 +35,8 @@ public class CamelMongodbTest extends AbstractSpringBootTestSupport {
     public static ITestConfig createTestConfig() {
         return new ITestConfigBuilder()
                 .module(inferModuleName(CamelMongodbTest.class))
-                .dependency("org.mongodb:mongodb-driver-sync:4.0.4")
-                .dependency("org.mongodb:mongodb-driver-core:4.0.4")
+                .dependency("org.mongodb:mongodb-driver-sync")
+                .dependency("org.mongodb:mongodb-driver-core")
                 .build();
     }
 


### PR DESCRIPTION
These two integration tests were failing last week, and it looks like the reason is the specified version of the mongodb driver, which is now 4.6.0 (https://github.com/apache/camel/blob/main/parent/pom.xml#L400).      I've tried locally and it doesn't seem necessary to specify the version of the dependencies - these tests pass locally for me without the version specified.