### PR TITLE
CAMEL-19863: camel-kamelet - Disable failing tests

### DIFF
--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletBasicTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletBasicTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.FluentProducerTemplate;
@@ -64,6 +65,7 @@ public class KameletBasicTest {
                 fluentTemplate.toF("kamelet:setBody/test?bodyValue=%s", body).request(String.class)).isEqualTo(body);
     }
 
+    @Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
     @Test
     public void canConsumeFromKamelet() {
         assertThat(

--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumeOnlyTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumeOnlyTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.kamelet.springboot;
 import org.apache.camel.Exchange;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.apache.camel.ConsumerTemplate;
 
@@ -40,7 +41,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
         KameletConsumeOnlyTest.class,
     }
 )
-
+@Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
 public class KameletConsumeOnlyTest {
 
     @Autowired

--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumerUoWIssueTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumerUoWIssueTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.SynchronizationAdapter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -43,7 +44,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
         KameletConsumerUoWIssueTest.class,
     }
 )
-
+@Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
 public class KameletConsumerUoWIssueTest {
 
     @Autowired


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-19863

## Motivation

Several tests are failing on the CI

## Modifications:

* Disable all the failing tests as long as they are not fixed