### PR TITLE
Fixed special logic in getRawPath

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
@@ -297,12 +297,8 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
 
     @Override
     protected String getRawPath(HttpServletRequest request) {
-        String uri = request.getRequestURI();
         String contextPath = request.getContextPath() == null ? "" : request.getContextPath();
         String servletPath = request.getServletPath() == null ? "" : request.getServletPath();
-        if (contextPath.isEmpty()) {
-            return servletPath;
-        }
-        return uri.substring(contextPath.length() + servletPath.length());
+        return contextPath + servletPath;
     }
 }


### PR DESCRIPTION
camel-openapi-validation still doesn't work with contract-first rest api's, if server.servlet.context-path is non-empty.

This pull request simplifies and fixes logic in getRawPath(), so that it works correctly with or without a non-empty context-path.

Note that if accepted, this fix should also be cherry-picked/applied to the camel-spring-boot-4.10.x branch.