### PR TITLE
fix: Adapt JAXBRuntimeHints to the behavior change in Spring 6.0.13

### DIFF
--- a/components-starter/camel-xml-jaxb-starter/src/main/java/org/apache/camel/xml/jaxb/springboot/JAXBRuntimeHints.java
+++ b/components-starter/camel-xml-jaxb-starter/src/main/java/org/apache/camel/xml/jaxb/springboot/JAXBRuntimeHints.java
@@ -196,9 +196,11 @@ final class JAXBRuntimeHints implements RuntimeHintsRegistrar {
             }
             applyIfMatch(c, XmlJavaTypeAdapter.class, XmlJavaTypeAdapter::value,
                     type -> hints.reflection().registerType(type, MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
-                    MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
+                            MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_PUBLIC_METHODS,
+                            MemberCategory.DECLARED_FIELDS));
             hints.reflection().registerType(c, MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
-                    MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS);
+                    MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_PUBLIC_METHODS,
+                    MemberCategory.DECLARED_FIELDS);
         }
         boolean classDetected = false;
         for (String className : getClassesFromIndexes(classLoader)) {
@@ -217,7 +219,7 @@ final class JAXBRuntimeHints implements RuntimeHintsRegistrar {
                 MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
         for (Class<?> c : JAXB_ANNOTATIONS) {
             hints.reflection().registerType(c, MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
-                    MemberCategory.INVOKE_DECLARED_METHODS);
+                    MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_PUBLIC_METHODS);
         }
         hints.proxies().registerJdkProxy(TypeReference.of(XmlSeeAlso.class), TypeReference.of("org.glassfish.jaxb.core.v2.model.annotation.Locatable"));
         for (String className : NATIVE_PROXY_DEFINITIONS) {
@@ -225,7 +227,8 @@ final class JAXBRuntimeHints implements RuntimeHintsRegistrar {
         }
         for (String className : JAXB_RUNTIME_CLASSES) {
             hints.reflection().registerTypeIfPresent(classLoader, className,
-                    MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS);
+                    MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
+                    MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_PUBLIC_METHODS);
         }
         // Register the JAXB resource bundles
         hints.reflection().registerTypeIfPresent(classLoader, "jakarta.xml.bind.Messages");

--- a/components-starter/camel-xml-jaxb-starter/src/test/java/org/apache/camel/xml/jaxb/springboot/Book.java
+++ b/components-starter/camel-xml-jaxb-starter/src/test/java/org/apache/camel/xml/jaxb/springboot/Book.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.xml.jaxb.springboot;
 
-import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;


### PR DESCRIPTION
fixes the [failing test JAXBRuntimeHintsTest](https://ci-builds.apache.org/job/Camel/job/Camel-Spring-Boot%20Daily%20JDK17/job/main/1458/testReport/junit/org.apache.camel.xml.jaxb.springboot/JAXBRuntimeHintsTest/shouldRegisterHintsForJAXB/) for 4.0

## Motivation

Since Spring 6.0.13 and the fix for https://github.com/spring-projects/spring-framework/issues/31224, the member category `INVOKE_DECLARED_METHODS` no longer includes public methods so the code needs to be adapted to this behavior change.

## Modifications:

* Register also the member category `INVOKE_PUBLIC_METHODS` when `INVOKE_DECLARED_METHODS` is registered