### PR TITLE
camel-kafka - Set the correct partition id

### DIFF
--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
@@ -282,11 +282,11 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
         CountDownLatch messagesLatch = new CountDownLatch(messageInTopic + messageInOtherTopic);
 
         Map<String, Object> inTopicHeaders = new HashMap<>();
-        inTopicHeaders.put(KafkaConstants.PARTITION_KEY, "1".getBytes());
+        inTopicHeaders.put(KafkaConstants.PARTITION_KEY, "0".getBytes());
         sendMessagesInRoute(messageInTopic, bytesTemplate, "IT test message".getBytes(), inTopicHeaders);
 
         Map<String, Object> otherTopicHeaders = new HashMap<>();
-        otherTopicHeaders.put(KafkaConstants.PARTITION_KEY, "1".getBytes());
+        otherTopicHeaders.put(KafkaConstants.PARTITION_KEY, "0".getBytes());
         otherTopicHeaders.put(KafkaConstants.TOPIC, TOPIC_BYTES_IN_HEADER);
         sendMessagesInRoute(messageInOtherTopic, bytesTemplate, "IT test message in other topic".getBytes(), otherTopicHeaders);
 


### PR DESCRIPTION
## Motivation

The test `KafkaProducerFullIT#producedBytesMessageIsReceivedByKafka` fails due to a `TimeoutException` with the message `Topic testBytes not present in metadata after 60000 ms`.

## Modifications

* Set the correct id of the existing partition which is `0`