### PR TITLE
MultipartProperties moved around in ServletMapping

### DIFF
--- a/components-starter/camel-servlet-starter/src/main/java/org/apache/camel/component/servlet/springboot/ServletMappingAutoConfiguration.java
+++ b/components-starter/camel-servlet-starter/src/main/java/org/apache/camel/component/servlet/springboot/ServletMappingAutoConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.boot.servlet.autoconfigure.MultipartProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/commits/decc32dde3c04c980466f6f5bc7b25f17ca99c69/spring-boot-project/spring-boot-servlet/src/main/java/org/springframework/boot/servlet/autoconfigure/MultipartProperties.java?browsing_rename_history=true&new_path=module/spring-boot-servlet/src/main/java/org/springframework/boot/servlet/autoconfigure/MultipartProperties.java&original_branch=0b601118bdc3c35d161c9ae58e25d9b104609a65

They moved this around per the spring framework commit linked.  I'm not sure this is the right answer in totality, but... its a start.  For instance, its unclear to me how this can exist in BOTH situations of 3.5 compatibility and 4.0 compatibility - maybe some of the conditional-on-class type annotations could alternate between two different possible beans or something? 

