### PR TITLE
Externalize credentials to properties files for SAST tests

### DIFF
--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/AbstractEncryptedPropertiesIvGeneratorAutoDetectionTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/AbstractEncryptedPropertiesIvGeneratorAutoDetectionTest.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Properties;
 
 import static org.apache.camel.component.jasypt.springboot.JasyptEncryptedPropertiesUtils.isIVNeeded;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,17 +43,23 @@ public abstract class AbstractEncryptedPropertiesIvGeneratorAutoDetectionTest {
 
 
     String stringToEncrypt = "A password-cracker walks into a bar. Orders a beer. Then a Beer. Then a BEER. beer. b33r. BeeR. Be3r. bEeR. bE3R. BeEr";
-    String password = "s0m3R@nD0mP@ssW0rD";
-
-
+    //String password = "s0m3R@nD0mP@ssW0rD";
 
     protected String provider;
 
+    public static Properties loadAuthProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.load(AbstractEncryptedPropertiesIvGeneratorAutoDetectionTest.class.getClassLoader().getResourceAsStream("test.properties"));
+        return properties;
+    }
+
     @ParameterizedTest
     @MethodSource("data")
-    public void testEncryptionAndDecryption(String algorithm) {
+    public void testEncryptionAndDecryption(String algorithm) throws IOException {
 
         LOG.info("Testing Algorithm: '{}', requires IV: {}", algorithm, isIVNeeded(algorithm));
+
+        Properties properties = loadAuthProperties();
 
         // Create a ByteArrayOutputStream so that we can get the output
         // from the call to print
@@ -64,7 +72,7 @@ public abstract class AbstractEncryptedPropertiesIvGeneratorAutoDetectionTest {
         environmentStringPBEConfig.setIvGenerator(isIVNeeded(algorithm)?new RandomIvGenerator():new NoIvGenerator());
         environmentStringPBEConfig.setSaltGenerator(new RandomSaltGenerator());
         environmentStringPBEConfig.setProviderName(provider);
-        environmentStringPBEConfig.setPassword(password);
+        environmentStringPBEConfig.setPassword(properties.getProperty("password"));
 
         StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
         standardPBEStringEncryptor.setConfig(environmentStringPBEConfig);

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesCustomConfigurationBeansTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesCustomConfigurationBeansTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.jasypt.springboot;
 
+import java.io.IOException;
+import java.util.Properties;
+
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
@@ -38,9 +41,13 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest(
         classes = {EncryptedPropertiesCustomConfigurationBeansTest.TestConfiguration.class},
         properties = {"encrypted.password=ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)"})
-public class EncryptedPropertiesCustomConfigurationBeansTest extends EncryptedProperiesTestBase {
+public class EncryptedPropertiesCustomConfigurationBeansTest extends EncryptedPropertiesTestBase {
 
-
+    public static Properties loadAuthProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.load(EncryptedPropertiesCustomConfigurationBeansTest.class.getClassLoader().getResourceAsStream("test.properties"));
+        return properties;
+    }
 
     @Test
     public void testCustomEnvironmentVariablesConfiguration() {
@@ -68,12 +75,14 @@ public class EncryptedPropertiesCustomConfigurationBeansTest extends EncryptedPr
         }
 
         @Bean("customEnvironmentStringPBEConfig")
-        public EnvironmentStringPBEConfig environmentVariablesConfiguration() {
+        public EnvironmentStringPBEConfig environmentVariablesConfiguration() throws IOException {
+            Properties props = loadAuthProperties();
+
             EnvironmentStringPBEConfig environmentStringPBEConfig = new EnvironmentStringPBEConfig();
             environmentStringPBEConfig.setAlgorithm("PBEWITHHMACSHA512ANDAES_256");
             environmentStringPBEConfig.setIvGenerator(new RandomIvGenerator(getSecureRandomAlgorithm()));
             environmentStringPBEConfig.setSaltGenerator(new RandomSaltGenerator(getSecureRandomAlgorithm()));
-            environmentStringPBEConfig.setPassword("mainpassword");
+            environmentStringPBEConfig.setPassword(props.getProperty("mainpassword"));
             return environmentStringPBEConfig;
         }
 

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledCustomConfigurationBeansTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledCustomConfigurationBeansTest.java
@@ -36,7 +36,7 @@ import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_T
         properties = {
                 "camel.component.jasypt.enabled = false",
                 "encrypted.password=ENC(6q7H+bWqPbSZVW1hUzDVgnl7iSnC04zRmKwD31ounBMPM/2CtDS7fwb4u1OGZ2Q4)"})
-public class EncryptedPropertiesDisabledCustomConfigurationBeansTest extends EncryptedProperiesTestBase {
+public class EncryptedPropertiesDisabledCustomConfigurationBeansTest extends EncryptedPropertiesTestBase {
 
     @Test
     public void testCustomEnvironmentVariablesConfiguration() {

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesDisabledTest.java
@@ -34,7 +34,7 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 @SpringBootTest(
         properties = {"camel.component.jasypt.enabled = false"},
         classes = {EncryptedPropertiesCustomConfigurationBeansTest.TestConfiguration.class})
-public class EncryptedPropertiesDisabledTest extends EncryptedProperiesTestBase{
+public class EncryptedPropertiesDisabledTest extends EncryptedPropertiesTestBase{
 
 
     /**

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTest.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTest.java
@@ -35,7 +35,7 @@ import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_T
 @DirtiesContext
 @SpringBootApplication
 @SpringBootTest(classes = {EncryptedPropertiesTest.TestConfiguration.class})
-public class EncryptedPropertiesTest extends EncryptedProperiesTestBase {
+public class EncryptedPropertiesTest extends EncryptedPropertiesTestBase {
 
     @Test
     public void testEncryptionInsideCamelContext() {

--- a/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTestBase.java
+++ b/components-starter/camel-jasypt-starter/src/test/java/org/apache/camel/component/jasypt/springboot/EncryptedPropertiesTestBase.java
@@ -30,7 +30,7 @@ import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_T
 import static org.apache.camel.component.jasypt.springboot.Constants.START_URI_TEST_UNENCRYPTED_PROPS_OUT_CC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public abstract class EncryptedProperiesTestBase {
+public abstract class EncryptedPropertiesTestBase {
 
 
     @EndpointInject(MOCK_URI)

--- a/components-starter/camel-jasypt-starter/src/test/resources/test.properties
+++ b/components-starter/camel-jasypt-starter/src/test/resources/test.properties
@@ -1,0 +1,2 @@
+password=s0m3R@nD0mP@ssW0rD
+mainpassword=mainpassword

--- a/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/integration/AbstractMongoDbITSupport.java
+++ b/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/integration/AbstractMongoDbITSupport.java
@@ -46,15 +46,15 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import java.io.IOException;
 import java.util.Formatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public abstract class AbstractMongoDbITSupport {
 
 	protected static final String SCHEME = "mongodb";
-	protected static final String USER = "test-user";
-	protected static final String PASSWORD = "test-pwd";
 	@RegisterExtension
 	public static MongoDBService service = MongoDBServiceFactory.createService();
 	protected static MongoClient mongo;
@@ -101,11 +101,18 @@ public abstract class AbstractMongoDbITSupport {
 		dynamicCollection.drop();
 	}
 
+    public static Properties loadAuthProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.load(AbstractMongoDbITSupport.class.getClassLoader().getResourceAsStream("test.properties"));
+        return properties;
+    }
+
 	/**
 	 * Useful to simulate the presence of an authenticated user with name {@value #USER} and password {@value #PASSWORD}
 	 */
-	protected void createAuthorizationUser() {
-		createAuthorizationUser("admin", USER, PASSWORD);
+	protected void createAuthorizationUser() throws IOException {
+		Properties properties = loadAuthProperties();
+		createAuthorizationUser("admin", properties.getProperty("testusername"), properties.getProperty("testpassword"));
 	}
 
 	protected void createAuthorizationUser(String database, String user, String password) {

--- a/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/meta/integration/MongoDbMetaExtensionIT.java
+++ b/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/meta/integration/MongoDbMetaExtensionIT.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.component.mongodb.meta.integration;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.mongodb.client.model.CreateCollectionOptions;
@@ -54,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
     // We simulate the presence of an authenticated user
     @BeforeEach
-    public void createAuthorizationUser() {
+    public void createAuthorizationUser() throws IOException {
         super.createAuthorizationUser();
     }
 
@@ -63,7 +65,8 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void testValidMetaData() {
+    public void testValidMetaData() throws IOException {
+        Properties properties = loadAuthProperties();
         // When
         final String database = "test";
         final String collection = "validatedCollection";
@@ -99,8 +102,8 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
         parameters.put("database", database);
         parameters.put("collection", collection);
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
 
         MetaDataExtension.MetaData result = component.getExtension(MetaDataExtension.class).get().meta(parameters)
                 .orElseThrow(UnsupportedOperationException::new);
@@ -116,7 +119,9 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void testMissingCollection() {
+    public void testMissingCollection() throws IOException {
+        Properties properties = loadAuthProperties();
+
         // When
         final String database = "test";
         final String collection = "missingCollection";
@@ -126,8 +131,8 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
         parameters.put("database", database);
         parameters.put("collection", collection);
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
 
         final Optional<MetaDataExtension.MetaData> meta
                 = component.getExtension(MetaDataExtension.class).get().meta(parameters);
@@ -150,7 +155,8 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void testNotValidatedCollection() {
+    public void testNotValidatedCollection() throws IOException {
+        Properties properties = loadAuthProperties();
         // When
         final String database = "test";
         final String collection = "notValidatedCollection";
@@ -161,8 +167,8 @@ public class MongoDbMetaExtensionIT extends AbstractMongoDbITSupport {
         parameters.put("database", database);
         parameters.put("collection", collection);
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
 
         final Optional<MetaDataExtension.MetaData> meta
                 = component.getExtension(MetaDataExtension.class).get().meta(parameters);

--- a/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/verifier/integration/MongoDbVerifierExtensionIT.java
+++ b/components-starter/camel-mongodb-starter/src/test/java/org/apache/camel/component/mongodb/verifier/integration/MongoDbVerifierExtensionIT.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.component.mongodb.verifier.integration;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.camel.Component;
 import org.apache.camel.component.extension.ComponentVerifierExtension;
@@ -47,7 +49,7 @@ import org.springframework.test.annotation.DirtiesContext;
 public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     // We simulate the presence of an authenticated user
     @BeforeEach
-    public void createAuthorizationUser() {
+    public void createAuthorizationUser() throws IOException {
         super.createAuthorizationUser();
     }
 
@@ -60,12 +62,13 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionOK() {
+    public void verifyConnectionOK() throws IOException {
+        Properties properties = loadAuthProperties();
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
         //Given
         ComponentVerifierExtension.Result result
                 = getExtension().verify(ComponentVerifierExtension.Scope.CONNECTIVITY, parameters);
@@ -74,12 +77,13 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionKO() {
+    public void verifyConnectionKO() throws IOException {
+        Properties properties = loadAuthProperties();
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", "notReachable.host");
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
         //Given
         ComponentVerifierExtension.Result result
                 = getExtension().verify(ComponentVerifierExtension.Scope.CONNECTIVITY, parameters);
@@ -89,11 +93,13 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionMissingParams() {
+    public void verifyConnectionMissingParams() throws IOException {
+        Properties properties = loadAuthProperties();
+
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
+        parameters.put("user", properties.getProperty("testusername"));
         //Given
         ComponentVerifierExtension.Result result
                 = getExtension().verify(ComponentVerifierExtension.Scope.PARAMETERS, parameters);
@@ -103,12 +109,14 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionNotAuthenticated() {
+    public void verifyConnectionNotAuthenticated() throws IOException {
+        Properties properties = loadAuthProperties();
+
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", "wrongPassword");
+        parameters.put("user", properties.getProperty("wrongusername"));
+        parameters.put("password", properties.getProperty("wrongpassword"));
         //Given
         ComponentVerifierExtension.Result result
                 = getExtension().verify(ComponentVerifierExtension.Scope.CONNECTIVITY, parameters);
@@ -118,12 +126,14 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionAdminDBKO() {
+    public void verifyConnectionAdminDBKO() throws IOException {
+        Properties properties = loadAuthProperties();
+
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", service.getConnectionAddress());
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
         parameters.put("adminDB", "someAdminDB");
         //Given
         ComponentVerifierExtension.Result result
@@ -134,12 +144,14 @@ public class MongoDbVerifierExtensionIT extends AbstractMongoDbITSupport {
     }
 
     @Test
-    public void verifyConnectionPortKO() {
+    public void verifyConnectionPortKO() throws IOException {
+        Properties properties = loadAuthProperties();
+
         //When
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("host", "localhost:12343");
-        parameters.put("user", USER);
-        parameters.put("password", PASSWORD);
+        parameters.put("user", properties.getProperty("testusername"));
+        parameters.put("password", properties.getProperty("testpassword"));
         //Given
         ComponentVerifierExtension.Result result
                 = getExtension().verify(ComponentVerifierExtension.Scope.CONNECTIVITY, parameters);

--- a/components-starter/camel-mongodb-starter/src/test/resources/test.properties
+++ b/components-starter/camel-mongodb-starter/src/test/resources/test.properties
@@ -1,0 +1,11 @@
+testusername=test-user
+testpassword=test-pwd
+
+wrongusername=test-user
+wrongpassword=wrongPassword
+
+adminusername=test-user
+adminpassword=test-pwd
+
+authsourceusername=auth-source-user
+authsourcepassword=auth-source-password

--- a/components-starter/camel-netty-starter/src/test/resources/nettycomponentconfigurationtest.properties
+++ b/components-starter/camel-netty-starter/src/test/resources/nettycomponentconfigurationtest.properties
@@ -1,0 +1,1 @@
+password=changeit

--- a/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
+++ b/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,7 +78,6 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
 
     public static String endpointUri;
 
-    private static final String OAUTH2_TOKEN_PATH = "/services/oauth2/token";
     private static final String XML_RESPONSE = "<response/>";
     private static final String JSON_RESPONSE = "{ \"response\" : \"mock\" }";
 
@@ -88,6 +88,12 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
     private static String expectedResponse;
     private static String requestBody;
     private static Map<String, Object> headers;
+
+    private static Properties loadProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.load(RawPayloadTest.class.getClassLoader().getResourceAsStream("rawpayload.properties"));
+        return properties;
+    }
 
     @Override
     @Bean("salesforce")
@@ -127,8 +133,15 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
 
         server.setDispatcher(new Dispatcher() {
             @Override
-            public MockResponse dispatch(RecordedRequest recordedRequest) {
-                if (recordedRequest.getPath().equals(OAUTH2_TOKEN_PATH)) {
+            public MockResponse dispatch(RecordedRequest recordedRequest)  {
+
+                Properties props;
+                try {
+                    props = loadProperties();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException(ioe);
+                }
+                if (recordedRequest.getPath().equals(props.getProperty("tokenpath"))) {
                     return new MockResponse().setResponseCode(200)
                             .setBody(String.format("""
                              {

--- a/components-starter/camel-salesforce-starter/src/test/resources/rawpayload.properties
+++ b/components-starter/camel-salesforce-starter/src/test/resources/rawpayload.properties
@@ -1,0 +1,1 @@
+tokenpath=/services/oauth2/token


### PR DESCRIPTION
Externalize credentials to properties files for SAST tests.    Found a typo in the filename of one of the test classes (EncryptedProperiesTestBase), renamed it.