### PR TITLE
CAMEL-20181: camel-openapi-java - fix compilain errors

### DIFF
--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
@@ -157,7 +157,7 @@ public class ComplexTypesTest {
 		RestOpenApiReader reader = new RestOpenApiReader();
 		OpenAPI openApi = reader.read(context, rests, config, context.getName(), new DefaultClassResolver());
 		assertNotNull(openApi);
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		LOG.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiModelApiSecurityRequirementsTest.java
@@ -97,7 +97,7 @@ public class RestOpenApiModelApiSecurityRequirementsTest {
 		OpenAPI openApi = reader.read(context, ((ModelCamelContext) context).getRestDefinitions(), config, context.getName(),
 				new DefaultClassResolver());
 		assertNotNull(openApi);
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 		log.info(json);
 
 		assertTrue(json.contains("\"securityDefinitions\" : {"));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsOverrideTest.java
@@ -101,7 +101,7 @@ public class RestOpenApiReaderApiDocsOverrideTest {
 
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 		log.info(json);
 
 		assertFalse(json.contains("\"/hello/bye\""));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderApiDocsTest.java
@@ -100,7 +100,7 @@ public class RestOpenApiReaderApiDocsTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderContextPathTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderContextPathTest.java
@@ -107,7 +107,7 @@ public class RestOpenApiReaderContextPathTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderDayOfWeekTest.java
@@ -102,7 +102,7 @@ public class RestOpenApiReaderDayOfWeekTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderEnableVendorExtensionTest.java
@@ -116,7 +116,7 @@ public class RestOpenApiReaderEnableVendorExtensionTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderFileResponseModelTest.java
@@ -95,7 +95,7 @@ public class RestOpenApiReaderFileResponseModelTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		LOG.info(json);
 		assertTrue(json.contains("\"type\" : \"file\""));

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelApiSecurityTest.java
@@ -121,7 +121,7 @@ public class RestOpenApiReaderModelApiSecurityTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelBookOrderTest.java
@@ -116,7 +116,7 @@ public class RestOpenApiReaderModelBookOrderTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderModelTest.java
@@ -114,7 +114,7 @@ public class RestOpenApiReaderModelTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderOverrideHostApiDocsTest.java
@@ -51,7 +51,7 @@ public class RestOpenApiReaderOverrideHostApiDocsTest extends RestOpenApiReaderA
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderPropertyPlaceholderTest.java
@@ -109,7 +109,7 @@ public class RestOpenApiReaderPropertyPlaceholderTest {
 		assertNotNull(openApi);
 
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
@@ -106,7 +106,7 @@ public class RestOpenApiReaderTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiV2SecuritySchemesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/RestOpenApiV2SecuritySchemesTest.java
@@ -104,7 +104,7 @@ public class RestOpenApiV2SecuritySchemesTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/SpringRestOpenApiReaderModelApiSecurityTest.java
@@ -72,7 +72,7 @@ public class SpringRestOpenApiReaderModelApiSecurityTest {
 				new DefaultClassResolver());
 		assertNotNull(openApi);
 
-		String json = RestOpenApiSupport.getJsonFromOpenAPI(openApi, config);
+		String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
 
 		log.info(json);
 


### PR DESCRIPTION
It related to
- https://github.com/apache/camel/pull/12316

The RestOpenApiSupport method `getJsonFromOpenAPI` -> `getJsonFromOpenAPIAsString`