### PR TITLE
CAMEL-21461: platform-http - add CORS support

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
@@ -23,8 +23,10 @@ import org.apache.camel.component.platform.http.PlatformHttpComponent;
 import org.apache.camel.component.platform.http.PlatformHttpEndpoint;
 import org.apache.camel.component.platform.http.PlatformHttpListener;
 import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
+import org.apache.camel.spi.RestConfiguration;
 import org.apache.camel.util.ReflectionHelper;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -32,12 +34,19 @@ import org.springframework.web.util.ServletRequestPathUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping implements PlatformHttpListener {
 
     private final PlatformHttpComponent component;
     private final PlatformHttpEngine engine;
+
+    private CorsConfiguration corsConfiguration;
 
     public CamelRequestHandlerMapping(PlatformHttpComponent component, PlatformHttpEngine engine) {
         this.component = component;
@@ -68,6 +77,55 @@ public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping imp
     }
 
     @Override
+    protected CorsConfiguration initCorsConfiguration(Object handler, Method method, RequestMappingInfo mappingInfo) {
+        RestConfiguration restConfiguration = component.getCamelContext().getRestConfiguration();
+
+        if (!restConfiguration.isEnableCORS()) {
+            // CORS disabled for camel
+            return null;
+        }
+
+        if (corsConfiguration == null) {
+            Map<String, String> corsHeaders = restConfiguration.getCorsHeaders();
+            corsConfiguration = createCorsConfiguration(corsHeaders != null ? corsHeaders : Collections.emptyMap());
+        }
+        return corsConfiguration;
+    }
+
+    @Override
+    protected CorsConfiguration getCorsConfiguration(Object handler, HttpServletRequest request) {
+        return super.getCorsConfiguration(handler, request);
+    }
+
+    private CorsConfiguration createCorsConfiguration(Map<String, String> corsHeaders) {
+        CorsConfiguration config = new CorsConfiguration();
+
+        String allowedOrigin = corsHeaders.get("Access-Control-Allow-Origin");
+        config.addAllowedOrigin(allowedOrigin != null ? allowedOrigin : RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_ORIGIN);
+
+        String allowMethodsStr = corsHeaders.get("Access-Control-Allow-Methods");
+        allowMethodsStr = allowMethodsStr != null ? allowMethodsStr : RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_METHODS;
+        for (String allowMethod : allowMethodsStr.split(",")) {
+            config.addAllowedMethod(allowMethod.trim());
+        }
+
+        String allowHeadersStr = corsHeaders.get("Access-Control-Allow-Headers");
+        allowHeadersStr = allowHeadersStr != null ? allowHeadersStr : RestConfiguration.CORS_ACCESS_CONTROL_ALLOW_HEADERS;
+        for (String allowHeader : allowHeadersStr.split(",")) {
+            config.addAllowedHeader(allowHeader.trim());
+        }
+
+        String maxAgeStr = corsHeaders.get("Access-Control-Max-Age");
+        Long maxAge = maxAgeStr != null ? Long.parseLong(maxAgeStr) : Long.parseLong(RestConfiguration.CORS_ACCESS_CONTROL_MAX_AGE);
+        config.setMaxAge(maxAge);
+
+        String allowCredentials = corsHeaders.get("Access-Control-Allow-Credentials");
+        config.setAllowCredentials(Boolean.parseBoolean(allowCredentials));
+
+        return config;
+    }
+
+    @Override
     protected HandlerMethod getHandlerInternal(HttpServletRequest request) throws Exception {
         ServletRequestPathUtils.parseAndCache(request);
         return super.getHandlerInternal(request);
@@ -81,7 +139,6 @@ public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping imp
         for (RequestMappingInfo info : requestMappingInfos) {
             // Needed in case of context reload
             unregisterMapping(info);
-
             registerMapping(info, model.getConsumer(), m);
         }
     }
@@ -100,18 +157,29 @@ public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping imp
         if (verbs == null && model.getConsumer() != null) {
             PlatformHttpEndpoint endpoint = (PlatformHttpEndpoint) model.getConsumer().getEndpoint();
             verbs = endpoint.getHttpMethodRestrict();
-
-            for (RequestMethod rm : RequestMethod.values()) {
-                createRequestMappingInfo(model, rm, result);
+            if (verbs == null) {
+                Collections.addAll(methods, RequestMethod.values());
             }
         }
         if (verbs != null) {
             for (String v : model.getVerbs().split(",")) {
                 RequestMethod rm = RequestMethod.resolve(v);
                 methods.add(rm);
-
-                createRequestMappingInfo(model, rm, result);
             }
+        }
+
+        if (component.getCamelContext().getRestConfiguration().isEnableCORS()) {
+            // when CORS is enabled Camel adds OPTIONS by default in httpMethodsRestrict
+            // which causes multiple registration of OPTIONS endpoints in spring.
+            // this causes issues when unregistering endpoints because others share
+            // the same handler (the consumer) so they get unregistered as well.
+            // removing the OPTIONS mappings maintains the intended behavior
+            // of this verb while avoiding this issue.
+            methods.remove(RequestMethod.OPTIONS);
+        }
+
+        for (RequestMethod rm : methods) {
+            createRequestMappingInfo(model, rm, result);
         }
 
         return result;

--- a/components-starter/camel-platform-http-starter/src/test/resources/application.properties
+++ b/components-starter/camel-platform-http-starter/src/test/resources/application.properties
@@ -15,5 +15,6 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-#logging.level.org.springframework.web: DEBUG
-#logging.level.org.springframework.boot.web: DEBUG
+#logging.level.org.springframework.web=TRACE
+#logging.level.org.springframework.boot.web=TRACE
+#spring.mvc.log-request-details=true


### PR DESCRIPTION
Enable CORS support when using platform-http.

I'm unsure if this caching [here](https://github.com/rinaldodev/camel-spring-boot/blob/951244227f5531b2ae4301e0a27907e252e51a34/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java#L86-L90) could be an issue. Do we allow changing CORS configurations after initialization?

```java
  if (corsConfiguration == null) {
      Map<String, String> corsHeaders = restConfiguration.getCorsHeaders();
      corsConfiguration = createCorsConfiguration(corsHeaders != null ? corsHeaders : Collections.emptyMap());
  }
  return corsConfiguration;
```