### PR TITLE
CAMEL-18729 - Fix GreeterService default WSDL URL in test

### DIFF
--- a/components-starter/camel-cxf-soap-starter/src/test/java/org/apache/camel/component/cxf/soap/springboot/wssecurity/WSSecurityRouteTest.java
+++ b/components-starter/camel-cxf-soap-starter/src/test/java/org/apache/camel/component/cxf/soap/springboot/wssecurity/WSSecurityRouteTest.java
@@ -84,7 +84,7 @@ public class WSSecurityRouteTest {
         BusFactory.setDefaultBus(bus);
         BusFactory.setThreadDefaultBus(bus);
 
-        GreeterService gs = new GreeterService();
+        GreeterService gs = new GreeterService(null);
         Greeter greeter = gs.getGreeterSignaturePort();
 
         ((BindingProvider) greeter).getRequestContext().put(
@@ -104,7 +104,7 @@ public class WSSecurityRouteTest {
         BusFactory.setDefaultBus(bus);
         BusFactory.setThreadDefaultBus(bus);
 
-        GreeterService gs = new GreeterService();
+        GreeterService gs = new GreeterService(null);
         Greeter greeter = gs.getGreeterUsernameTokenPort();
 
         ((BindingProvider) greeter).getRequestContext().put(
@@ -124,7 +124,7 @@ public class WSSecurityRouteTest {
         BusFactory.setDefaultBus(bus);
         BusFactory.setThreadDefaultBus(bus);
 
-        GreeterService gs = new GreeterService();
+        GreeterService gs = new GreeterService(null);
         Greeter greeter = gs.getGreeterEncryptionPort();
 
         ((BindingProvider) greeter).getRequestContext().put(
@@ -144,7 +144,7 @@ public class WSSecurityRouteTest {
         BusFactory.setDefaultBus(bus);
         BusFactory.setThreadDefaultBus(bus);
 
-        GreeterService gs = new GreeterService();
+        GreeterService gs = new GreeterService(null);
         Greeter greeter = gs.getGreeterSecurityPolicyPort();
 
         ((BindingProvider) greeter).getRequestContext().put(


### PR DESCRIPTION
with the default constructor, the location _file:/home/jenkins/workspace/Camel_Daily_Snapshot_Deploy_main/components/camel-cxf/camel-cxf-spring-soap/src/test/resources/hello_world_wssec.wsdl_ will be used