### PR TITLE
Add enabled property for OpenTelemetry starter

### DIFF
--- a/components-starter/camel-opentelemetry-starter/src/main/docs/opentelemetry.json
+++ b/components-starter/camel-opentelemetry-starter/src/main/docs/opentelemetry.json
@@ -8,6 +8,13 @@
   ],
   "properties": [
     {
+      "name": "camel.opentelemetry.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Global option to enable\/disable OpenTelemetry integration, default is true.",
+      "sourceType": "org.apache.camel.opentelemetry.starter.OpenTelemetryConfigurationProperties",
+      "defaultValue": true
+    },
+    {
       "name": "camel.opentelemetry.encoding",
       "type": "java.lang.Boolean",
       "description": "Activate or deactivate dash encoding in headers (required by JMS) for messaging",

--- a/components-starter/camel-opentelemetry-starter/src/main/java/org/apache/camel/opentelemetry/starter/OpenTelemetryConfigurationProperties.java
+++ b/components-starter/camel-opentelemetry-starter/src/main/java/org/apache/camel/opentelemetry/starter/OpenTelemetryConfigurationProperties.java
@@ -16,13 +16,15 @@
  */
 package org.apache.camel.opentelemetry.starter;
 
-import java.util.Set;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.opentelemetry")
 public class OpenTelemetryConfigurationProperties {
 
+    /**
+     * Global option to enable/disable OpenTelemetry integration, default is true.
+     */
+    private boolean enabled = true;
     /**
      * Sets exclude pattern(s) that will disable tracing for Camel messages that
      * matches the pattern. Multiple patterns can be separated by comma.
@@ -33,6 +35,14 @@ public class OpenTelemetryConfigurationProperties {
      * messaging
      */
     private Boolean encoding;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     public String getExcludePatterns() {
         return excludePatterns;


### PR DESCRIPTION
This adds a "enabled" property to the "camel.opentelemetry" group, to fix IntelliJ `Cannot resolve configuration property 'camel.opentelemetry.enabled'` warnings.