### PR TITLE
Make Jasypt beans conditional so that can be overridden

### DIFF
--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
@@ -58,6 +58,7 @@ import static org.springframework.core.annotation.AnnotationUtils.findAnnotation
 public class JasyptEncryptedPropertiesAutoconfiguration {
 
     @Bean
+    @ConditionalOnMissingBean(JasyptEncryptedPropertiesConfiguration.class)
     public JasyptEncryptedPropertiesConfiguration JasyptEncryptedPropertiesAutoconfiguration(
             final ConfigurableEnvironment environment) {
         JasyptEncryptedPropertiesConfiguration config = new JasyptEncryptedPropertiesConfiguration();
@@ -98,6 +99,7 @@ public class JasyptEncryptedPropertiesAutoconfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(EncryptablePropertySourcesPlaceholderConfigurer.class)
     public EncryptablePropertySourcesPlaceholderConfigurer propertyConfigurer(StringEncryptor stringEncryptor) {
         return new EncryptablePropertySourcesPlaceholderConfigurer(stringEncryptor);
     }
@@ -107,6 +109,7 @@ public class JasyptEncryptedPropertiesAutoconfiguration {
      * properties inside the camel context.
      */
     @Bean
+    @ConditionalOnMissingBean(PropertiesParser.class)
     public PropertiesParser encryptedPropertiesParser(PropertyResolver propertyResolver,
             StringEncryptor stringEncryptor) {
         return new JasyptSpringEncryptedPropertiesParser(propertyResolver, stringEncryptor);

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptEncryptedPropertiesAutoconfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertyResolver;
 
@@ -111,8 +112,8 @@ public class JasyptEncryptedPropertiesAutoconfiguration {
     @Bean
     @ConditionalOnMissingBean(PropertiesParser.class)
     public PropertiesParser encryptedPropertiesParser(PropertyResolver propertyResolver,
-            StringEncryptor stringEncryptor) {
-        return new JasyptSpringEncryptedPropertiesParser(propertyResolver, stringEncryptor);
+             StringEncryptor stringEncryptor, Environment env) {
+        return new JasyptSpringEncryptedPropertiesParser(propertyResolver, stringEncryptor, env);
     }
 
     public SaltGenerator getSaltGenerator(JasyptEncryptedPropertiesConfiguration configuration) {

--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptSpringEncryptedPropertiesParser.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/JasyptSpringEncryptedPropertiesParser.java
@@ -16,23 +16,28 @@
  */
 package org.apache.camel.component.jasypt.springboot;
 
-import org.apache.camel.component.properties.DefaultPropertiesParser;
 import org.apache.camel.component.properties.PropertiesLookup;
+import org.apache.camel.spring.boot.SpringPropertiesParser;
 import org.jasypt.encryption.StringEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertyResolver;
 
 import static org.jasypt.properties.PropertyValueEncryptionUtils.isEncryptedValue;
 import static org.jasypt.properties.PropertyValueEncryptionUtils.decrypt;
 
-public class JasyptSpringEncryptedPropertiesParser extends DefaultPropertiesParser {
+public class JasyptSpringEncryptedPropertiesParser extends SpringPropertiesParser {
 
     private PropertyResolver propertyResolver;
 
     private StringEncryptor stringEncryptor;
 
     @Autowired
-    public JasyptSpringEncryptedPropertiesParser(PropertyResolver propertyResolver, StringEncryptor stringEncryptor) {
+    public JasyptSpringEncryptedPropertiesParser(
+            PropertyResolver propertyResolver,
+            StringEncryptor stringEncryptor,
+            Environment env) {
+        super(env);
         this.propertyResolver = propertyResolver;
         this.stringEncryptor = stringEncryptor;
     }


### PR DESCRIPTION
At the moment, the documentation does not work as is, a bean like
```
<bean id="jasypt" class="org.apache.camel.component.jasypt.JasyptPropertiesParser">
    <!-- password is mandatory, you can prefix it with sysenv: or sys: to indicate it should use
         an OS environment or JVM system property value, so you don't have the master password defined here -->
    <property name="password" value="secret"/>
</bean>
```
has to be defined as primary="true" otherwise two spring beans are loaded in the context for the same class.

Marking beans as conditional solves this issue.