### PR TITLE
Avoid test execution of PlatformHttpBase class

### DIFF
--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBase.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBase.java
@@ -22,7 +22,7 @@ import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 
-public class PlatformHttpBase {
+abstract class PlatformHttpBase {
 
 	@Autowired
 	private TestRestTemplate restTemplate;


### PR DESCRIPTION
Those tests must be executed only from inheritor classes