### PR TITLE
Fixed Flaky Tests Caused by JSON permutations

### DIFF
--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonFieldNamePolicyTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonFieldNamePolicyTest.java
@@ -26,15 +26,14 @@ import org.apache.camel.component.gson.GsonDataFormat;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @DirtiesContext
@@ -72,9 +71,10 @@ public class GsonFieldNamePolicyTest {
         pojo.setFirstName("Donald");
         pojo.setLastName("Duck");
 
-        String expected = "{\"id\":123,\"first_name\":\"Donald\",\"last_name\":\"Duck\"}";
         String json = template.requestBody("direct:inPojo", pojo, String.class);
-        assertEquals(expected, json);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"first_name\":\"Donald\""));
+        assertTrue(json.contains("\"last_name\":\"Duck\""));
     }
 
     // *************************************

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonFieldNamePolicyTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonFieldNamePolicyTest.java
@@ -26,14 +26,16 @@ import org.apache.camel.component.gson.GsonDataFormat;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 
 @DirtiesContext

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonMarshalExclusionTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonMarshalExclusionTest.java
@@ -31,14 +31,16 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 
 @DirtiesContext

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonMarshalExclusionTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/GsonMarshalExclusionTest.java
@@ -31,14 +31,14 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @DirtiesContext
@@ -95,7 +95,9 @@ public class GsonMarshalExclusionTest {
 
         Object marshalled = template.requestBody("direct:inPojoExcludeAge", in);
         String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
-        assertEquals("{\"height\":190,\"weight\":70}", marshalledAsString);
+        assertTrue(marshalledAsString.contains("\"height\":190"));
+        assertTrue(marshalledAsString.contains("\"weight\":70"));
+        assertFalse(marshalledAsString.contains("\"age\":30"));
 
         template.sendBody("direct:backPojoExcludeAge", marshalled);
 

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/SpringGsonFieldNamePolicyTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/SpringGsonFieldNamePolicyTest.java
@@ -24,14 +24,14 @@ import org.apache.camel.component.gson.GsonDataFormat;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @DirtiesContext
@@ -82,8 +82,9 @@ public class SpringGsonFieldNamePolicyTest {
         pojo.setFirstName("Donald");
         pojo.setLastName("Duck");
 
-        String expected = "{\"id\":123,\"first_name\":\"Donald\",\"last_name\":\"Duck\"}";
         String json = template.requestBody("direct:inPojo", pojo, String.class);
-        assertEquals(expected, json);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"first_name\":\"Donald\""));
+        assertTrue(json.contains("\"last_name\":\"Duck\""));
     }
 }

--- a/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/SpringGsonFieldNamePolicyTest.java
+++ b/components-starter/camel-gson-starter/src/test/java/org/apache/camel/component/gson/springboot/SpringGsonFieldNamePolicyTest.java
@@ -24,14 +24,15 @@ import org.apache.camel.component.gson.GsonDataFormat;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @DirtiesContext


### PR DESCRIPTION
### Description
Flaky Tests found using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the commands -
`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.springboot.GsonFieldNamePolicyTest#testMarshalPojo
`

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.springboot.GsonMarshalExclusionTest#testMarshalAndUnmarshalPojoWithAnotherExclusion
`

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.springboot.SpringGsonFieldNamePolicyTest#testMarshalPojo
`
The logged failures were-
```
[WARNING] Flakes: 
[WARNING] org.apache.camel.component.gson.springboot.GsonFieldNamePolicyTest.testMarshalPojo
[ERROR]   Run 1: GsonFieldNamePolicyTest.testMarshalPojo:76 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"id":123,"last_name":"Duck","first_name":"Donald"}>
[INFO]   Run 2: PASS
```
```
[ERROR] [WARNING] Flakes: 
[WARNING] org.apache.camel.component.gson.springboot.GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithAnotherExclusion
[ERROR]   Run 1: GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithAnotherExclusion:98 expected: <{"height":190,"weight":70}> but was: <{"weight":70,"height":190}>
[INFO]   Run 2: PASS
```
```
[WARNING] Flakes: 
[WARNING] org.apache.camel.component.gson.springboot.SpringGsonFieldNamePolicyTest.testMarshalPojo
[ERROR]   Run 1: SpringGsonFieldNamePolicyTest.testMarshalPojo:87 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"last_name":"Duck","id":123,"first_name":"Donald"}>
[INFO]   Run 2: PASS
```
### Investigation
The tests  fail with a comparison error while comparing an expected JSON String and the result from the value returned by the funtion template.requestBody(...). The function of the that converts given Pojo Object to String does not guarantee the order of the fields in the Pojos. This makes the test outcome non-deterministic, and the test fails whenever the function returns a mismatch in order of the elements in the JSON String. To fix this, the expected and actual keys should be checked in a more deterministic way so that the assertions do not fail.

### Fix
Expected and actual arrays can be compared without making assumptions about the order of the keys in these JSON Strings. Instead of using assertEquals for the complete JSON String, using contains for every subpart of the expected String makes the test more deterministic and ensures that the flakiness from the test is removed.

The PR does not introduce a breaking change.