### PR TITLE
CAMEL-18963: upgrade both spring-boot starters using camel-openapi-java

### DIFF
--- a/components-starter/camel-openapi-java-starter/pom.xml
+++ b/components-starter/camel-openapi-java-starter/pom.xml
@@ -38,6 +38,14 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-openapi-java</artifactId>
       <version>${camel-version}</version>
+      <!--START OF GENERATED CODE-->
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+      <!--END OF GENERATED CODE-->
     </dependency>
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
@@ -41,10 +41,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -52,8 +48,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -160,14 +155,9 @@ public class ComplexTypesTest {
 				.collect(Collectors.toList());
 
 		RestOpenApiReader reader = new RestOpenApiReader();
-		OasDocument openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
+		OpenAPI openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
 		assertNotNull(openApi);
-
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		LOG.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
@@ -36,12 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -99,16 +94,10 @@ public class RestOpenApiModelApiSecurityRequirementsTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
-
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
-
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 		log.info(json);
 
 		assertTrue(json.contains("\"securityDefinitions\" : {"));
@@ -132,16 +121,10 @@ public class RestOpenApiModelApiSecurityRequirementsTest {
 		config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
-
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
-
+        String json = io.swagger.v3.core.util.Json.pretty(openApi);
 		log.info(json);
 
 		assertTrue(json.contains("securitySchemes"));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
@@ -39,12 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -98,17 +95,13 @@ public class RestOpenApiReaderApiDocsOverrideTest {
 		config.setBasePath("/api");
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
-		OasDocument openApi = null;
+		OpenAPI openApi = null;
 		openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 		log.info(json);
 
 		assertFalse(json.contains("\"/hello/bye\""));
@@ -126,17 +119,13 @@ public class RestOpenApiReaderApiDocsOverrideTest {
 		config.setSchemes(new String[] {"http"});
 		config.setBasePath("/api");
 		RestOpenApiReader reader = new RestOpenApiReader();
-		OasDocument openApi = null;
+		OpenAPI openApi = null;
 		openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 		log.info(json);
 
 		assertFalse(json.contains("\"/hello/bye\""));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
@@ -39,12 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -99,15 +96,11 @@ public class RestOpenApiReaderApiDocsTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -130,15 +123,11 @@ public class RestOpenApiReaderApiDocsTest {
 		config.setBasePath("/api");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderContextPathTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderContextPathTest.java
@@ -39,14 +39,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
-import io.apicurio.datamodels.openapi.v2.models.Oas20Info;
-import io.apicurio.datamodels.openapi.v3.models.Oas30Info;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -102,20 +98,16 @@ public class RestOpenApiReaderContextPathTest {
 		config.setHost("localhost:8080");
 		config.setSchemes(new String[] {"http"});
 		config.setBasePath("/api");
-		Oas20Info info = new Oas20Info();
+		Info info = new Info();
 		config.setInfo(info);
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -144,22 +136,19 @@ public class RestOpenApiReaderContextPathTest {
 		config.setHost("localhost:8080");
 		config.setSchemes(new String[] {"http"});
 		config.setBasePath("/api");
-		Oas30Info info = new Oas30Info();
+		Info info = new Info();
 		config.setInfo(info);
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
-
+		json = json.replace("\n", " ").replaceAll("\\s+", " ");
+		
 		assertTrue(json.contains("\"url\" : \"http://localhost:8080/api\""));
 		assertTrue(json.contains("\"/hello/bye\""));
 		assertTrue(json.contains("\"summary\" : \"To update the greeting message\""));
@@ -169,10 +158,12 @@ public class RestOpenApiReaderContextPathTest {
 		assertFalse(json.contains("\"/api/hello/hi/{name}\""));
 		assertTrue(json.contains("\"type\" : \"number\""));
 		assertTrue(json.contains("\"format\" : \"float\""));
-		assertTrue(json.contains("\"application/xml\" : \"<hello>Hi</hello>\""));
-		assertTrue(json.contains("\"x-example\" : \"Donald Duck\""));
-		assertTrue(json.contains("\"success\" : \"123\""));
-		assertTrue(json.contains("\"error\" : \"-1\""));
+		// The example is under the section for this media type
+        assertTrue(json.contains("\"application/xml\" : {"));
+        assertTrue(json.contains("\"example\" : \"<hello>Hi</hello>\""));
+		assertTrue(json.contains("\"example\" : \"Donald Duck\""));
+		assertTrue(json.contains("\"success\" : { \"value\" : \"123\" }"));
+        assertTrue(json.contains("\"error\" : { \"value\" : \"-1\" }"));
 		assertTrue(json.contains("\"type\" : \"array\""));
 		assertTrue(json.contains("\"format\" : \"date-time\""));
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
@@ -38,12 +38,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -101,15 +98,11 @@ public class RestOpenApiReaderDayOfWeekTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -136,15 +129,11 @@ public class RestOpenApiReaderDayOfWeekTest {
 		//config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
@@ -39,12 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -115,15 +112,11 @@ public class RestOpenApiReaderEnableVendorExtensionTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -149,15 +142,11 @@ public class RestOpenApiReaderEnableVendorExtensionTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
@@ -38,14 +38,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
-import io.apicurio.datamodels.openapi.v2.models.Oas20Info;
-import io.apicurio.datamodels.openapi.v3.models.Oas30Info;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -90,20 +86,16 @@ public class RestOpenApiReaderFileResponseModelTest {
 		config.setHost("localhost:8080");
 		config.setSchemes(new String[] {"http"});
 		config.setBasePath("/api");
-		Oas20Info info = new Oas20Info();
+		Info info = new Info();
 		config.setInfo(info);
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		LOG.info(json);
 		assertTrue(json.contains("\"type\" : \"file\""));
@@ -117,19 +109,15 @@ public class RestOpenApiReaderFileResponseModelTest {
 		config.setHost("localhost:8080");
 		config.setSchemes(new String[] {"http"});
 		config.setBasePath("/api");
-		Oas30Info info = new Oas30Info();
+		Info info = new Info();
 		config.setInfo(info);
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		LOG.info(json);
 		assertTrue(json.contains("\"format\" : \"binary\""));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
@@ -39,12 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -120,15 +117,11 @@ public class RestOpenApiReaderModelApiSecurityTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -163,15 +156,11 @@ public class RestOpenApiReaderModelApiSecurityTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
@@ -38,12 +38,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -115,15 +112,11 @@ public class RestOpenApiReaderModelBookOrderTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -151,15 +144,11 @@ public class RestOpenApiReaderModelBookOrderTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
@@ -39,12 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -113,15 +110,11 @@ public class RestOpenApiReaderModelTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -147,15 +140,11 @@ public class RestOpenApiReaderModelTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
@@ -28,12 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderApiDocsTest {
 
@@ -50,15 +47,11 @@ public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderA
 		config.setHost("http:mycoolserver:8888/myapi");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -83,15 +76,11 @@ public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderA
 		config.setHost("http:mycoolserver:8888/myapi");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
@@ -40,14 +40,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 import java.util.List;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -110,15 +105,11 @@ public class RestOpenApiReaderPropertyPlaceholderTest {
 		RestOpenApiSupport support = new RestOpenApiSupport();
 		List<RestDefinition> rests = support.getRestDefinitions(context);
 
-		OasDocument openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
+		OpenAPI openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiV3SecuritySchemesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiV3SecuritySchemesTest.java
@@ -37,12 +37,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext
 @CamelSpringBootTest
@@ -111,36 +108,35 @@ public class RestOpenApiV3SecuritySchemesTest {
 		config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
 
 		RestOpenApiReader reader = new RestOpenApiReader();
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 
 		json = json.replace("\n", " ").replaceAll("\\s+", " ");
 
-		assertTrue(json.contains("\"petstore_auth_implicit\" : { \"flows\" : { \"implicit\" : { \"authorizationUrl\" : " +
-				"\"https://petstore.swagger.io/oauth/dialog\", \"refreshUrl\" : " +
-				"\"https://petstore.swagger.io/oauth/refresh\" } }, \"type\" : \"oauth2\" }"));
-		assertTrue(json.contains("\"oauth_password\" : { \"flows\" : { \"password\" : { \"tokenUrl\" : " +
-				"\"https://petstore.swagger.io/oauth/token\" } }, \"type\" : \"oauth2\" }"));
-		assertTrue(json.contains("\"oauth2_accessCode\" : { \"flows\" : { \"authorizationCode\" : { \"authorizationUrl\" : " +
-				"\"https://petstore.swagger.io/oauth/dialog\", \"tokenUrl\" : " +
-				"\"https://petstore.swagger.io/oauth/token\" } }, \"type\" : \"oauth2\" }"));
+		assertTrue(json.contains(
+		        "\"petstore_auth_implicit\" : { \"type\" : \"oauth2\", \"flows\" : { \"implicit\" : { \"authorizationUrl\" : " +
+		                "\"https://petstore.swagger.io/oauth/dialog\", \"refreshUrl\" : " +
+		        "\"https://petstore.swagger.io/oauth/refresh\" } } }"));
 		assertTrue(
-				json.contains("\"api_key_header\" : { \"type\" : \"apiKey\", \"name\" : \"myHeader\", \"in\" : \"header\" }"));
+		        json.contains("\"oauth_password\" : { \"type\" : \"oauth2\", \"flows\" : { \"password\" : { \"tokenUrl\" : " +
+		                "\"https://petstore.swagger.io/oauth/token\" } } }"));
+		assertTrue(json.contains(
+		        "\"oauth2_accessCode\" : { \"type\" : \"oauth2\", \"flows\" : { \"authorizationCode\" : { \"authorizationUrl\" : "
+		                + "\"https://petstore.swagger.io/oauth/dialog\", \"tokenUrl\" : " +
+		        "\"https://petstore.swagger.io/oauth/token\" } } }"));
+		assertTrue(
+		        json.contains("\"api_key_header\" : { \"type\" : \"apiKey\", \"name\" : \"myHeader\", \"in\" : \"header\" }"));
 		assertTrue(json.contains("\"api_key_query\" : { \"type\" : \"apiKey\", \"name\" : \"myQuery\", \"in\" : \"query\" }"));
 		assertTrue(json.contains("\"api_key_cookie\" : { \"type\" : \"apiKey\", \"description\" : \"API Key using cookie\", " +
-				"\"name\" : \"myCookie\", \"in\" : \"cookie\" }"));
+		        "\"name\" : \"myCookie\", \"in\" : \"cookie\" }"));
 		assertTrue(
-				json.contains("\"openIdConnect_auth\" : { \"openIdConnectUrl\" : " +
-						"\"https://petstore.swagger.io/openidconnect\", \"type\" : \"openIdConnect\" }"));
+		        json.contains("\"openIdConnect_auth\" : { \"type\" : \"openIdConnect\", \"openIdConnectUrl\" : " +
+		                "\"https://petstore.swagger.io/openidconnect\" }"));
 		assertTrue(json.contains("\"mutualTLS_auth\" : { \"type\" : \"mutualTLS\" }"));
 	}
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
@@ -34,12 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
-import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @CamelSpringBootTest
@@ -71,15 +68,11 @@ public class SpringRestOpenApiReaderModelApiSecurityTest {
 		config.setVersion("2.0");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
 
 		log.info(json);
 
@@ -115,15 +108,11 @@ public class SpringRestOpenApiReaderModelApiSecurityTest {
 		config.setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 		RestOpenApiReader reader = new RestOpenApiReader();
 
-		OasDocument openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
+		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		Object dump = Library.writeNode(openApi);
-		String json = mapper.writeValueAsString(dump);
+		String json = Json.pretty(openApi);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/resources/application.properties
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/application.properties
@@ -14,15 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-
-appender.file.type = File
-appender.file.name = file
-appender.file.fileName = target/camel-openapi-java-test.log
-appender.file.layout.type = PatternLayout
-appender.file.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
-appender.out.type = Console
-appender.out.name = out
-appender.out.layout.type = PatternLayout
-appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
-rootLogger.level = INFO
-rootLogger.appenderRef.file.ref = file
+spring.main.banner-mode=off

--- a/components-starter/camel-openapi-java-starter/src/test/resources/logback.xml
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+    <file>target/camel-openapi-java-starter-test.log</file>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V2SchemaForComplexTypesRequest.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V2SchemaForComplexTypesRequest.json
@@ -6,15 +6,17 @@
   "paths" : {
     "/complexRequest" : {
       "post" : {
+        "summary" : "Demo complex request type",
+        "operationId" : "verb",
         "consumes" : [ "application/json" ],
         "produces" : [ "text/plain" ],
         "parameters" : [ {
+          "in" : "body",
           "name" : "body",
+          "required" : true,
           "schema" : {
             "$ref" : "#/definitions/SampleComplexRequestType"
-          },
-          "in" : "body",
-          "required" : true
+          }
         } ],
         "responses" : {
           "200" : {
@@ -24,13 +26,35 @@
             }
           }
         },
-        "operationId" : "verb",
-        "summary" : "Demo complex request type",
         "x-camelContextId" : "camel"
       }
     }
   },
+  "securityDefinitions" : {
+    "global" : {
+      "type" : "oauth2",
+      "authorizationUrl" : "https://AUTHORIZATION_URL",
+      "tokenUrl" : "https://TOKEN_URL",
+      "flow" : "accessCode",
+      "scopes" : {
+        "groups" : "Required scopes for Camel REST APIs"
+      }
+    }
+  },
   "definitions" : {
+    "SampleComplexResponseType_InnerClass" : {
+      "type" : "object",
+      "properties" : {
+        "doubleField" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      },
+      "x-className" : {
+        "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
+        "type" : "string"
+      }
+    },
     "CustomData" : {
       "type" : "object",
       "properties" : {
@@ -44,42 +68,9 @@
       }
     },
     "SampleComplexRequestType" : {
-      "required" : [ "mapOfStrings", "requestField1" ],
       "type" : "object",
+      "required" : [ "mapOfStrings", "requestField1" ],
       "properties" : {
-        "data" : {
-          "$ref" : "#/definitions/CustomData"
-        },
-        "listOfData" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/CustomData"
-          }
-        },
-        "listOfListOfData" : {
-          "type" : "array",
-          "items" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/CustomData"
-            }
-          }
-        },
-        "mapOfData" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "$ref" : "#/definitions/CustomData"
-          }
-        },
-        "mapOfMapOfData" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "$ref" : "#/definitions/CustomData"
-            }
-          }
-        },
         "requestField1" : {
           "type" : "string"
         },
@@ -92,10 +83,46 @@
             "type" : "string"
           }
         },
+        "data" : {
+          "$ref" : "#/definitions/CustomData"
+        },
+        "mapOfData" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/CustomData"
+          }
+        },
         "arrayOfString" : {
           "type" : "array",
           "items" : {
             "type" : "string"
+          }
+        },
+        "mapOfMapOfData" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/definitions/CustomData"
+            }
+          }
+        },
+        "innerClass" : {
+          "$ref" : "#/definitions/SampleComplexRequestType_InnerClass"
+        },
+        "listOfListOfData" : {
+          "type" : "array",
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/CustomData"
+            }
+          }
+        },
+        "listOfData" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/CustomData"
           }
         },
         "mapOfStrings" : {
@@ -105,11 +132,8 @@
           }
         },
         "timeUnit" : {
-          "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ],
-          "type" : "string"
-        },
-        "innerClass" : {
-          "$ref" : "#/definitions/SampleComplexRequestType_InnerClass"
+          "type" : "string",
+          "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
         }
       },
       "x-className" : {
@@ -121,38 +145,14 @@
       "type" : "object",
       "properties" : {
         "longField" : {
-          "format" : "int64",
-          "type" : "integer"
+          "type" : "integer",
+          "format" : "int64"
         }
       },
       "x-className" : {
         "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
         "type" : "string"
       }
-    },
-    "SampleComplexResponseType_InnerClass" : {
-      "type" : "object",
-      "properties" : {
-        "doubleField" : {
-          "format" : "double",
-          "type" : "number"
-        }
-      },
-      "x-className" : {
-        "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
-        "type" : "string"
-      }
-    }
-  },
-  "securityDefinitions" : {
-    "global" : {
-      "flow" : "accessCode",
-      "authorizationUrl" : "https://AUTHORIZATION_URL",
-      "tokenUrl" : "https://TOKEN_URL",
-      "scopes" : {
-        "groups" : "Required scopes for Camel REST APIs"
-      },
-      "type" : "oauth2"
     }
   }
 }

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V2SchemaForComplexTypesResponse.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V2SchemaForComplexTypesResponse.json
@@ -6,15 +6,17 @@
   "paths" : {
     "/complexResponse" : {
       "get" : {
+        "summary" : "Demo complex response type",
+        "operationId" : "verb",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
+          "in" : "body",
           "name" : "body",
+          "required" : true,
           "schema" : {
             "$ref" : "#/definitions/SampleComplexRequestType_InnerClass"
-          },
-          "in" : "body",
-          "required" : true
+          }
         } ],
         "responses" : {
           "200" : {
@@ -24,35 +26,41 @@
             }
           }
         },
-        "operationId" : "verb",
-        "summary" : "Demo complex response type",
         "x-camelContextId" : "camel"
       }
     }
   },
+  "securityDefinitions" : {
+    "global" : {
+      "type" : "oauth2",
+      "authorizationUrl" : "https://AUTHORIZATION_URL",
+      "tokenUrl" : "https://TOKEN_URL",
+      "flow" : "accessCode",
+      "scopes" : {
+        "groups" : "Required scopes for Camel REST APIs"
+      }
+    }
+  },
   "definitions" : {
-    "SampleComplexRequestType_InnerClass" : {
+    "SampleComplexResponseType_InnerClass" : {
       "type" : "object",
       "properties" : {
-        "longField" : {
-          "format" : "int64",
-          "type" : "integer"
+        "doubleField" : {
+          "type" : "number",
+          "format" : "double"
         }
       },
       "x-className" : {
-        "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
+        "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
         "type" : "string"
       }
     },
     "SampleComplexResponseType" : {
-      "required" : [ "arrayOfStrings", "responseField1" ],
       "type" : "object",
+      "required" : [ "arrayOfStrings", "responseField1" ],
       "properties" : {
-        "responseField1" : {
-          "type" : "string"
-        },
-        "responseField2" : {
-          "type" : "string"
+        "innerClass" : {
+          "$ref" : "#/definitions/SampleComplexResponseType_InnerClass"
         },
         "arrayOfStrings" : {
           "type" : "array",
@@ -61,11 +69,14 @@
           }
         },
         "month" : {
-          "enum" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ],
+          "type" : "string",
+          "enum" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ]
+        },
+        "responseField2" : {
           "type" : "string"
         },
-        "innerClass" : {
-          "$ref" : "#/definitions/SampleComplexResponseType_InnerClass"
+        "responseField1" : {
+          "type" : "string"
         }
       },
       "x-className" : {
@@ -73,29 +84,18 @@
         "type" : "string"
       }
     },
-    "SampleComplexResponseType_InnerClass" : {
+    "SampleComplexRequestType_InnerClass" : {
       "type" : "object",
       "properties" : {
-        "doubleField" : {
-          "format" : "double",
-          "type" : "number"
+        "longField" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       },
       "x-className" : {
-        "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
+        "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
         "type" : "string"
       }
-    }
-  },
-  "securityDefinitions" : {
-    "global" : {
-      "flow" : "accessCode",
-      "authorizationUrl" : "https://AUTHORIZATION_URL",
-      "tokenUrl" : "https://TOKEN_URL",
-      "scopes" : {
-        "groups" : "Required scopes for Camel REST APIs"
-      },
-      "type" : "oauth2"
     }
   }
 }

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesRequest.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesRequest.json
@@ -6,6 +6,8 @@
   "paths" : {
     "/complexRequest" : {
       "post" : {
+        "summary" : "Demo complex request type",
+        "operationId" : "verb",
         "requestBody" : {
           "description" : "",
           "content" : {
@@ -19,24 +21,35 @@
         },
         "responses" : {
           "200" : {
+            "description" : "Receives a complex object as parameter",
             "content" : {
               "text/plain" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/SampleComplexResponseType_InnerClass"
                 }
               }
-            },
-            "description" : "Receives a complex object as parameter"
+            }
           }
         },
-        "operationId" : "verb",
-        "summary" : "Demo complex request type",
         "x-camelContextId" : "camel"
       }
     }
   },
   "components" : {
     "schemas" : {
+      "SampleComplexResponseType_InnerClass" : {
+        "type" : "object",
+        "properties" : {
+          "doubleField" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        },
+        "x-className" : {
+          "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
+          "type" : "string"
+        }
+      },
       "CustomData" : {
         "type" : "object",
         "properties" : {
@@ -111,8 +124,8 @@
             }
           },
           "timeUnit" : {
-            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ],
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
           },
           "innerClass" : {
             "$ref" : "#/components/schemas/SampleComplexRequestType_InnerClass"
@@ -127,31 +140,19 @@
         "type" : "object",
         "properties" : {
           "longField" : {
-            "format" : "int64",
-            "type" : "integer"
+            "type" : "integer",
+            "format" : "int64"
           }
         },
         "x-className" : {
           "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
           "type" : "string"
         }
-      },
-      "SampleComplexResponseType_InnerClass" : {
-        "type" : "object",
-        "properties" : {
-          "doubleField" : {
-            "format" : "double",
-            "type" : "number"
-          }
-        },
-        "x-className" : {
-          "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
-          "type" : "string"
-        }
       }
     },
     "securitySchemes" : {
       "global" : {
+        "type" : "oauth2",
         "flows" : {
           "authorizationCode" : {
             "authorizationUrl" : "https://AUTHORIZATION_URL",
@@ -160,8 +161,7 @@
               "groups" : "Required scopes for Camel REST APIs"
             }
           }
-        },
-        "type" : "oauth2"
+        }
       }
     }
   }

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesResponse.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesResponse.json
@@ -6,6 +6,8 @@
   "paths" : {
     "/complexResponse" : {
       "get" : {
+        "summary" : "Demo complex response type",
+        "operationId" : "verb",
         "requestBody" : {
           "description" : "",
           "content" : {
@@ -19,34 +21,32 @@
         },
         "responses" : {
           "200" : {
+            "description" : "Returns a complex object",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/SampleComplexResponseType"
                 }
               }
-            },
-            "description" : "Returns a complex object"
+            }
           }
         },
-        "operationId" : "verb",
-        "summary" : "Demo complex response type",
         "x-camelContextId" : "camel"
       }
     }
   },
   "components" : {
     "schemas" : {
-      "SampleComplexRequestType_InnerClass" : {
+      "SampleComplexResponseType_InnerClass" : {
         "type" : "object",
         "properties" : {
-          "longField" : {
-            "format" : "int64",
-            "type" : "integer"
+          "doubleField" : {
+            "type" : "number",
+            "format" : "double"
           }
         },
         "x-className" : {
-          "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
+          "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
           "type" : "string"
         }
       },
@@ -67,8 +67,8 @@
             }
           },
           "month" : {
-            "enum" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ],
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ]
           },
           "innerClass" : {
             "$ref" : "#/components/schemas/SampleComplexResponseType_InnerClass"
@@ -79,22 +79,23 @@
           "type" : "string"
         }
       },
-      "SampleComplexResponseType_InnerClass" : {
+      "SampleComplexRequestType_InnerClass" : {
         "type" : "object",
         "properties" : {
-          "doubleField" : {
-            "format" : "double",
-            "type" : "number"
+          "longField" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         },
         "x-className" : {
-          "format" : "org.apache.camel.openapi.model.SampleComplexResponseType$InnerClass",
+          "format" : "org.apache.camel.openapi.model.SampleComplexRequestType$InnerClass",
           "type" : "string"
         }
       }
     },
     "securitySchemes" : {
       "global" : {
+        "type" : "oauth2",
         "flows" : {
           "authorizationCode" : {
             "authorizationUrl" : "https://AUTHORIZATION_URL",
@@ -103,8 +104,7 @@
               "groups" : "Required scopes for Camel REST APIs"
             }
           }
-        },
-        "type" : "oauth2"
+        }
       }
     }
   }


### PR DESCRIPTION
Modify the AutoConfiguration classes to use the modified return type in RestOpenApiReader.read method. Since OpenAPI is now directly returned there is no need to convert it to json and reparse it with swagger. In addition, this change allows handling of an OpenAPI 2.x specification which will be automatically upgraded to OpenAPI 3.x. Previously this would have failed due to the direct use of OpenAPIV3Parser.