### PR TITLE
CAMEL-19864: camel-univocity-parsers - Disable the IT

### DIFF
--- a/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
+++ b/tests/camel-itest-spring-boot/src/test/java/org/apache/camel/itest/springboot/CamelUnivocityParsersTest.java
@@ -20,6 +20,7 @@ import org.apache.camel.itest.springboot.util.ArquillianPackager;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -38,6 +39,7 @@ public class CamelUnivocityParsersTest extends AbstractSpringBootTestSupport {
                 .build();
     }
 
+    @Disabled("https://issues.apache.org/jira/browse/CAMEL-19864")
     @Test
     public void componentTests() throws Exception {
         this.runDataformatTest(config, "univocityCsv");


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-19864

## Motivation

The integration test of the component `camel-univocity-parsers` is failing on the CI

## Modifications:

* Disable the integration test as long as it is not fixed