### PR TITLE
Remove spring-boot-version; inherited from camel-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,7 @@
         <jdk.version>17</jdk.version>
         <compiler.fork>false</compiler.fork>
 
-        <!-- Spring-Boot target version -->
-        <spring-boot-version>3.5.6</spring-boot-version>
+        <!-- spring-boot-version is now maintained in camel/parent/pom.xml https://github.com/apache/camel/blob/main/parent/pom.xml#L484 -->
 
         <!-- Camel target version -->
         <camel-version>4.15.0-SNAPSHOT</camel-version>


### PR DESCRIPTION
https://github.com/apache/camel/pull/19395 introduced a spring-boot-version to camel/parent/pom.xml because it is required for jbang in the camel project.     Adding it to camel-parent means it is now available in camel-dependencies, which is the parent for org.apache.camel.springboot:spring-boot (https://github.com/apache/camel-spring-boot/blob/main/pom.xml#L23-L27).

I think we can remove the spring-boot version here to avoid duplication/avoid any conflict of versions.