### PR TITLE
CAMEL-19869: camel-infinispan - Disable failing ITs

### DIFF
--- a/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryIT.java
+++ b/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryIT.java
@@ -21,6 +21,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,7 @@ import org.springframework.test.annotation.DirtiesContext;
 				InfinispanRemoteAggregationRepositoryIT.class
 		}
 )
+@Disabled("https://issues.apache.org/jira/browse/CAMEL-19869")
 public class InfinispanRemoteAggregationRepositoryIT extends InfinispanRemoteTestSupport {
 	public static final int COMPLETION_SIZE = 4;
 	public static final String CORRELATOR_HEADER = "CORRELATOR_HEADER";

--- a/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryOperationsIT.java
+++ b/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryOperationsIT.java
@@ -26,6 +26,7 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,6 +47,7 @@ import org.springframework.test.annotation.DirtiesContext;
                 InfinispanRemoteAggregationRepositoryOperationsIT.class
         }
 )
+@Disabled("https://issues.apache.org/jira/browse/CAMEL-19869")
 public class InfinispanRemoteAggregationRepositoryOperationsIT extends InfinispanRemoteTestSupport {
     private static InfinispanRemoteAggregationRepository aggregationRepository;
 


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-19869

## Motivation

The integration tests `InfinispanRemoteAggregationRepositoryIT` and `InfinispanRemoteAggregationRepositoryOperationsIT` are failing on the CI.

## Modifications:

* Disable the integration tests as long as they are not fixed
