### PR TITLE
chore: provide dependabot configuration to update Maven plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: *-plugin


### PR DESCRIPTION
usually Maven plugin dependencies are automatically updated in Camel core and in fact we should be able to have different ones in most cases