### PR TITLE
CAMEL-21243 Add dependencyManagement entry for org.osgi:org.osgi.core for camel-braintree-starter

### DIFF
--- a/components-starter/camel-braintree-starter/pom.xml
+++ b/components-starter/camel-braintree-starter/pom.xml
@@ -28,6 +28,18 @@
   <packaging>jar</packaging>
   <name>Camel SB Starters :: Braintree</name>
   <description>Spring-Boot Starter for Camel Braintree support</description>
+  <properties>
+    <camel-braintree-osgi-version>4.2.0</camel-braintree-osgi-version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <version>${camel-braintree-osgi-version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-21243

org.osgi:org.osgi.core:8.0.0 does not exist - the last version was 6.0.0, and then it was renamed to org.osgi:osgi.core - https://mvnrepository.com/artifact/org.osgi/osgi.core  - my build is asking for version 8.0.0 though

com.braintreepayments.gateway:braintree-java:3.35.0 uses org.osgi:org.osgi.core:4.2.0 https://repo1.maven.org/maven2/com/braintreepayments/gateway/braintree-java/3.35.0/braintree-java-3.35.0.pom