### PR TITLE
camel-jolokia-starter: Enables discovery on local environment

### DIFF
--- a/components-starter/camel-jolokia-starter/src/main/docs/jolokia.adoc
+++ b/components-starter/camel-jolokia-starter/src/main/docs/jolokia.adoc
@@ -29,6 +29,7 @@ Moreover, it is possible to configure the Jolokia server accessing to the config
 according to https://jolokia.org/reference/html/manual/agents.html#jvm-agent-installation[Jolokia agent configuration]
 using `camel.component.jolokia.server-config` map configuration,
 i.e. `camel.component.jolokia.server-config.port=8779` or `camel.component.jolokia.server-config.authMode=jaas`
+ The value of the `discoveryEnabled` configuration key is set to `true` on JVM local environment (not on Kubernetes), to allow the Hawtio process to discover the Jolokia agent. It is possible to disable the default configuration by setting `camel.component.jolokia.server-config.discoveryEnabled=false`.
 
 To avoid to expose all the JMX MBeans (see https://jolokia.org/reference/html/manual/security.html[Security] considerations),
 it is provided a default Jolokia https://jolokia.org/reference/html/manual/security.html#security-restrictor[Restrictor]

--- a/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfiguration.java
+++ b/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfiguration.java
@@ -89,6 +89,7 @@ public class JolokiaComponentAutoConfiguration {
 			setDefaultConfigValue(ConfigKey.RESTRICTOR_CLASS.getKeyValue(),
 					"org.apache.camel.component.jolokia.springboot.restrictor.CamelRestrictor");
 		}
+		boolean k8sSet = false;
 		if (configuration.isKubernetesDiscover()) {
 			LOG.debug("trying to discover k8s environment");
 			final String caCert = configuration.isKubernetesUseDefaultCa() ? DEFAULT_CA_ON_K8S
@@ -97,9 +98,14 @@ public class JolokiaComponentAutoConfiguration {
 				setDefaultConfigValue("protocol", "https");
 				setDefaultConfigValue("useSslClientAuthentication", "true");
 				setDefaultConfigValue("caCert", caCert);
+				k8sSet = true;
 			} else {
 				LOG.debug("kubernetesDiscover is enabled but the file {} does not exist, no additional properties will be set", caCert);
 			}
+		}
+		//enable discovery on local JVM not in a POD
+		if (!k8sSet && !Files.exists(Path.of(DEFAULT_CA_ON_K8S))) {
+			setDefaultConfigValue("discoveryEnabled", "true");
 		}
 		springJolokiaConfigHolder.setConfig(configuration.getServerConfig());
 		return springJolokiaConfigHolder;

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationDiscoveryDisabledTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationDiscoveryDisabledTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jolokia.springboot;
+
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {CamelAutoConfiguration.class, JolokiaComponentAutoConfiguration.class},
+		properties = {"camel.component.jolokia.serverConfig.port=0"
+				, "camel.component.jolokia.server-config.discoveryEnabled=false"})
+public class JolokiaComponentAutoConfigurationDiscoveryDisabledTest extends JolokiaComponentTestBase {
+
+	@Test
+	void discoveryDisabledByPropertyTest() {
+		assertDiscoveryEnabled(false);
+	}
+}

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationOnK8STest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationOnK8STest.java
@@ -69,5 +69,7 @@ public class JolokiaComponentAutoConfigurationOnK8STest extends JolokiaComponent
 				.hasFieldOrPropertyWithValue("context", "/jolokia/")
 				.hasFieldOrPropertyWithValue("useSslClientAuthentication", true)
 				.hasFieldOrProperty("caCert").isNotNull();
+
+		assertDiscoveryEnabled(false);
 	}
 }

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationTest.java
@@ -78,7 +78,8 @@ public class JolokiaComponentAutoConfigurationTest extends JolokiaComponentTestB
 				.asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
 				.containsEntry("host", "0.0.0.0")
 				.containsEntry("autoStart", "true")
-				.containsEntry("restrictorClass", CamelRestrictor.class.getCanonicalName());
+				.containsEntry("restrictorClass", CamelRestrictor.class.getCanonicalName())
+				.containsEntry("discoveryEnabled", "true");
 
 		Assertions.assertThat(agent).as("check default agent/server configuration")
 				.hasFieldOrPropertyWithValue("lookupConfig", false)
@@ -89,5 +90,7 @@ public class JolokiaComponentAutoConfigurationTest extends JolokiaComponentTestB
 				.extracting("config")
 					.hasFieldOrPropertyWithValue("protocol", "http")
 					.hasFieldOrPropertyWithValue("context", "/jolokia/");
+
+		assertDiscoveryEnabled(true);
 	}
 }

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentTestBase.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentTestBase.java
@@ -20,6 +20,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jolokia.server.core.config.ConfigKey;
 import org.jolokia.support.spring.SpringJolokiaAgent;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -31,5 +34,16 @@ class JolokiaComponentTestBase {
 	@BeforeEach
 	void checkAgentIsAutoWired() {
 		assertThat(agent).isNotNull();
+	}
+
+	protected void assertDiscoveryEnabled(boolean value) {
+		Assertions.assertThat(agent).as("check Discovery feature configuration")
+				.extracting("serviceManager")
+				.extracting("configuration")
+				.extracting("configMap")
+				.asInstanceOf(InstanceOfAssertFactories.map(ConfigKey.class, String.class))
+				.extractingByKey(ConfigKey.DISCOVERY_ENABLED)
+				.isNotNull()
+				.isEqualTo(String.valueOf(value));
 	}
 }


### PR DESCRIPTION
in local environment it can be useful to have the discovery feature enabled by default, so that from Hawtio UI the agent is automatically discovered, instead of adding the connection manually