### PR TITLE
Use camel-jetty component rather than camel-jetty-starter to prevent circular dependency

### DIFF
--- a/core/camel-spring-boot-xml/pom.xml
+++ b/core/camel-spring-boot-xml/pom.xml
@@ -93,9 +93,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jetty-starter</artifactId>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jetty</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I'm finding a circular dependency in the use of camel-jetty-starter as a test resource in camel-spring-boot-xml - in a clean build camel-jetty-starter is never built by the time that camel-spring-boot-xml tries to build.

I poked around and I think what's required by the test case isn't the camel-jetty-starter but only the camel-jetty component as the only reference is here inside of a camelContext:

https://github.com/apache/camel-spring-boot/blob/main/core/camel-spring-boot-xml/src/test/resources/spring-camel-context.xml#L28