### PR TITLE
CAMEL-19110: Upgrade Spring Boot to 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>3.0.3</spring-boot-version>
+        <spring-boot-version>3.0.4</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>4.0.0-SNAPSHOT</camel-version>


### PR DESCRIPTION
Update to Spring Boot 3.0.4.

The PR for the corresponding dependency updates for Camel core is here: https://github.com/apache/camel/pull/9467.