### PR TITLE
Externalize passwords into properties files, set features to DocumentBuilderFactory

### DIFF
--- a/components-starter/camel-ftp-starter/src/test/resources/users.properties
+++ b/components-starter/camel-ftp-starter/src/test/resources/users.properties
@@ -1,0 +1,5 @@
+admin=admin
+scott=tiger
+us@r=t%st
+joe=p+%w0&r)d
+jane=%j#7%c6i

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddCommentProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddCommentProducerTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithComments;
 import static org.apache.camel.component.jira.springboot.test.Utils.newComment;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +26,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -151,16 +151,14 @@ public class AddCommentProducerTest {
     @Configuration
     public class TestConfiguration {
         
-        
-
         @Bean
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     comment = "A new test comment " + new Date();
                     from("direct:start")
-                            .to("jira://addComment?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://addComment?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueLinkProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueLinkProducerTest.java
@@ -21,7 +21,6 @@ import static org.apache.camel.component.jira.JiraConstants.CHILD_ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
 import static org.apache.camel.component.jira.JiraConstants.LINK_TYPE;
 import static org.apache.camel.component.jira.JiraConstants.PARENT_ISSUE_KEY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithLinks;
 import static org.apache.camel.component.jira.springboot.test.Utils.newIssueLink;
@@ -32,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -254,9 +254,9 @@ public class AddIssueLinkProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     from("direct:start")
-                            .to("jira://addIssueLink?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://addIssueLink?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddIssueProducerTest.java
@@ -25,7 +25,6 @@ import static org.apache.camel.component.jira.JiraConstants.ISSUE_SUMMARY;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_TYPE_ID;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_TYPE_NAME;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.KEY;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.userAssignee;
@@ -33,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -222,9 +222,9 @@ public class AddIssueProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     from("direct:start")
-                            .to("jira://addIssue?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://addIssue?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddWorkLogProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AddWorkLogProducerTest.java
@@ -23,7 +23,6 @@ import static org.apache.camel.component.jira.JiraConstants.MINUTES_SPENT;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithComments;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithWorkLogs;
 import static org.apache.camel.component.jira.springboot.test.Utils.newWorkLog;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -236,7 +235,7 @@ public class AddWorkLogProducerTest {
                 @Override
                 public void configure() throws Exception {
                     from("direct:start")
-                    .to("jira://addWorkLog?jiraUrl=" + JIRA_CREDENTIALS)
+                    .to("jira://addWorkLog?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                     .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AttachFileProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/AttachFileProducerTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.KEY;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithAttachment;
@@ -178,10 +177,10 @@ public class AttachFileProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     from("direct:start")
                             .setHeader(ISSUE_KEY, () -> KEY + "-1")
-                            .to("jira://attach?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://attach?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/DeleteIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/DeleteIssueProducerTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.KEY;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.mockito.ArgumentMatchers.any;
@@ -148,7 +147,7 @@ public class DeleteIssueProducerTest {
                 public void configure() throws IOException {
                     from("direct:start")
                             .setHeader(ISSUE_KEY, () -> KEY + "-1")
-                            .to("jira://deleteIssue?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://deleteIssue?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchCommentsProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchCommentsProducerTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -27,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
@@ -160,9 +160,9 @@ public class FetchCommentsProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     from("direct:start")
-                            .to("jira://fetchComments?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://fetchComments?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/FetchIssueProducerTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -159,7 +158,7 @@ public class FetchIssueProducerTest {
                 @Override
                 public void configure() throws Exception {
                     from("direct:start")
-                    .to("jira://fetchIssue?jiraUrl=" + JIRA_CREDENTIALS)
+                    .to("jira://fetchIssue?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                     .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/JiraTestConstants.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/JiraTestConstants.java
@@ -16,13 +16,24 @@
  */
 package org.apache.camel.component.jira.springboot.test;
 
-public interface JiraTestConstants {
+import java.io.IOException;
+import java.util.Properties;
 
-    String KEY = "TST";
-    String TEST_JIRA_URL = "https://somerepo.atlassian.net";
-    String PROJECT = "TST";
-    String USERNAME = "someguy";
-    String PASSWORD = "my_password";
-    String JIRA_CREDENTIALS = TEST_JIRA_URL + "&username=" + USERNAME + "&password=" + PASSWORD;
-    String WATCHED_COMPONENTS = "Priority,Status,Resolution";
+public class JiraTestConstants {
+
+    static String KEY = "TST";
+    static String TEST_JIRA_URL = "https://somerepo.atlassian.net";
+    static String PROJECT = "TST";
+    static String WATCHED_COMPONENTS = "Priority,Status,Resolution";
+
+    private static Properties loadAuthProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.load(JiraTestConstants.class.getClassLoader().getResourceAsStream("jiraauth.properties"));
+        return properties;
+    }
+
+    public static String getJiraCredentials() throws IOException {
+        Properties props = loadAuthProperties();
+        return TEST_JIRA_URL + "&username=" + props.getProperty("username") + "&password=" + props.getProperty("password");
+    }
 }

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/NewCommentsConsumerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/NewCommentsConsumerTest.java
@@ -20,7 +20,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssueWithComments;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.PROJECT;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -220,8 +220,8 @@ public class NewCommentsConsumerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
-                    from("jira://newComments?jiraUrl=" + JIRA_CREDENTIALS + "&jql=project=" + PROJECT + "&delay=1000")
+                public void configure() throws IOException {
+                    from("jira://newComments?jiraUrl=" + JiraTestConstants.getJiraCredentials() + "&jql=project=" + PROJECT + "&delay=1000")
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/NewIssuesConsumerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/NewIssuesConsumerTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.PROJECT;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -189,8 +189,8 @@ public class NewIssuesConsumerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
-                    from("jira://newIssues?jiraUrl=" + JIRA_CREDENTIALS + "&jql=project=" + PROJECT + "&delay=5000")
+                public void configure() throws IOException  {
+                    from("jira://newIssues?jiraUrl=" + JiraTestConstants.getJiraCredentials() + "&jql=project=" + PROJECT + "&delay=5000")
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/TransitionIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/TransitionIssueProducerTest.java
@@ -23,7 +23,6 @@ import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FAC
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.TEST_JIRA_URL;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.transitionIssueDone;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -158,7 +157,7 @@ public class TransitionIssueProducerTest {
                     from("direct:start")
                             .setHeader(ISSUE_KEY, () -> KEY + "-1")
                             .setHeader(ISSUE_TRANSITION_ID, () -> 31)
-                            .to("jira://transitionIssue?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://transitionIssue?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/UpdateIssueProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/UpdateIssueProducerTest.java
@@ -23,7 +23,6 @@ import static org.apache.camel.component.jira.JiraConstants.ISSUE_PRIORITY_NAME;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_SUMMARY;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_TYPE_NAME;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
 import static org.apache.camel.component.jira.springboot.test.Utils.userAssignee;
 
@@ -32,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -199,9 +199,9 @@ public class UpdateIssueProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException  {
                     from("direct:start")
-                            .to("jira://updateIssue?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://updateIssue?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/WatchUpdatesConsumerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/WatchUpdatesConsumerTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.jira.springboot.test;
 
 
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.PROJECT;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.WATCHED_COMPONENTS;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
@@ -29,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -203,8 +203,8 @@ public class WatchUpdatesConsumerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
-                    from("jira://watchUpdates?jiraUrl=" + JIRA_CREDENTIALS
+                public void configure() throws IOException {
+                    from("jira://watchUpdates?jiraUrl=" + JiraTestConstants.getJiraCredentials()
                          + "&jql=project=" + PROJECT + "&delay=5000&watchedFields=" + WATCHED_COMPONENTS)
                                  .to(mockResult);
                 }

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/WatcherProducerTest.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/WatcherProducerTest.java
@@ -21,7 +21,6 @@ import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_WATCHERS_ADD;
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_WATCHERS_REMOVE;
 import static org.apache.camel.component.jira.JiraConstants.JIRA_REST_CLIENT_FACTORY;
-import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.JIRA_CREDENTIALS;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.KEY;
 import static org.apache.camel.component.jira.springboot.test.JiraTestConstants.TEST_JIRA_URL;
 import static org.apache.camel.component.jira.springboot.test.Utils.createIssue;
@@ -30,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -247,9 +247,9 @@ public class WatcherProducerTest {
         public RouteBuilder routeBuilder() {
             return new RouteBuilder() {
                 @Override
-                public void configure() {
+                public void configure() throws IOException {
                     from("direct:start")
-                            .to("jira://watchers?jiraUrl=" + JIRA_CREDENTIALS)
+                            .to("jira://watchers?jiraUrl=" + JiraTestConstants.getJiraCredentials())
                             .to(mockResult);
                 }
             };

--- a/components-starter/camel-jira-starter/src/test/resources/jiraauth.properties
+++ b/components-starter/camel-jira-starter/src/test/resources/jiraauth.properties
@@ -1,0 +1,3 @@
+username=someguy
+password=my_password
+

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/SpringBootStarterMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/SpringBootStarterMojo.java
@@ -327,7 +327,12 @@ public class SpringBootStarterMojo extends AbstractSpringBootGenerator {
                     boolean editablePom = content.contains(GENERATED_SECTION_START_COMMENT);
                     if (editablePom) {
                         content = removeGeneratedSections(content, 10);
-                        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+                        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
+                        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities",false);
+                        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities",false);
+
+                        DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
 
                         Document pom;
                         try (InputStream contentIn = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {


### PR DESCRIPTION
Beginning to review SAST results and implement suggestions - externalize passwords (I still have more starter tests to fix up and will in subsequent commits), set features to DocumentBuilderFactory