### PR TITLE
Make S3CreateDownloadLinkOperationTest FIPS compliant

### DIFF
--- a/components-starter/camel-aws2-s3-starter/src/test/java/org/apache/camel/component/aws2/s3/S3CreateDownloadLinkOperationTest.java
+++ b/components-starter/camel-aws2-s3-starter/src/test/java/org/apache/camel/component/aws2/s3/S3CreateDownloadLinkOperationTest.java
@@ -100,7 +100,7 @@ public class S3CreateDownloadLinkOperationTest extends BaseS3 {
 
                     from("direct:createDownloadLinkWithoutCredentials").to(awsEndpoint).to("mock:result");
 
-                    from("direct:createDownloadLink").to(awsEndpoint + "&accessKey=xxx&secretKey=yyy&region=eu-west-1")
+                    from("direct:createDownloadLink").to(awsEndpoint + "&accessKey=xxx&secretKey=randomatleast16bytesyy&region=eu-west-1")
                             .to("mock:result");
                 }
             };


### PR DESCRIPTION
Changing the length of the password by at least 16 bytes, allows test execution in FIPS enabled environments