### PR TITLE
chore: remove unused Groovy property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <avro-version>1.12.0</avro-version>
-        <groovy-version>4.0.13</groovy-version>
         <graal-sdk-version>22.3.2</graal-sdk-version>
         <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>
         <jaxb-version>2.3.0</jaxb-version>


### PR DESCRIPTION
this property was introduced with this commit
https://github.com/apache/camel-spring-boot/commit/c96b417942338355c162701712de3f61534ce52d#diff-3bd5450df7dcb3ed37c45148874e9ef333df5e52678576df6d6711e036670640

it was used in building tools pom which doesn't exist anymore, or t least is not part of camel-spring-boot repository and is only in camel core one. i do not found a reason fo rwhich camel-spring-boot should override this version