### PR TITLE
camel-salesforce - Add missing test dependency and id

### DIFF
--- a/components-starter/camel-salesforce-starter/pom.xml
+++ b/components-starter/camel-salesforce-starter/pom.xml
@@ -45,6 +45,13 @@
       <version>${okclient-version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- forcing okhttp v3.x related to https://issues.apache.org/jira/browse/CAMEL-16336 -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${squareup-okhttp-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
+++ b/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
@@ -127,10 +127,16 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
 
         server.setDispatcher(new Dispatcher() {
             @Override
-            public MockResponse dispatch(RecordedRequest recordedRequest) throws InterruptedException {
+            public MockResponse dispatch(RecordedRequest recordedRequest) {
                 if (recordedRequest.getPath().equals(OAUTH2_TOKEN_PATH)) {
                     return new MockResponse().setResponseCode(200)
-                            .setBody("{ \"access_token\": \"mock_token\", \"instance_url\": \"" + loginUrl + "\"}");
+                            .setBody(String.format("""
+                             {
+                                "access_token": "mock_token",
+                                "instance_url": "%s",
+                                "id": "https://login.salesforce.com/id/00D4100000xxxxxxxx/0054100000xxxxxxxx"
+                             }
+                             """, loginUrl));
                 } else {
                     return new MockResponse().setResponseCode(200)
                             .setHeader(HttpHeader.CONTENT_TYPE.toString(),


### PR DESCRIPTION
## Motivation

The test `RawPayloadTest` in `camel-salesforce` fails due to the exception `NoSuchMethodError: 'void okhttp3.internal.Internal.initializeInstanceForTests()'`

## Modifications:

* Adds the missing test dependency based on https://github.com/apache/camel/blob/main/components/camel-salesforce/camel-salesforce-component/pom.xml#L237-L243
* Adds the id to the fake payload response to avoid an NPE when [extracting the `orgId`](https://github.com/apache/camel/blob/main/components/camel-salesforce/camel-salesforce-component/pom.xml#L237-L243)