### PR TITLE
CAMEL-21701: Make single file upload easy to access from message body

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/docs/platform-http.json
+++ b/components-starter/camel-platform-http-starter/src/main/docs/platform-http.json
@@ -17,15 +17,13 @@
       "name": "camel.component.platform-http.autowired-enabled",
       "type": "java.lang.Boolean",
       "description": "Whether autowiring is enabled. This is used for automatic autowiring options (the option must be marked as autowired) by looking up in the registry to find if there is a single instance of matching type, which then gets configured on the component. This can be used for automatic configuring JDBC data sources, JMS connection factories, AWS Clients, etc.",
-      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration",
-      "defaultValue": true
+      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration"
     },
     {
       "name": "camel.component.platform-http.bridge-error-handler",
       "type": "java.lang.Boolean",
       "description": "Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions (if possible) occurred while the Camel consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. Important: This is only possible if the 3rd party component allows Camel to be alerted if an exception was thrown. Some components handle this internally only, and therefore bridgeErrorHandler is not possible. In other situations we may improve the Camel component to hook into the 3rd party component and make this possible for future releases. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored.",
-      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration",
-      "defaultValue": false
+      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration"
     },
     {
       "name": "camel.component.platform-http.customizer.enabled",
@@ -48,8 +46,7 @@
       "name": "camel.component.platform-http.handle-write-response-error",
       "type": "java.lang.Boolean",
       "description": "When Camel is complete processing the message, and the HTTP server is writing response. This option controls whether Camel should catch any failure during writing response and store this on the Exchange, which allows onCompletion\/UnitOfWork to regard the Exchange as failed and have access to the caused exception from the HTTP server.",
-      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration",
-      "defaultValue": false
+      "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration"
     },
     {
       "name": "camel.component.platform-http.header-filter-strategy",


### PR DESCRIPTION
The behavior is slightly different compared to plain Camel https://github.com/apache/camel/pull/17045

the `attachment.getContent()` in Camel is a String, while, in Camel Spring Boot, a FileInputStream, therefore https://github.com/apache/camel-spring-boot/compare/main...Croway:CAMEL-21701?expand=1#diff-e11e7487d45a9ac2f3cc2803af2694c0d238bc6720d49b1cb9e8f1ea4494a99bR109
