### PR TITLE
[CAMEL-21581]: Remove ppc64le-specific maven profile for hashicorp-vault-starter

### DIFF
--- a/components-starter/camel-hashicorp-vault-starter/pom.xml
+++ b/components-starter/camel-hashicorp-vault-starter/pom.xml
@@ -64,29 +64,4 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
-  <profiles>
-    <profile>
-      <id>ppc64le</id>
-      <activation>
-        <os>
-          <arch>ppc64le</arch>
-        </os>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <skipITs>${skipTests}</skipITs>
-              <reuseForks>true</reuseForks>
-              <systemPropertyVariables>
-                <hashicorp.vault.container>icr.io/ppc64le-oss/vault-ppc64le:v1.13.1</hashicorp.vault.container>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
**Jira:** https://issues.apache.org/jira/browse/CAMEL-21581
**Description:** 
Removed the ppc64le-specific Maven profile from the camel-hashicorp-vault-starter POM file to simplify the configuration and avoid hardcoding architecture-specific details.
Updated the camel-test-infra to dynamically retrieve the container image details from the [container.properties] file, ensuring a consistent and maintainable approach.
This change allows the appropriate container image to be selected based on the architecture without requiring separate profiles in the POM

**Test Result:**  
[ppc64le_hashicorp_starter_main_build_13.1image.txt](https://github.com/user-attachments/files/18291961/ppc64le_hashicorp_starter_main_build_13.1image.txt)
[x86_hashicorp_starter_main_build_13.1image.txt](https://github.com/user-attachments/files/18291964/x86_hashicorp_starter_main_build_13.1image.txt)
