### PR TITLE
Use SB Async Interceptor

### DIFF
--- a/components-starter/camel-platform-http-starter/pom.xml
+++ b/components-starter/camel-platform-http-starter/pom.xml
@@ -61,6 +61,10 @@
       <version>${jetty-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -27,6 +27,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.env.Environment;
 
+import java.util.concurrent.Executor;
+
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(name = { "org.apache.camel.component.servlet.springboot.PlatformHttpComponentAutoConfiguration",
         "org.apache.camel.component.servlet.springboot.PlatformHttpComponentConverter" })
@@ -35,11 +37,14 @@ public class SpringBootPlatformHttpAutoConfiguration {
     @Autowired
     CamelContext camelContext;
 
+    @Autowired
+    Executor executor;
+
     @Bean(name = "platform-http-engine")
     @ConditionalOnMissingBean(PlatformHttpEngine.class)
     public PlatformHttpEngine springBootPlatformHttpEngine(Environment env) {
         int port = Integer.parseInt(env.getProperty("server.port", "8080"));
-        return new SpringBootPlatformHttpEngine(port);
+        return new SpringBootPlatformHttpEngine(port, executor);
     }
 
     @Bean


### PR DESCRIPTION
The previous implementation was not using full Async code therefore we noticed issues under some circumstances.

The following implementation uses the Async interceptor provided by Spring Boot, right now the stack trace is similar to a plain Spring Boot Async RestController.