### PR TITLE
[CAMEL-21570]: Disable test cases on ppc64le architecture

### DIFF
--- a/components-starter/camel-aws2-cw-starter/pom.xml
+++ b/components-starter/camel-aws2-cw-starter/pom.xml
@@ -61,4 +61,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-aws2-ddb-starter/pom.xml
+++ b/components-starter/camel-aws2-ddb-starter/pom.xml
@@ -66,4 +66,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-aws2-kinesis-starter/pom.xml
+++ b/components-starter/camel-aws2-kinesis-starter/pom.xml
@@ -62,4 +62,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-aws2-s3-starter/pom.xml
+++ b/components-starter/camel-aws2-s3-starter/pom.xml
@@ -66,4 +66,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-aws2-sns-starter/pom.xml
+++ b/components-starter/camel-aws2-sns-starter/pom.xml
@@ -61,4 +61,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-aws2-sqs-starter/pom.xml
+++ b/components-starter/camel-aws2-sqs-starter/pom.xml
@@ -72,4 +72,25 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>ppc64le</id>
+      <activation>
+        <os>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
**JIRA**: [CAMEL-21570](https://issues.apache.org/jira/browse/CAMEL-21570)

**Description**: camel-aws2-cw-starter, camel-aws2-ddb-starter, camel-aws2-kinesis-starter, camel-aws2-s3-starter, camel-aws2-sns-starter, camel-aws2-sqs-starter modules currently fails Upstream CI builds on the ppc64le architecture due to the lack of a supported aws-v2 image for ppc64le. To prevent these failures, the test cases should be disabled on this architecture.

**Test Result:** 
[ppc64le_aws2_cw_main_build_success_logs.txt](https://github.com/user-attachments/files/18252078/ppc64le_aws2_cw_main_build_success_logs.txt)
[ppc64le_aws2_ddb_main_build_success_logs.txt](https://github.com/user-attachments/files/18252079/ppc64le_aws2_ddb_main_build_success_logs.txt)
[ppc64le_aws2_kinesis_main_build_success_logs.txt](https://github.com/user-attachments/files/18252080/ppc64le_aws2_kinesis_main_build_success_logs.txt)
[ppc64le_aws2_s3_main_build_success_logs.txt](https://github.com/user-attachments/files/18252081/ppc64le_aws2_s3_main_build_success_logs.txt)
[ppc64le_aws2_sns_main_build_success_logs.txt](https://github.com/user-attachments/files/18252082/ppc64le_aws2_sns_main_build_success_logs.txt)
[ppc64le_aws2_sqs_main_build_success_logs.txt](https://github.com/user-attachments/files/18252083/ppc64le_aws2_sqs_main_build_success_logs.txt)
