### PR TITLE
Platform-http do not spawn useless threads

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
@@ -20,10 +20,6 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.platform.http.PlatformHttpEndpoint;
 import org.apache.camel.component.platform.http.spi.PlatformHttpConsumer;
 import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
-import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.aop.interceptor.AsyncExecutionInterceptor;
-import org.springframework.aop.support.DefaultPointcutAdvisor;
-import org.springframework.aop.support.JdkRegexpMethodPointcut;
 
 import java.util.concurrent.Executor;
 
@@ -43,19 +39,7 @@ public class SpringBootPlatformHttpEngine implements PlatformHttpEngine {
 
     @Override
     public PlatformHttpConsumer createConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
-        ProxyFactory factory = new ProxyFactory();
-        factory.setTarget(new SpringBootPlatformHttpConsumer(endpoint, processor));
-
-        JdkRegexpMethodPointcut jdkRegexpMethodPointcut = new JdkRegexpMethodPointcut();
-        jdkRegexpMethodPointcut.setPattern("org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpConsumer.service");
-
-        DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor();
-        advisor.setAdvice(new AsyncExecutionInterceptor(executor));
-        advisor.setPointcut(jdkRegexpMethodPointcut);
-
-        factory.addAdvisor(advisor);
-
-        return (SpringBootPlatformHttpConsumer) factory.getProxy();
+        return new SpringBootPlatformHttpConsumer(endpoint, processor, executor);
     }
 
     @Override

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
@@ -44,7 +44,7 @@ public class SpringBootPlatformHttpEngine implements PlatformHttpEngine {
     @Override
     public PlatformHttpConsumer createConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
         ProxyFactory factory = new ProxyFactory();
-        factory.setTarget(new SpringBootPlatformHttpConsumer(endpoint, processor, executor));
+        factory.setTarget(new SpringBootPlatformHttpConsumer(endpoint, processor));
 
         JdkRegexpMethodPointcut jdkRegexpMethodPointcut = new JdkRegexpMethodPointcut();
         jdkRegexpMethodPointcut.setPattern("org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpConsumer.service");

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
@@ -27,11 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -400,8 +398,7 @@ public class SpringBootPlatformHttpCertificationTest extends PlatformHttpBase {
                         detailedCookie()
                                 .value("bar")
                                 .path(CookieConfiguration.DEFAULT_PATH)
-                                .domain((String) null)
-                                .sameSite(CookieConfiguration.DEFAULT_SAME_SITE.getValue()))
+                                .domain((String) null))
                 .body(equalTo("add"));
     }
 }


### PR DESCRIPTION
The previous implementation was creating 2 threads per request, the first one, created by spring framework via AsyncExecutionInterceptor, and the second one with `CompletableFuture.runAsync`.

This PR avoids the creation of the 2nd thread, this way, the behavior is like plain Spring Boot `@Async`. And the Apache Camel thread pool can be controlled via 
```
spring.task.execution.pool.max-size=10
spring.task.execution.pool.core-size=10
``` 

While improving this behavior I faced an issue with the return object of the service method, in particular, as you can see from https://github.com/apache/camel-spring-boot/compare/main...Croway:suboptimal-thread-usage?expand=1#diff-7844a79d0aab67af46e8f0538438aa37f3c8b8afb04072724cc78fcf8acb17f5R84 the method still returns CompletableFuture, though I am not doing a runAsync or supplyAsync (the service method is already running asynchronously) and the return is `CompletableFuture.completedFuture(null)`.

I tried using `void` instead of `CompletableFuture`, but I was getting the following error `The request object has been recycled and is no longer associated with this facade` when accessing the HttpServletRequest Object, I do not fully understand this behavior, maybe Spring expects a completable future.