### PR TITLE
Align to spring-boot 2.6.12

### DIFF
--- a/archetypes/camel-archetype-spring-boot/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/pom.xml
@@ -34,8 +34,8 @@
     <packaging>maven-archetype</packaging>
 
     <properties>
-        <spring-boot-version>2.6.11</spring-boot-version>
-         <archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
+        <spring-boot-version>2.6.12</spring-boot-version>
+        <archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>2.6.11</spring-boot-version>
+        <spring-boot-version>2.6.12</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>3.14.6-SNAPSHOT</camel-version>


### PR DESCRIPTION
https://github.com/apache/camel/pull/8444 is the camel side PR to align to spring-boot 2.6.12 spring-boot-dependencies