### PR TITLE
camel-kafka - Properly define the after all method

### DIFF
--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
@@ -47,6 +47,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -128,7 +129,7 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
     }
 
     @AfterAll
-    public void after() {
+    public static void after() {
         // clean all test topics
         final List<String> topics = new ArrayList<>();
         topics.add(TOPIC_BYTES);
@@ -137,6 +138,10 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
         topics.add(TOPIC_STRINGS);
 
         kafkaAdminClient.deleteTopics(topics);
+    }
+
+    @AfterEach
+    public void reset() {
         mockEndpoint.reset();
     }
 


### PR DESCRIPTION
## Motivation

The build fails due to some tests that must be fixed

## Modifications:

* Makes the method annotated with `@AfterAll` static as expected by JUnit to prevent runtime error
* Resets the mock endpoint after each test to better match with the context