### PR TITLE
CAMEL-19861: camel-kafka - Increase the result wait time

### DIFF
--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerIdempotentTestSupport.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerIdempotentTestSupport.java
@@ -57,7 +57,7 @@ public abstract class KafkaConsumerIdempotentTestSupport extends BaseEmbeddedKaf
         List<Exchange> exchangeList = mockEndpoint.getReceivedExchanges();
 
         mockEndpoint.assertIsSatisfied(10000);
-
+        mockEndpoint.setResultWaitTime(20_000);
         assertEquals(size, exchangeList.size());
 
         Map<String, Object> headers = mockEndpoint.getExchanges().get(0).getIn().getHeaders();


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19861

## Motivation

The test `KafkaConsumerIdempotentWithProcessorIT` fails randomly on the CI.

## Modifications:

* Increase the result wait time to 20 seconds
