### PR TITLE
chore: Upgrade Wiremock Spring Boot version to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
-        <wiremock-spring-boot-version>3.0.2</wiremock-spring-boot-version>
+        <wiremock-spring-boot-version>3.4.0</wiremock-spring-boot-version>
         <spring-session-hazelcast-version>3.3.2</spring-session-hazelcast-version>
     </properties>
 


### PR DESCRIPTION
it aligns with the Spring Boot version used