### PR TITLE
Remove undertow-version; use version from camel-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
         <springdoc-version>1.6.6</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.0.31</swagger-parser-v3-version>
-        <undertow-version>2.2.16.Final</undertow-version>
     </properties>
 
 


### PR DESCRIPTION
I think we should remove the undertow-version property and use the https://github.com/apache/camel/blob/camel-3.x/parent/pom.xml#L537 version from camel-parent.    It appears like this is already occurring in main (4.x) - undertow.version doesn't exist there https://github.com/apache/camel-spring-boot/blob/main/pom.xml#L116-L132