### PR TITLE
chore: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     schedule:
       interval: weekly
     allow:
-      - dependency-name: *-plugin
+      - dependency-name: "*-plugin"


### PR DESCRIPTION
the * must be enclosed in quotes to be a valid yaml