### PR TITLE
Upgrade avro-version to 1.12.0 to match camel

### DIFF
--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroLookupResolverTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroLookupResolverTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.jackson.avro.springboot.test;
 
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
 
+import org.apache.avro.NameValidator;
 import org.apache.avro.Schema;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
@@ -57,7 +58,7 @@ public class JacksonAvroLookupResolverTest {
     private SchemaResolver getSchemaResolver() {
         String schemaJson = "{\n" + "\"type\": \"record\",\n" + "\"name\": \"Pojo\",\n" + "\"fields\": [\n"
                 + " {\"name\": \"text\", \"type\": \"string\"}\n" + "]}";
-        Schema raw = new Schema.Parser().setValidate(true).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalJsonNodeTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalJsonNodeTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
 
+import org.apache.avro.NameValidator;
 import org.apache.avro.Schema;
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
@@ -70,10 +71,10 @@ public class JacksonAvroMarshalUnmarshalJsonNodeTest {
                 + "    \"type\":\"record\",\n" + "    \"fields\":[\n"
                 + "      {\"name\":\"text\", \"type\":\"string\"}\n" + "    ]\n" + "  }\n" + "}";
 
-        Schema raw = new Schema.Parser().setValidate(true).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
 
-        Schema rawList = new Schema.Parser().setValidate(true).parse(listSchemaJson);
+        Schema rawList = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(listSchemaJson);
         AvroSchema schemaList = new AvroSchema(rawList);
 
         SchemaResolver resolver = ex -> {

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoListTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoListTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
 
+import org.apache.avro.NameValidator;
 import org.apache.avro.Schema;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
@@ -62,7 +63,7 @@ public class JacksonAvroMarshalUnmarshalPojoListTest {
         String schemaJson = "{\n" + "  \"type\": \"array\",  \n" + "  \"items\":{\n" + "    \"name\":\"Pojo\",\n"
                 + "    \"type\":\"record\",\n" + "    \"fields\":[\n"
                 + "      {\"name\":\"text\", \"type\":\"string\"}\n" + "    ]\n" + "  }\n" + "}";
-        Schema raw = new Schema.Parser().setValidate(true).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.jackson.avro.springboot.test;
 
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
 
+import org.apache.avro.NameValidator;
 import org.apache.avro.Schema;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
@@ -57,7 +58,7 @@ public class JacksonAvroMarshalUnmarshalPojoTest {
     private SchemaResolver getSchemaResolver() {
         String schemaJson = "{\n" + "\"type\": \"record\",\n" + "\"name\": \"Pojo\",\n" + "\"fields\": [\n"
                 + " {\"name\": \"text\", \"type\": \"string\"}\n" + "]}";
-        Schema raw = new Schema.Parser().setValidate(true).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <aether-version>1.0.2.v20150114</aether-version>
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
-        <avro-version>1.11.0</avro-version>
+        <avro-version>1.12.0</avro-version>
         <groovy-version>4.0.13</groovy-version>
         <graal-sdk-version>22.3.2</graal-sdk-version>
         <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -255,22 +255,22 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-ipc</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-protobuf</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>


### PR DESCRIPTION
Camel is using avro-version 1.12.0 https://github.com/apache/camel/blob/main/parent/pom.xml#L75

Update the version of avro to 1.12.0.     The one API change I found was in avro Schema.Parser, changing setValidate(true) to Parser(NameValidator.STRICT_VALIDATOR).     Ran the tests on camel-avro* and camel-*-avro and it seems okay to me.