### PR TITLE
Remove jolokia-version, use the jolokia-version from camel/parent/pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>
 	    <cyclonedx-maven-plugin-version>2.8.1</cyclonedx-maven-plugin-version>
-        <jolokia-version>2.1.1</jolokia-version>
     </properties>
 
 


### PR DESCRIPTION
camel/parent.xml has a jolokia-version https://github.com/cunningt/camel-spring-boot/pull/new/jolokiavers

I'd like to remove the jolokia-version specified in camel-spring-boot in favor of the camel version (less properties to maintain).    Ran the camel-jolokia-starter tests and they pass with camel's jolokia-version (2.1.2).