### PR TITLE
CAMEL-21801: Add Camel Spring Boot starter

### DIFF
--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/others.properties
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/others.properties
@@ -29,6 +29,7 @@ reactor
 resilience4j
 rxjava
 shiro
+spring-cloud-config
 spring-security
 telemetry-dev
 undertow-spring-security

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/others/spring-cloud-config.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/others/spring-cloud-config.json
@@ -1,0 +1,14 @@
+{
+  "other": {
+    "kind": "other",
+    "name": "spring-cloud-config",
+    "title": "Spring Cloud Config",
+    "description": "Camel Spring Cloud Config support",
+    "deprecated": false,
+    "firstVersion": "4.12.0",
+    "supportLevel": "Preview",
+    "groupId": "org.apache.camel.springboot",
+    "artifactId": "camel-spring-cloud-config-starter",
+    "version": "4.12.0-SNAPSHOT"
+  }
+}

--- a/components-starter/camel-spring-cloud-config-starter/pom.xml
+++ b/components-starter/camel-spring-cloud-config-starter/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.camel.springboot</groupId>
+    <artifactId>components-starter</artifactId>
+    <version>4.12.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>camel-spring-cloud-config-starter</artifactId>
+  <packaging>jar</packaging>
+  <name>Camel SB Starters :: spring-cloud-config</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>${spring-boot-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-cloud-config</artifactId>
+      <version>${camel-version}</version>
+      <!--START OF GENERATED CODE-->
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+      </exclusions>
+      <!--END OF GENERATED CODE-->
+    </dependency>
+    <!--START OF GENERATED CODE-->
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-core-starter</artifactId>
+    </dependency>
+    <!--END OF GENERATED CODE-->
+  </dependencies>
+</project>

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/CamelCloudConfigEnvironmentPostProcessor.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/CamelCloudConfigEnvironmentPostProcessor.java
@@ -1,0 +1,52 @@
+package org.apache.camel.component.spring.cloud.config.springboot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertiesPropertySource;
+
+import java.util.Properties;
+
+public class CamelCloudConfigEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelCloudConfigEnvironmentPostProcessor.class);
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        // Do an early property load, this way the environment is loaded with properties
+        // this post processor will be invoked later on by spring boot
+        ConfigDataEnvironmentPostProcessor.applyTo(environment);
+
+        // Map Camel Spring Config properties to Spring Boot specific properties
+        Properties properties = new Properties();
+        if (environment.containsProperty("camel.vault.spring-config.uris") && !environment.containsProperty("spring.config.import")) {
+            LOG.debug("Converting Camel property \"{}\" to Spring Boot \"{}\"", "camel.vault.spring-config.uris", "spring.config.import");
+            properties.put("spring.config.import", "optional:configserver:" + environment.getProperty("camel.vault.spring-config.uris"));
+        }
+        convertPropertyIfExists(environment, "spring.cloud.config.username", "camel.vault.spring-config.username", properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.password", "camel.vault.spring-config.password", properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.label", "camel.vault.spring-config.label", properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.token", "camel.vault.spring-config.token", properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.profile", "camel.vault.spring-config.profile", properties);
+
+        environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-spring-cloud-config-properties", properties));
+    }
+
+    private void convertPropertyIfExists(ConfigurableEnvironment environment,
+                                         String springPropertyName,
+                                         String camelPropertyName,
+                                         Properties properties) {
+        if (environment.containsProperty(camelPropertyName) && !environment.containsProperty(springPropertyName)) {
+            LOG.debug("Converting Camel property \"{}\" to Spring Boot \"{}\"", camelPropertyName, springPropertyName);
+            properties.put(springPropertyName, environment.getProperty(camelPropertyName));
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return ConfigDataEnvironmentPostProcessor.ORDER - 1;
+    }
+}

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/CamelCloudConfigEnvironmentPostProcessor.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/CamelCloudConfigEnvironmentPostProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.spring.cloud.config.springboot;
 
 import org.slf4j.Logger;
@@ -22,23 +38,30 @@ public class CamelCloudConfigEnvironmentPostProcessor implements EnvironmentPost
 
         // Map Camel Spring Config properties to Spring Boot specific properties
         Properties properties = new Properties();
-        if (environment.containsProperty("camel.vault.spring-config.uris") && !environment.containsProperty("spring.config.import")) {
-            LOG.debug("Converting Camel property \"{}\" to Spring Boot \"{}\"", "camel.vault.spring-config.uris", "spring.config.import");
-            properties.put("spring.config.import", "optional:configserver:" + environment.getProperty("camel.vault.spring-config.uris"));
+        if (environment.containsProperty("camel.vault.spring-config.uris")
+                && !environment.containsProperty("spring.config.import")) {
+            LOG.debug("Converting Camel property \"{}\" to Spring Boot \"{}\"", "camel.vault.spring-config.uris",
+                    "spring.config.import");
+            properties.put("spring.config.import",
+                    "optional:configserver:" + environment.getProperty("camel.vault.spring-config.uris"));
         }
-        convertPropertyIfExists(environment, "spring.cloud.config.username", "camel.vault.spring-config.username", properties);
-        convertPropertyIfExists(environment, "spring.cloud.config.password", "camel.vault.spring-config.password", properties);
-        convertPropertyIfExists(environment, "spring.cloud.config.label", "camel.vault.spring-config.label", properties);
-        convertPropertyIfExists(environment, "spring.cloud.config.token", "camel.vault.spring-config.token", properties);
-        convertPropertyIfExists(environment, "spring.cloud.config.profile", "camel.vault.spring-config.profile", properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.username", "camel.vault.spring-config.username",
+                properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.password", "camel.vault.spring-config.password",
+                properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.label", "camel.vault.spring-config.label",
+                properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.token", "camel.vault.spring-config.token",
+                properties);
+        convertPropertyIfExists(environment, "spring.cloud.config.profile", "camel.vault.spring-config.profile",
+                properties);
 
-        environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-spring-cloud-config-properties", properties));
+        environment.getPropertySources()
+                .addFirst(new PropertiesPropertySource("overridden-camel-spring-cloud-config-properties", properties));
     }
 
-    private void convertPropertyIfExists(ConfigurableEnvironment environment,
-                                         String springPropertyName,
-                                         String camelPropertyName,
-                                         Properties properties) {
+    private void convertPropertyIfExists(ConfigurableEnvironment environment, String springPropertyName,
+            String camelPropertyName, Properties properties) {
         if (environment.containsProperty(camelPropertyName) && !environment.containsProperty(springPropertyName)) {
             LOG.debug("Converting Camel property \"{}\" to Spring Boot \"{}\"", camelPropertyName, springPropertyName);
             properties.put(springPropertyName, environment.getProperty(camelPropertyName));

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.spring.cloud.config.springboot;
 
 import org.apache.camel.component.spring.cloud.config.SpringCloudConfigPropertiesFunction;
@@ -21,27 +37,26 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
         Properties properties = new Properties();
         ConfigurableEnvironment environment = event.getEnvironment();
 
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.spring-cloud-config.early-resolve-properties"))) {
+        if (Boolean.parseBoolean(
+                environment.getProperty("camel.component.spring-cloud-config.early-resolve-properties"))) {
             SpringCloudConfigPropertiesFunction springCloudConfigPropertiesFunction = new SpringCloudConfigPropertiesFunction();
             springCloudConfigPropertiesFunction.setEnvironment(environment);
             for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
                 if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
                     mapPropertySource.getSource().forEach((key, value) -> {
                         String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
+                        if ((value instanceof OriginTrackedValue originTrackedValue
+                                && originTrackedValue.getValue() instanceof String v)) {
                             stringValue = v;
                         } else if (value instanceof String v) {
                             stringValue = v;
                         }
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{spring-config:") &&
-                                stringValue.endsWith("}}")) {
+                        if (stringValue != null && stringValue.startsWith("{{spring-config:")
+                                && stringValue.endsWith("}}")) {
                             LOG.debug("decrypting and overriding property {}", key);
                             try {
-                                String element = springCloudConfigPropertiesFunction.apply(stringValue
-                                        .replace("{{spring-config:", "")
-                                        .replace("}}", ""));
+                                String element = springCloudConfigPropertiesFunction
+                                        .apply(stringValue.replace("{{spring-config:", "").replace("}}", ""));
                                 properties.put(key, element);
                             } catch (Exception e) {
                                 // Log and do nothing
@@ -51,7 +66,8 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
                     });
                 }
             }
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-spring-config-properties", properties));
+            environment.getPropertySources()
+                    .addFirst(new PropertiesPropertySource("overridden-camel-spring-config-properties", properties));
         }
     }
 }

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
@@ -1,0 +1,57 @@
+package org.apache.camel.component.spring.cloud.config.springboot;
+
+import org.apache.camel.component.spring.cloud.config.SpringCloudConfigPropertiesFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.origin.OriginTrackedValue;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+
+import java.util.Properties;
+
+public class SpringBootCloudConfigPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+    private static final Logger LOG = LoggerFactory.getLogger(SpringBootCloudConfigPropertiesParser.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+        Properties properties = new Properties();
+        ConfigurableEnvironment environment = event.getEnvironment();
+
+        if (Boolean.parseBoolean(environment.getProperty("camel.component.spring-cloud-config.early-resolve-properties"))) {
+            SpringCloudConfigPropertiesFunction springCloudConfigPropertiesFunction = new SpringCloudConfigPropertiesFunction();
+            springCloudConfigPropertiesFunction.setEnvironment(environment);
+            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
+                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
+                    mapPropertySource.getSource().forEach((key, value) -> {
+                        String stringValue = null;
+                        if ((value instanceof OriginTrackedValue originTrackedValue &&
+                                originTrackedValue.getValue() instanceof String v)) {
+                            stringValue = v;
+                        } else if (value instanceof String v) {
+                            stringValue = v;
+                        }
+                        if (stringValue != null &&
+                                stringValue.startsWith("{{spring-config:") &&
+                                stringValue.endsWith("}}")) {
+                            LOG.debug("decrypting and overriding property {}", key);
+                            try {
+                                String element = springCloudConfigPropertiesFunction.apply(stringValue
+                                        .replace("{{spring-config:", "")
+                                        .replace("}}", ""));
+                                properties.put(key, element);
+                            } catch (Exception e) {
+                                // Log and do nothing
+                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                            }
+                        }
+                    });
+                }
+            }
+            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-spring-config-properties", properties));
+        }
+    }
+}

--- a/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/LICENSE.txt
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/NOTICE.txt
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/spring.factories
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,22 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+org.springframework.context.ApplicationListener=\
+  org.apache.camel.component.spring.cloud.config.springboot.SpringBootCloudConfigPropertiesParser
+
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.apache.camel.component.spring.cloud.config.springboot.CamelCloudConfigEnvironmentPostProcessor

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -404,6 +404,7 @@
     <module>camel-splunk-hec-starter</module>
     <module>camel-splunk-starter</module>
     <module>camel-spring-batch-starter</module>
+    <module>camel-spring-cloud-config-starter</module>
     <module>camel-spring-jdbc-starter</module>
     <module>camel-spring-ldap-starter</module>
     <module>camel-spring-rabbitmq-starter</module>

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1590,6 +1590,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-spring-cloud-config-starter</artifactId>
+        <version>4.12.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-spring-jdbc-starter</artifactId>
         <version>4.12.0-SNAPSHOT</version>
       </dependency>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -1834,6 +1834,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-spring-cloud-config-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-spring-jdbc-starter</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
The starter does not add much since spring-cloud-config is already integrated with Spring Boot, but, this PR adds an Early Properties function converter, for example, an application.properties like
```
my.db.pass={{spring-config:myPass}}
```
is resolved at runtime.

The other feature `CamelCloudConfigEnvironmentPostProcessor`, is a translation of custom Apache Camel spring cloud config properties to the Spring Boot ones, this way we'll hook into the SB lifecycle with the expected properties, this is handy in case of prototyping with plain Camel, and then export the project to Camel Spring Boot. 