### PR TITLE
Use new setter in OpenTelemetryTracer to use ContextPropagators from …

### DIFF
--- a/components-starter/camel-opentelemetry-starter/src/main/java/org/apache/camel/opentelemetry/starter/OpenTelemetryAutoConfiguration.java
+++ b/components-starter/camel-opentelemetry-starter/src/main/java/org/apache/camel/opentelemetry/starter/OpenTelemetryAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.camel.opentelemetry.starter;
 
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import org.apache.camel.CamelContext;
 import org.apache.camel.opentelemetry.OpenTelemetryTracer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,9 @@ public class OpenTelemetryAutoConfiguration {
     @Autowired(required = false)
     private Tracer tracer;
 
+    @Autowired(required = false)
+    private ContextPropagators contextPropagators;
+
     @Bean(initMethod = "", destroyMethod = "")
     // Camel handles the lifecycle of this bean
     @ConditionalOnMissingBean(OpenTelemetryTracer.class)
@@ -42,6 +46,9 @@ public class OpenTelemetryAutoConfiguration {
         OpenTelemetryTracer ottracer = new OpenTelemetryTracer();
         if (tracer != null) {
             ottracer.setTracer(tracer);
+        }
+        if (contextPropagators != null) {
+            ottracer.setContextPropagators(contextPropagators);
         }
         if (config.getExcludePatterns() != null) {
             ottracer.setExcludePatterns(config.getExcludePatterns());


### PR DESCRIPTION
…auto configured OpenTelemetry.

Uses https://github.com/apache/camel/pull/9341 to avoid the auto generation of **OpenTelemetry.noop()** and use the proper auto configured parts of the _openTelemetry_ bean.