### PR TITLE
camel-infinispan-starter: Add org.infinispan:infinispan-api dependency

### DIFF
--- a/components-starter/camel-infinispan-starter/pom.xml
+++ b/components-starter/camel-infinispan-starter/pom.xml
@@ -68,6 +68,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Before the BOM import the infinispan-api was in test scope, but withe BOM import the infinispan-api is compile scope
clients that imports this starter fails with CNFE of org.infinispan.api.annotations.indexing.option.VectorSimilarity

You can try to run the [infinispan](https://github.com/apache/camel-spring-boot-examples/tree/main/infinispan) example to see how it fails.