### PR TITLE
CAMEL-20148: Discover resources on classpath

### DIFF
--- a/tests/camel-itest-spring-boot/src/test/resources/BOOT-MANIFEST.MF
+++ b/tests/camel-itest-spring-boot/src/test/resources/BOOT-MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Main-Class: org.springframework.boot.loader.JarLauncher
+Main-Class: org.springframework.boot.loader.launch.JarLauncher
 Start-Class: org.apache.camel.itest.springboot.ITestApplication


### PR DESCRIPTION
Due to [nested jar support in spring boot 3.2](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support) filenames on the classloader start with jar:nested: instead of jar:file: