### PR TITLE
Revert "CAMEL-21387: camel-opentelemetry-starter add default dependen…

### DIFF
--- a/components-starter/camel-opentelemetry-starter/pom.xml
+++ b/components-starter/camel-opentelemetry-starter/pom.xml
@@ -39,15 +39,6 @@
       <artifactId>camel-opentelemetry</artifactId>
       <version>${camel-version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${spring-boot-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-tracing-bridge-otel</artifactId>
-    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>


### PR DESCRIPTION
…cies for basic setup (#1268)"

This reverts commit 6c8feedbd326d52f14363941a950041e863d4042.

Let's revert this and default to having the OTEL Java agent setup instrumentation by default (like we do in our examples). There are subtle changes in SB vs agent configuration (more spans, default exporters) which might be unnecessarily troublesome when upgrading. I will also add some more documentation to make it clear. Hope this ok! cc @Croway 