### PR TITLE
chore: Upgrade Maven compiler plugin to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <graal-sdk-version>22.3.2</graal-sdk-version>
         <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>
         <jaxb-version>2.3.0</jaxb-version>
-        <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
+        <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <maven-javadoc-plugin-version>3.10.0</maven-javadoc-plugin-version>
         <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>


### PR DESCRIPTION
it aligns with version in Camel Core https://github.com/apache/camel/blob/5fe84bcb4269061f057b296a6b53ddda8e6d1f72/pom.xml#L128