### PR TITLE
Add version element to JUnit dependency

### DIFF
--- a/components-starter/camel-swift-starter/pom.xml
+++ b/components-starter/camel-swift-starter/pom.xml
@@ -43,6 +43,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-junit5</artifactId>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Add version element to JUnit dependency in `camel-swift-starter` to avoid build failure when releasing.