### PR TITLE
Remove camel-core-engine-starter - does not exist

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,11 +42,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-core-engine-starter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
                 <artifactId>camel-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
As far as I can find camel-core-engine-starter doesn't exist and I can't find it ever deployed - I think it is okay to remove? 