### PR TITLE
Remove jolokia-version from camel-spring-boot in favor of version from camel/parent.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>
 	    <cyclonedx-maven-plugin-version>2.8.1</cyclonedx-maven-plugin-version>
-        <jolokia-version>2.1.1</jolokia-version>
     </properties>
 
 

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -220,27 +220,27 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-commons</artifactId>
-        <version>1.13.6</version>
+        <version>1.13.8</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-observation</artifactId>
-        <version>1.13.6</version>
+        <version>1.13.8</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-jmx</artifactId>
-        <version>1.13.6</version>
+        <version>1.13.8</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>1.13.6</version>
+        <version>1.13.8</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-tracing</artifactId>
-        <version>1.3.5</version>
+        <version>1.3.6</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
camel/parent/pom.xml has a jolokia-version https://github.com/apache/camel/blob/camel-4.8.x/parent/pom.xml#L286

Remove the jolokia-version from camel-spring-boot in favor of inheriting that version (less versions to maintain)