### PR TITLE
Upgrade failing test to FHIR 6.6.1

### DIFF
--- a/components-starter/camel-fhir-starter/src/test/java/org/apache/camel/component/fhir/FhirUpdateIT.java
+++ b/components-starter/camel-fhir-starter/src/test/java/org/apache/camel/component/fhir/FhirUpdateIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.fhir;
 
-import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -164,7 +163,7 @@ public class FhirUpdateIT extends AbstractFhirTestSupport {
         Date date = new SimpleDateFormat("yyyy-MM-dd").parse("1998-04-29");
         assertNotEquals(date, patient.getBirthDate());
         this.patient.setBirthDate(date);
-        String url = "Patient?" + Patient.SP_IDENTIFIER + '=' + URLEncoder.encode(this.patient.getId(), "UTF-8");
+        String url = "Patient?" + Patient.SP_RES_ID + '=' + patient.getIdPart();
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is org.hl7.fhir.instance.model.api.IBaseResource
         headers.put("CamelFhir.resource", this.patient);
@@ -185,7 +184,7 @@ public class FhirUpdateIT extends AbstractFhirTestSupport {
         Date date = new SimpleDateFormat("yyyy-MM-dd").parse("1998-04-29");
         assertNotEquals(date, patient.getBirthDate());
         this.patient.setBirthDate(date);
-        String url = "Patient?" + Patient.SP_IDENTIFIER + '=' + URLEncoder.encode(this.patient.getId(), "UTF-8");
+        String url = "Patient?" + Patient.SP_RES_ID + '=' + patient.getIdPart();
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is org.hl7.fhir.instance.model.api.IBaseResource
         headers.put("CamelFhir.resourceAsString", this.fhirContext.newJsonParser().encodeResourceToString(this.patient));


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19867

## Motivation

Some tests of the integration test `FhirUpdateIT` fail on the CI, so they need to be investigated and fixed.

## Modifications:

* Backport [the fix](https://github.com/apache/camel-spring-boot/commit/0d365fd48771d0f8a599154c908db179a1f9ebbe) used in the main branch