### PR TITLE
Prevent CI workflows from running on forks

### DIFF
--- a/.github/workflows/automatic-sync-main.yml
+++ b/.github/workflows/automatic-sync-main.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   build:
     name: Sync Camel Spring Boot Main Branch
+    if: github.repository == 'apache/camel-spring-boot'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Camel project

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -6,6 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'apache/camel-spring-boot'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'apache/camel-spring-boot'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Prevent camel-spring-boot workflows from running on forks like camel-quarkus does https://github.com/apache/camel-quarkus/commit/a4174460f67bfb792d331512abbab928c7d71dd5