### PR TITLE
Align Jakarta Jaxb 4.0.2 with Camel core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <avro-version>1.12.0</avro-version>
         <graal-sdk-version>22.3.2</graal-sdk-version>
-        <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>
+        <jakarta-jaxb-version>4.0.2</jakarta-jaxb-version>
         <jaxb-version>2.3.0</jaxb-version>
         <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>


### PR DESCRIPTION
I'm wondering why it is not inheriting the version from Camel core bom. And if there is a good reason, I guess we should add it to the allow list of dependabot to have automatic updates