### PR TITLE
CAMEL-19854: camel-kafka - Disable the test KafkaConsumerHealthCheckIT

### DIFF
--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerHealthCheckIT.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerHealthCheckIT.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
                 KafkaConsumerHealthCheckIT.TestConfiguration.class,
         }
 )
+@Disabled("https://issues.apache.org/jira/browse/CAMEL-19854")
 public class KafkaConsumerHealthCheckIT extends BaseEmbeddedKafkaTestSupport {
     public static final String TOPIC = "test-health";
 


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-19854 for 4.0

## Motivation

The test KafkaConsumerHealthCheckIT always fails on the CI.

## Modifications:

* Disable the test as long as it is not fixed