### PR TITLE
CAMEL-18984: Add autoconfigure imports

### DIFF
--- a/components-starter/camel-undertow-spring-security-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+org.apache.camel.undertow.spring.boot.UndertowSpringSecurityConfiguration
+org.apache.camel.undertow.spring.boot.UndertowSpringSecurityCustomizer


### PR DESCRIPTION
Hello @davsclaus @Kinae I've added AutConfiguration.imports for both configuration classes, though I don't fully understand why https://github.com/apache/camel-spring-boot/pull/721/files#diff-47c8b6bf12f1a4c3f116d1e2c09fa7451f9fbbac7a3adc1c248c07be11b55cfbR31 is not annotated with Configuration. An example with this starter would be nice to have.