### PR TITLE
Align to spring-boot 2.7.4 (#637)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>2.7.3</spring-boot-version>
+        <spring-boot-version>2.7.4</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>3.18.3-SNAPSHOT</camel-version>


### PR DESCRIPTION
Cherry pick upgrade of spring-boot to 2.7.4 over the LTS branch