### PR TITLE
[Camel-19462] fixed maven plugin validation issues

### DIFF
--- a/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
+++ b/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
@@ -108,11 +108,6 @@
             <version>${maven-plugin-plugin-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven-version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
             <version>3.1.0</version>

--- a/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
+++ b/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-artifact-transfer</artifactId>
+            <version>0.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
             <version>3.1.0</version>
         </dependency>

--- a/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
+++ b/tooling/camel-spring-boot-generator-maven-plugin/pom.xml
@@ -119,10 +119,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
@@ -108,13 +108,13 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
     /**
      * The user configuration
      */
-    @Parameter(readonly = true)
+    @Parameter
     protected DependencySet dependencies;
 
     /**
      * The conflict checks configured by the user
      */
-    @Parameter(readonly = true)
+    @Parameter
     protected ExternalBomConflictCheckSet checkConflicts;
 
     /**

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
@@ -52,7 +52,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Exclusion;
@@ -65,7 +65,10 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -82,6 +85,12 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
+
+    /**
+     * The maven session.
+     */
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
+    private MavenSession session;
 
     /**
      * The source pom template file.
@@ -124,7 +133,7 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
      * List of Remote Repositories used by the resolver
      */
     @Parameter(property = "project.remoteArtifactRepositories", readonly = true, required = true)
-    protected List remoteRepositories;
+    protected List<ArtifactRepository> remoteRepositories;
 
     /**
      * Location of the local repository.
@@ -559,9 +568,15 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
 
         Artifact art = artifactFactory.createArtifact(groupId, artifactId, version, "runtime", type);
 
-        artifactResolver.resolve(art, remoteRepositories, localRepository);
+        ProjectBuildingRequest buildingRequest =
+                new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        buildingRequest
+                .setRemoteRepositories(remoteRepositories)
+                .setLocalRepository(localRepository);
 
-        return art;
+        return artifactResolver
+                .resolveArtifact(buildingRequest, art)
+                .getArtifact();
     }
 
     private MavenProject loadExternalProjectPom(File pomFile) throws Exception {


### PR DESCRIPTION

Fixed the plugin validation issues with camel-spring-boot-generator-maven-plugin.

1. Removed maven-compat, and updated code to use the ArtifactResolver from maven-artifact-transfer.
2. Removed plexus-container-default since plexus-build-api is no longer dependent on this.
3. Removed read-only elements from Parameters that are intended to by used by users.