### PR TITLE
Use JSONAssert rather than assertEquals for better failure output / order insensitivity

### DIFF
--- a/components-starter/camel-openapi-java-starter/pom.xml
+++ b/components-starter/camel-openapi-java-starter/pom.xml
@@ -83,6 +83,12 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${jsonassert-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
@@ -33,6 +33,8 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.Test;
 
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,7 +136,7 @@ public class ComplexTypesTest {
                 .collect(Collectors.joining("\n"));
         is.close();
 
-        assertEquals(expected, json);
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
     }
 
     private BeanConfig getBeanConfig(String apiVersion) {

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -4457,7 +4457,7 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.13.1</version>
+        <version>3.15.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hit an error locally with this test and think JSONAssert would make a lot of sense to help debug future errors (better output, not having to worry about order).
