### PR TITLE
fix(starters): camel observation events not in metrics

### DIFF
--- a/components-starter/camel-observation-starter/src/main/java/org/apache/camel/observation/starter/ObservationAutoConfiguration.java
+++ b/components-starter/camel-observation-starter/src/main/java/org/apache/camel/observation/starter/ObservationAutoConfiguration.java
@@ -16,8 +16,12 @@
  */
 package org.apache.camel.observation.starter;
 
+import io.micrometer.core.instrument.observation.MeterObservationHandler;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingAwareMeterObservationHandler;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.observation.MicrometerObservationTracer;
 
@@ -58,4 +62,18 @@ public class ObservationAutoConfiguration {
 
         return micrometerObservationTracer;
     }
+
+    @Bean
+    // No-op version to suppress metric creation which may explode the length
+    // of actuator as seen in CAMEL-22349
+    public TracingAwareMeterObservationHandler<Observation.Context> tracingAwareMeterObservationHandler(Tracer tracer) {
+        return new TracingAwareMeterObservationHandler<>(
+            new MeterObservationHandler<Observation.Context>() {},
+            tracer
+        ) {
+            @Override
+            public void onEvent(Observation.Event event, Observation.Context context) {}
+        };
+    }
+
 }

--- a/components-starter/camel-observation-starter/src/main/java/org/apache/camel/observation/starter/ObservationConfigurationProperties.java
+++ b/components-starter/camel-observation-starter/src/main/java/org/apache/camel/observation/starter/ObservationConfigurationProperties.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.observation.starter;
 
-import java.util.Set;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "camel.observation")


### PR DESCRIPTION
We need to filter the default TracingAwareMeterObservationHandler handler which is in charge to treat Observations as regular metrics. By providing a NOOP implementation, the framework will treat the regular trace only, without affecting `/metrics` endpoint at all.

Closes CAMEL-22349