### PR TITLE
UndertowMetricsAutoConfiguration enabled if actuator in classpath

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/actuate/metrics/undertow/UndertowMetricsAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/actuate/metrics/undertow/UndertowMetricsAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnWebApplication
-@ConditionalOnClass({ Undertow.class, MeterBinder.class })
+@ConditionalOnClass({ Undertow.class, MeterBinder.class, CompositeMeterRegistryAutoConfiguration.class })
 public class UndertowMetricsAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
to avoid `java.lang.IllegalArgumentException: Could not find class [org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration]` in case the application doesn't have the actuator on the dependencies