### PR TITLE
CAMEL-19863: fix Kamelet tests using timer

### DIFF
--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletBasicTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletBasicTest.java
@@ -65,7 +65,6 @@ public class KameletBasicTest {
                 fluentTemplate.toF("kamelet:setBody/test?bodyValue=%s", body).request(String.class)).isEqualTo(body);
     }
 
-    @Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
     @Test
     public void canConsumeFromKamelet() {
         assertThat(
@@ -107,7 +106,7 @@ public class KameletBasicTest {
                         .setBody().constant("{{bodyValue}}");
 
                 routeTemplate("tick")
-                        .from("timer:{{routeId}}?repeatCount=1&delay=-1")
+                        .from("timer:{{routeId}}?repeatCount=1&delay=-1&includeMetadata=true")
                         .setBody().exchangeProperty(Exchange.TIMER_COUNTER)
                         .to("kamelet:sink");
 

--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumeOnlyTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumeOnlyTest.java
@@ -41,7 +41,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
         KameletConsumeOnlyTest.class,
     }
 )
-@Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
+
 public class KameletConsumeOnlyTest {
 
     @Autowired
@@ -65,8 +65,9 @@ public class KameletConsumeOnlyTest {
             @Override
             public void configure() {
                 routeTemplate("tick")
-                        .from("timer:{{routeId}}?repeatCount=1&delay=-1")
+                        .from("timer:{{routeId}}?repeatCount=1&delay=-1&includeMetadata=true")
                         .setBody().exchangeProperty(Exchange.TIMER_COUNTER)
+                        .log("Body is ${body}")
                         .to("kamelet:sink");
             }
         };

--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumerUoWIssueTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletConsumerUoWIssueTest.java
@@ -44,7 +44,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
         KameletConsumerUoWIssueTest.class,
     }
 )
-@Disabled("https://issues.apache.org/jira/browse/CAMEL-19863")
+
 public class KameletConsumerUoWIssueTest {
 
     @Autowired
@@ -77,7 +77,7 @@ public class KameletConsumerUoWIssueTest {
             @Override
             public void configure() {
                 routeTemplate("tick")
-                        .from("timer:tick?repeatCount=1&delay=-1")
+                        .from("timer:tick?repeatCount=1&delay=-1&includeMetadata=true")
                         .setBody().exchangeProperty(Exchange.TIMER_COUNTER)
                         .process(new Processor() {
                             @Override


### PR DESCRIPTION
Add includeMetadata=true to the timer endpoint.