### PR TITLE
[infinispan] Client property configurable in tests

### DIFF
--- a/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteConfigurationIT.java
+++ b/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteConfigurationIT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.infinispan.remote;
 
+import static org.apache.camel.component.infinispan.remote.InfinispanRemoteTestSupport.CLIENT_INTELLIGENCE_BASIC;
+
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.infra.infinispan.services.InfinispanService;
 import org.apache.camel.test.infra.infinispan.services.InfinispanServiceFactory;
@@ -59,7 +61,7 @@ public class InfinispanRemoteConfigurationIT {
 		configuration.setSecurityServerName("infinispan");
 		configuration.setSaslMechanism("DIGEST-MD5");
 		configuration.setSecurityRealm("default");
-		if (SystemUtils.IS_OS_MAC) {
+		if (CLIENT_INTELLIGENCE_BASIC) {
 			configuration.addConfigurationProperty(
 					"infinispan.client.hotrod.client_intelligence", "BASIC");
 		}

--- a/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteTestSupport.java
+++ b/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteTestSupport.java
@@ -49,6 +49,8 @@ public class InfinispanRemoteTestSupport {
 	public static InfinispanService service = InfinispanServiceFactory.createService();
 	protected static RemoteCacheManager cacheContainer;
 
+	public static final boolean CLIENT_INTELLIGENCE_BASIC = SystemUtils.IS_OS_MAC || Boolean.parseBoolean(System.getProperty("infinispan.client_intelligence.basic", "false"));
+
 	@Autowired
 	ProducerTemplate template;
 
@@ -133,7 +135,7 @@ public class InfinispanRemoteTestSupport {
 				.saslMechanism("DIGEST-MD5")
 				.realm("default");
 
-		if (SystemUtils.IS_OS_MAC) {
+		if (CLIENT_INTELLIGENCE_BASIC) {
 			Properties properties = new Properties();
 			properties.put("infinispan.client.hotrod.client_intelligence", "BASIC");
 			clientBuilder.withProperties(properties);

--- a/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusteredTestSupport.java
+++ b/components-starter/camel-infinispan-starter/src/test/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusteredTestSupport.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.infinispan.remote.cluster;
 
+import static org.apache.camel.component.infinispan.remote.InfinispanRemoteTestSupport.CLIENT_INTELLIGENCE_BASIC;
+
 import java.util.Properties;
 
 import org.apache.camel.test.infra.infinispan.services.InfinispanService;
@@ -24,43 +26,35 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.configuration.cache.CacheMode;
-import org.testcontainers.shaded.org.apache.commons.lang3.SystemUtils;
 
 public final class InfinispanRemoteClusteredTestSupport {
+
 	private InfinispanRemoteClusteredTestSupport() {
 	}
 
 	public static Configuration createConfiguration(InfinispanService service) {
-		if (SystemUtils.IS_OS_MAC) {
-			Properties properties = new Properties();
+
+		final ConfigurationBuilder configBuilder = new ConfigurationBuilder();
+
+		if (CLIENT_INTELLIGENCE_BASIC) {
+			final Properties properties = new Properties();
 			properties.put("infinispan.client.hotrod.client_intelligence", "BASIC");
-			return new ConfigurationBuilder()
-					.withProperties(properties)
-					.addServer()
-					.host(service.host())
-					.port(service.port())
-					.security()
-					.authentication()
-					.username(service.username())
-					.password(service.password())
-					.serverName("infinispan")
-					.saslMechanism("DIGEST-MD5")
-					.realm("default")
-					.build();
-		} else {
-			return new ConfigurationBuilder()
-					.addServer()
-					.host(service.host())
-					.port(service.port())
-					.security()
-					.authentication()
-					.username(service.username())
-					.password(service.password())
-					.serverName("infinispan")
-					.saslMechanism("DIGEST-MD5")
-					.realm("default")
-					.build();
+			configBuilder.withProperties(properties);
 		}
+
+		configBuilder
+				.addServer()
+				.host(service.host())
+				.port(service.port())
+				.security()
+				.authentication()
+				.username(service.username())
+				.password(service.password())
+				.serverName("infinispan")
+				.saslMechanism("DIGEST-MD5")
+				.realm("default");
+
+		return configBuilder.build();
 	}
 
 	public static void createCache(RemoteCacheManager cacheContainer, String cacheName) {


### PR DESCRIPTION
Adds `infinispan.client_intelligence.basic` system property to set `infinispan.client.hotrod.client_intelligence=BASIC` client property configuration in `camel-infinispan-starter` tests