### PR TITLE
CAMEL-20868: camel-aws-xray configure AWS XRay tracing out of the box

### DIFF
--- a/components-starter/camel-aws-xray-starter/pom.xml
+++ b/components-starter/camel-aws-xray-starter/pom.xml
@@ -47,6 +47,18 @@
       </exclusions>
       <!--END OF GENERATED CODE-->
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-spring-junit5</artifactId>
+      <version>${camel-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-spring-boot</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-aws-xray-starter/src/main/docs/aws-xray.json
+++ b/components-starter/camel-aws-xray-starter/src/main/docs/aws-xray.json
@@ -1,3 +1,31 @@
 {
-  "properties": []
+  "groups": [
+    {
+      "name": "camel.aws-xray",
+      "type": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties",
+      "sourceType": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "camel.aws-xray.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Global option to enable\/disable AWS XRay integration, default is true.",
+      "sourceType": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties",
+      "defaultValue": true
+    },
+    {
+      "name": "camel.aws-xray.exclude-patterns",
+      "type": "java.util.Set<java.lang.String>",
+      "description": "Sets exclude pattern(s) that will disable tracing for Camel messages that matches the pattern. Multiple patterns can be separated by comma.",
+      "sourceType": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties"
+    },
+    {
+      "name": "camel.aws-xray.tracing-strategy",
+      "type": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties$TracingStrategy",
+      "description": "Tracing strategy used. Defaults to {@link org.apache.camel.component.aws.xray.TraceAnnotatedTracingStrategy}",
+      "sourceType": "org.apache.camel.aws.xray.starter.AwsXRayConfigurationProperties"
+    }
+  ],
+  "hints": []
 }

--- a/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/AwsXRayAutoConfiguration.java
+++ b/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/AwsXRayAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.aws.xray.starter;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.aws.xray.NoopTracingStrategy;
+import org.apache.camel.component.aws.xray.TraceAnnotatedTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.apache.camel.spi.InterceptStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AwsXRayConfigurationProperties.class)
+@ConditionalOnProperty(value = "camel.aws-xray.enabled", matchIfMissing = true)
+public class AwsXRayAutoConfiguration {
+
+    @Autowired(required=false)
+    @CamelAwsXRayTracingStrategy
+    private InterceptStrategy xRayStrategy;
+
+    @Bean
+    @ConditionalOnMissingBean(XRayTracer.class)
+    XRayTracer awsTracer(CamelContext context,
+            AwsXRayConfigurationProperties config) {
+        XRayTracer tracer = new XRayTracer();
+        context.setTracing(true);
+        tracer.setCamelContext(context);
+        if(xRayStrategy != null) {
+            tracer.setTracingStrategy(xRayStrategy);
+        } else if (config.getTracingStrategy() == AwsXRayConfigurationProperties.TracingStrategy.NOOP) {
+            tracer.setTracingStrategy(new NoopTracingStrategy());
+        } else {
+            // by default let's use TraceAnnotatedTracingStrategy
+            tracer.setTracingStrategy(new TraceAnnotatedTracingStrategy());
+        }
+        tracer.setExcludePatterns(config.getExcludePatterns());
+        tracer.init(context);
+        return tracer;
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/AwsXRayConfigurationProperties.java
+++ b/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/AwsXRayConfigurationProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.aws.xray.starter;
+
+import java.util.Set;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "camel.aws-xray")
+public class AwsXRayConfigurationProperties {
+
+    /**
+     * Global option to enable/disable AWS XRay integration, default is true.
+     */
+    private boolean enabled = true;
+    /**
+     * Sets exclude pattern(s) that will disable tracing for Camel messages that matches the pattern. Multiple patterns
+     * can be separated by comma.
+     */
+    private Set<String> excludePatterns;
+
+    /**
+     * Tracing strategy used. Defaults to {@link org.apache.camel.component.aws.xray.TraceAnnotatedTracingStrategy}
+     */
+    private TracingStrategy tracingStrategy = TracingStrategy.DEFAULT;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Set<String> getExcludePatterns() {
+        return excludePatterns;
+    }
+
+    public void setExcludePatterns(Set<String> excludePatterns) {
+        this.excludePatterns = excludePatterns;
+    }
+
+    public TracingStrategy getTracingStrategy() {
+        return tracingStrategy;
+    }
+
+    public void setTracingStrategy(TracingStrategy tracingStrategy) {
+        this.tracingStrategy = tracingStrategy;
+    }
+
+
+    public enum TracingStrategy {
+        DEFAULT, NOOP }
+
+}

--- a/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/CamelAwsXRayTracingStrategy.java
+++ b/components-starter/camel-aws-xray-starter/src/main/java/org/apache/camel/aws/xray/starter/CamelAwsXRayTracingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.aws.xray.starter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ *
+ * Annotate your custom AWS XRay tracing strategy. Will be used if found. Must implement {@link org.apache.camel.spi.InterceptStrategy}.
+ *
+ */
+@Target({ ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface CamelAwsXRayTracingStrategy {
+}

--- a/components-starter/camel-aws-xray-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/components-starter/camel-aws-xray-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.apache.camel.aws.xray.starter.AwsXRayAutoConfiguration

--- a/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayCustomTest.java
+++ b/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayCustomTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.aws.xray.starter;
+
+import java.util.List;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DirtiesContext
+@CamelSpringBootTest
+@SpringBootTest(classes = { CamelAutoConfiguration.class, CamelAwsXRayCustomTest.class, AwsXRayAutoConfiguration.class, CustomAwsXRayTracingStrategy.class })
+public class CamelAwsXRayCustomTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Autowired
+    private XRayTracer tracer;
+
+    @Test
+    public void testTraceAnnotatedTracingStrategy() {
+        assertTrue(context.hasService(tracer));
+        List<InterceptStrategy> interceptStrategies = context.getCamelContextExtension().getInterceptStrategies();
+        boolean found = false;
+        for (InterceptStrategy is: interceptStrategies) {
+            if (is instanceof CustomAwsXRayTracingStrategy) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Tracing Strategy should have been added");
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayDisabledTest.java
+++ b/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayDisabledTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.aws.xray.starter;
+
+import java.util.List;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.aws.xray.TraceAnnotatedTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DirtiesContext
+@TestPropertySource(locations = "/disabled.properties")
+@CamelSpringBootTest
+@SpringBootTest(classes = { CamelAutoConfiguration.class, CamelAwsXRayDisabledTest.class, AwsXRayAutoConfiguration.class })
+public class CamelAwsXRayDisabledTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Autowired(required = false)
+    private XRayTracer tracer;
+
+    @Test
+    public void testTraceAnnotatedTracingStrategy() {
+        assertNull(tracer);
+        List<InterceptStrategy> interceptStrategies = context.getCamelContextExtension().getInterceptStrategies();
+        boolean found = false;
+        for (InterceptStrategy is: interceptStrategies) {
+            if (is instanceof TraceAnnotatedTracingStrategy) {
+                found = true;
+                break;
+            }
+        }
+        assertFalse(found, "Tracing Strategy should not have been added");
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayNoopTest.java
+++ b/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayNoopTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.aws.xray.starter;
+
+import java.util.List;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.aws.xray.NoopTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DirtiesContext
+@CamelSpringBootTest
+@TestPropertySource(locations = "/noop.properties")
+@SpringBootTest(classes = { CamelAutoConfiguration.class, CamelAwsXRayNoopTest.class, AwsXRayAutoConfiguration.class })
+public class CamelAwsXRayNoopTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Autowired
+    private XRayTracer tracer;
+
+    @Test
+    public void testTraceAnnotatedTracingStrategy() {
+        assertTrue(context.hasService(tracer));
+        List<InterceptStrategy> interceptStrategies = context.getCamelContextExtension().getInterceptStrategies();
+        boolean found = false;
+        for (InterceptStrategy is: interceptStrategies) {
+            if (is instanceof NoopTracingStrategy) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Noop Tracing Strategy should have been added");
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayTest.java
+++ b/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CamelAwsXRayTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.aws.xray.starter;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.aws.xray.TraceAnnotatedTracingStrategy;
+import org.apache.camel.component.aws.xray.XRayTracer;
+import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DirtiesContext
+@TestPropertySource(locations = "/default.properties")
+@CamelSpringBootTest
+@SpringBootTest(classes = { CamelAutoConfiguration.class, CamelAwsXRayTest.class, AwsXRayAutoConfiguration.class })
+public class CamelAwsXRayTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Autowired
+    private XRayTracer tracer;
+
+    @Test
+    public void testTraceAnnotatedTracingStrategy() {
+        assertTrue(context.hasService(tracer));
+        Set<String> excludePatterns = tracer.getExcludePatterns();
+        assertTrue(excludePatterns.contains("excludeme"));
+        assertTrue(excludePatterns.contains("foobar"));
+        assertEquals(2, excludePatterns.size());
+        List<InterceptStrategy> interceptStrategies = context.getCamelContextExtension().getInterceptStrategies();
+        boolean found = false;
+        for (InterceptStrategy is: interceptStrategies) {
+            if (is instanceof TraceAnnotatedTracingStrategy) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Tracing Strategy should have been added");
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CustomAwsXRayTracingStrategy.java
+++ b/components-starter/camel-aws-xray-starter/src/test/java/org/apache/camel/aws/xray/starter/CustomAwsXRayTracingStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.aws.xray.starter;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.NamedNode;
+import org.apache.camel.Processor;
+import org.apache.camel.spi.InterceptStrategy;
+import org.apache.camel.support.processor.DelegateAsyncProcessor;
+
+@CamelAwsXRayTracingStrategy
+public class CustomAwsXRayTracingStrategy implements InterceptStrategy {
+
+    @Override
+    public Processor wrapProcessorInInterceptors(
+            CamelContext camelContext, NamedNode processorDefinition,
+            Processor target, Processor nextTarget) {
+        // custom logic here
+        return new DelegateAsyncProcessor(target);
+    }
+}

--- a/components-starter/camel-aws-xray-starter/src/test/resources/default.properties
+++ b/components-starter/camel-aws-xray-starter/src/test/resources/default.properties
@@ -1,0 +1,1 @@
+camel.aws-xray.exclude-patterns=excludeme,foobar

--- a/components-starter/camel-aws-xray-starter/src/test/resources/disabled.properties
+++ b/components-starter/camel-aws-xray-starter/src/test/resources/disabled.properties
@@ -1,0 +1,1 @@
+camel.aws-xray.enabled=false

--- a/components-starter/camel-aws-xray-starter/src/test/resources/noop.properties
+++ b/components-starter/camel-aws-xray-starter/src/test/resources/noop.properties
@@ -1,0 +1,1 @@
+camel.aws-xray.tracing-strategy=noop


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-20868

Enables and configures Camel AWS XRay tracing when _camel-aws-xray-starter_ is added to the classpath. This also adds a _CamelAwsXRayTracingStrategy_ annotation so a custom tracing strategy can be easily used instead of the default _TraceAnnotatedTracingStrategy_.

 Thanks !

