### PR TITLE
CAMEL-22760: Bridge spring.kafka.* properties to camel-kafka component

### DIFF
--- a/components-starter/camel-kafka-starter/pom.xml
+++ b/components-starter/camel-kafka-starter/pom.xml
@@ -52,6 +52,12 @@
       </exclusions>
       -->
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-kafka</artifactId>
+      <version>${spring-boot-version}</version>
+      <optional>true</optional>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
+++ b/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
@@ -42,10 +43,14 @@ import org.springframework.core.io.Resource;
  * <p>
  * If a property is explicitly set under {@code camel.component.kafka.*}, it takes
  * precedence over the corresponding {@code spring.kafka.*} property.
+ * <p>
+ * This bridge is enabled by default. Set {@code camel.component.kafka.bridge-spring-kafka-properties=false}
+ * to disable it.
  */
 @AutoConfiguration(after = KafkaAutoConfiguration.class, before = KafkaComponentAutoConfiguration.class)
 @ConditionalOnClass(KafkaProperties.class)
 @ConditionalOnBean(KafkaProperties.class)
+@ConditionalOnProperty(name = "camel.component.kafka.bridge-spring-kafka-properties", matchIfMissing = true)
 public class SpringKafkaPropertiesAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringKafkaPropertiesAutoConfiguration.class);

--- a/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
+++ b/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka.springboot;
+
+import java.util.Collections;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
+
+/**
+ * Auto-configuration that bridges Spring Boot's {@code spring.kafka.*} properties
+ * to the Camel Kafka component configuration ({@code camel.component.kafka.*}).
+ * <p>
+ * This allows users to configure Kafka once using standard Spring Boot properties
+ * and have the Camel Kafka component automatically pick up those settings, without
+ * needing to duplicate configuration under {@code camel.component.kafka.*}.
+ * <p>
+ * If a property is explicitly set under {@code camel.component.kafka.*}, it takes
+ * precedence over the corresponding {@code spring.kafka.*} property.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(KafkaProperties.class)
+@AutoConfigureBefore(KafkaComponentAutoConfiguration.class)
+public class SpringKafkaPropertiesAutoConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringKafkaPropertiesAutoConfiguration.class);
+
+    private final KafkaProperties kafkaProperties;
+    private final KafkaComponentConfiguration camelKafkaConfig;
+    private final Environment environment;
+
+    public SpringKafkaPropertiesAutoConfiguration(
+            KafkaProperties kafkaProperties,
+            KafkaComponentConfiguration camelKafkaConfig,
+            Environment environment) {
+        this.kafkaProperties = kafkaProperties;
+        this.camelKafkaConfig = camelKafkaConfig;
+        this.environment = environment;
+    }
+
+    @PostConstruct
+    public void bridgeProperties() {
+        // Get the set of camel.component.kafka.* properties explicitly set by the user
+        Map<String, Object> camelKafkaProps = Binder.get(environment)
+                .bind("camel.component.kafka", Bindable.mapOf(String.class, Object.class))
+                .orElse(Collections.emptyMap());
+
+        boolean bridged = false;
+
+        // Bootstrap servers
+        if (!camelKafkaProps.containsKey("brokers")
+                && kafkaProperties.getBootstrapServers() != null
+                && !kafkaProperties.getBootstrapServers().isEmpty()) {
+            String brokers = String.join(",", kafkaProperties.getBootstrapServers());
+            camelKafkaConfig.setBrokers(brokers);
+            LOG.debug("Bridged spring.kafka.bootstrap-servers -> camel.component.kafka.brokers: {}", brokers);
+            bridged = true;
+        }
+
+        // Client ID
+        if (!camelKafkaProps.containsKey("client-id")
+                && kafkaProperties.getClientId() != null) {
+            camelKafkaConfig.setClientId(kafkaProperties.getClientId());
+            LOG.debug("Bridged spring.kafka.client-id -> camel.component.kafka.client-id");
+            bridged = true;
+        }
+
+        // Security protocol
+        if (!camelKafkaProps.containsKey("security-protocol")
+                && kafkaProperties.getSecurity() != null
+                && kafkaProperties.getSecurity().getProtocol() != null) {
+            camelKafkaConfig.setSecurityProtocol(kafkaProperties.getSecurity().getProtocol());
+            LOG.debug("Bridged spring.kafka.security.protocol -> camel.component.kafka.security-protocol");
+            bridged = true;
+        }
+
+        // Consumer group ID
+        if (!camelKafkaProps.containsKey("group-id")
+                && kafkaProperties.getConsumer() != null
+                && kafkaProperties.getConsumer().getGroupId() != null) {
+            camelKafkaConfig.setGroupId(kafkaProperties.getConsumer().getGroupId());
+            LOG.debug("Bridged spring.kafka.consumer.group-id -> camel.component.kafka.group-id");
+            bridged = true;
+        }
+
+        // SSL properties
+        bridged |= bridgeSslProperties(camelKafkaProps);
+
+        // SASL properties from spring.kafka.properties map
+        bridged |= bridgeSaslProperties(camelKafkaProps);
+
+        if (bridged) {
+            LOG.info("Bridged spring.kafka.* properties to camel.component.kafka.*");
+        }
+    }
+
+    private boolean bridgeSslProperties(Map<String, Object> camelKafkaProps) {
+        KafkaProperties.Ssl ssl = kafkaProperties.getSsl();
+        if (ssl == null) {
+            return false;
+        }
+
+        boolean bridged = false;
+
+        if (!camelKafkaProps.containsKey("ssl-key-password") && ssl.getKeyPassword() != null) {
+            camelKafkaConfig.setSslKeyPassword(ssl.getKeyPassword());
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-keystore-location") && ssl.getKeyStoreLocation() != null) {
+            camelKafkaConfig.setSslKeystoreLocation(resourceToPath(ssl.getKeyStoreLocation()));
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-keystore-password") && ssl.getKeyStorePassword() != null) {
+            camelKafkaConfig.setSslKeystorePassword(ssl.getKeyStorePassword());
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-keystore-type") && ssl.getKeyStoreType() != null) {
+            camelKafkaConfig.setSslKeystoreType(ssl.getKeyStoreType());
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-truststore-location") && ssl.getTrustStoreLocation() != null) {
+            camelKafkaConfig.setSslTruststoreLocation(resourceToPath(ssl.getTrustStoreLocation()));
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-truststore-password") && ssl.getTrustStorePassword() != null) {
+            camelKafkaConfig.setSslTruststorePassword(ssl.getTrustStorePassword());
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-truststore-type") && ssl.getTrustStoreType() != null) {
+            camelKafkaConfig.setSslTruststoreType(ssl.getTrustStoreType());
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("ssl-protocol") && ssl.getProtocol() != null) {
+            camelKafkaConfig.setSslProtocol(ssl.getProtocol());
+            bridged = true;
+        }
+
+        if (bridged) {
+            LOG.debug("Bridged spring.kafka.ssl.* properties to camel.component.kafka.ssl-*");
+        }
+        return bridged;
+    }
+
+    private boolean bridgeSaslProperties(Map<String, Object> camelKafkaProps) {
+        Map<String, String> rawProps = kafkaProperties.getProperties();
+        if (rawProps == null || rawProps.isEmpty()) {
+            return false;
+        }
+
+        boolean bridged = false;
+
+        if (!camelKafkaProps.containsKey("sasl-mechanism")
+                && rawProps.containsKey("sasl.mechanism")) {
+            camelKafkaConfig.setSaslMechanism(rawProps.get("sasl.mechanism"));
+            LOG.debug("Bridged spring.kafka.properties[sasl.mechanism] -> camel.component.kafka.sasl-mechanism");
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("sasl-jaas-config")
+                && rawProps.containsKey("sasl.jaas.config")) {
+            camelKafkaConfig.setSaslJaasConfig(rawProps.get("sasl.jaas.config"));
+            LOG.debug("Bridged spring.kafka.properties[sasl.jaas.config] -> camel.component.kafka.sasl-jaas-config");
+            bridged = true;
+        }
+        if (!camelKafkaProps.containsKey("sasl-kerberos-service-name")
+                && rawProps.containsKey("sasl.kerberos.service.name")) {
+            camelKafkaConfig.setSaslKerberosServiceName(rawProps.get("sasl.kerberos.service.name"));
+            LOG.debug("Bridged spring.kafka.properties[sasl.kerberos.service.name] -> camel.component.kafka.sasl-kerberos-service-name");
+            bridged = true;
+        }
+
+        return bridged;
+    }
+
+    private static String resourceToPath(Resource resource) {
+        try {
+            return resource.getFile().getAbsolutePath();
+        } catch (Exception e) {
+            try {
+                return resource.getURI().toString();
+            } catch (Exception ex) {
+                return resource.toString();
+            }
+        }
+    }
+}

--- a/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
+++ b/components-starter/camel-kafka-starter/src/main/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesAutoConfiguration.java
@@ -16,19 +16,19 @@
  */
 package org.apache.camel.component.kafka.springboot;
 
-import java.util.Collections;
 import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 
@@ -43,16 +43,19 @@ import org.springframework.core.io.Resource;
  * If a property is explicitly set under {@code camel.component.kafka.*}, it takes
  * precedence over the corresponding {@code spring.kafka.*} property.
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = KafkaAutoConfiguration.class, before = KafkaComponentAutoConfiguration.class)
 @ConditionalOnClass(KafkaProperties.class)
-@AutoConfigureBefore(KafkaComponentAutoConfiguration.class)
+@ConditionalOnBean(KafkaProperties.class)
 public class SpringKafkaPropertiesAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringKafkaPropertiesAutoConfiguration.class);
 
+    private static final String CAMEL_KAFKA_PREFIX = "camel.component.kafka.";
+    private static final String SPRING_KAFKA_PREFIX = "spring.kafka.";
+
     private final KafkaProperties kafkaProperties;
     private final KafkaComponentConfiguration camelKafkaConfig;
-    private final Environment environment;
+    private final Binder binder;
 
     public SpringKafkaPropertiesAutoConfiguration(
             KafkaProperties kafkaProperties,
@@ -60,22 +63,16 @@ public class SpringKafkaPropertiesAutoConfiguration {
             Environment environment) {
         this.kafkaProperties = kafkaProperties;
         this.camelKafkaConfig = camelKafkaConfig;
-        this.environment = environment;
+        this.binder = Binder.get(environment);
     }
 
     @PostConstruct
     public void bridgeProperties() {
-        // Get the set of camel.component.kafka.* properties explicitly set by the user
-        Map<String, Object> camelKafkaProps = Binder.get(environment)
-                .bind("camel.component.kafka", Bindable.mapOf(String.class, Object.class))
-                .orElse(Collections.emptyMap());
-
         boolean bridged = false;
 
-        // Bootstrap servers
-        if (!camelKafkaProps.containsKey("brokers")
-                && kafkaProperties.getBootstrapServers() != null
-                && !kafkaProperties.getBootstrapServers().isEmpty()) {
+        // Bootstrap servers — KafkaProperties defaults to ["localhost:9092"],
+        // so we must check if the user explicitly set spring.kafka.bootstrap-servers
+        if (!isCamelPropertyBound("brokers") && isSpringPropertyBound("bootstrap-servers")) {
             String brokers = String.join(",", kafkaProperties.getBootstrapServers());
             camelKafkaConfig.setBrokers(brokers);
             LOG.debug("Bridged spring.kafka.bootstrap-servers -> camel.component.kafka.brokers: {}", brokers);
@@ -83,15 +80,14 @@ public class SpringKafkaPropertiesAutoConfiguration {
         }
 
         // Client ID
-        if (!camelKafkaProps.containsKey("client-id")
-                && kafkaProperties.getClientId() != null) {
+        if (!isCamelPropertyBound("client-id") && kafkaProperties.getClientId() != null) {
             camelKafkaConfig.setClientId(kafkaProperties.getClientId());
             LOG.debug("Bridged spring.kafka.client-id -> camel.component.kafka.client-id");
             bridged = true;
         }
 
         // Security protocol
-        if (!camelKafkaProps.containsKey("security-protocol")
+        if (!isCamelPropertyBound("security-protocol")
                 && kafkaProperties.getSecurity() != null
                 && kafkaProperties.getSecurity().getProtocol() != null) {
             camelKafkaConfig.setSecurityProtocol(kafkaProperties.getSecurity().getProtocol());
@@ -100,7 +96,7 @@ public class SpringKafkaPropertiesAutoConfiguration {
         }
 
         // Consumer group ID
-        if (!camelKafkaProps.containsKey("group-id")
+        if (!isCamelPropertyBound("group-id")
                 && kafkaProperties.getConsumer() != null
                 && kafkaProperties.getConsumer().getGroupId() != null) {
             camelKafkaConfig.setGroupId(kafkaProperties.getConsumer().getGroupId());
@@ -109,17 +105,17 @@ public class SpringKafkaPropertiesAutoConfiguration {
         }
 
         // SSL properties
-        bridged |= bridgeSslProperties(camelKafkaProps);
+        bridged |= bridgeSslProperties();
 
         // SASL properties from spring.kafka.properties map
-        bridged |= bridgeSaslProperties(camelKafkaProps);
+        bridged |= bridgeSaslProperties();
 
         if (bridged) {
             LOG.info("Bridged spring.kafka.* properties to camel.component.kafka.*");
         }
     }
 
-    private boolean bridgeSslProperties(Map<String, Object> camelKafkaProps) {
+    private boolean bridgeSslProperties() {
         KafkaProperties.Ssl ssl = kafkaProperties.getSsl();
         if (ssl == null) {
             return false;
@@ -127,35 +123,35 @@ public class SpringKafkaPropertiesAutoConfiguration {
 
         boolean bridged = false;
 
-        if (!camelKafkaProps.containsKey("ssl-key-password") && ssl.getKeyPassword() != null) {
+        if (!isCamelPropertyBound("ssl-key-password") && ssl.getKeyPassword() != null) {
             camelKafkaConfig.setSslKeyPassword(ssl.getKeyPassword());
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-keystore-location") && ssl.getKeyStoreLocation() != null) {
+        if (!isCamelPropertyBound("ssl-keystore-location") && ssl.getKeyStoreLocation() != null) {
             camelKafkaConfig.setSslKeystoreLocation(resourceToPath(ssl.getKeyStoreLocation()));
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-keystore-password") && ssl.getKeyStorePassword() != null) {
+        if (!isCamelPropertyBound("ssl-keystore-password") && ssl.getKeyStorePassword() != null) {
             camelKafkaConfig.setSslKeystorePassword(ssl.getKeyStorePassword());
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-keystore-type") && ssl.getKeyStoreType() != null) {
+        if (!isCamelPropertyBound("ssl-keystore-type") && ssl.getKeyStoreType() != null) {
             camelKafkaConfig.setSslKeystoreType(ssl.getKeyStoreType());
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-truststore-location") && ssl.getTrustStoreLocation() != null) {
+        if (!isCamelPropertyBound("ssl-truststore-location") && ssl.getTrustStoreLocation() != null) {
             camelKafkaConfig.setSslTruststoreLocation(resourceToPath(ssl.getTrustStoreLocation()));
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-truststore-password") && ssl.getTrustStorePassword() != null) {
+        if (!isCamelPropertyBound("ssl-truststore-password") && ssl.getTrustStorePassword() != null) {
             camelKafkaConfig.setSslTruststorePassword(ssl.getTrustStorePassword());
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-truststore-type") && ssl.getTrustStoreType() != null) {
+        if (!isCamelPropertyBound("ssl-truststore-type") && ssl.getTrustStoreType() != null) {
             camelKafkaConfig.setSslTruststoreType(ssl.getTrustStoreType());
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("ssl-protocol") && ssl.getProtocol() != null) {
+        if (!isCamelPropertyBound("ssl-protocol") && ssl.getProtocol() != null) {
             camelKafkaConfig.setSslProtocol(ssl.getProtocol());
             bridged = true;
         }
@@ -166,7 +162,7 @@ public class SpringKafkaPropertiesAutoConfiguration {
         return bridged;
     }
 
-    private boolean bridgeSaslProperties(Map<String, Object> camelKafkaProps) {
+    private boolean bridgeSaslProperties() {
         Map<String, String> rawProps = kafkaProperties.getProperties();
         if (rawProps == null || rawProps.isEmpty()) {
             return false;
@@ -174,19 +170,19 @@ public class SpringKafkaPropertiesAutoConfiguration {
 
         boolean bridged = false;
 
-        if (!camelKafkaProps.containsKey("sasl-mechanism")
+        if (!isCamelPropertyBound("sasl-mechanism")
                 && rawProps.containsKey("sasl.mechanism")) {
             camelKafkaConfig.setSaslMechanism(rawProps.get("sasl.mechanism"));
             LOG.debug("Bridged spring.kafka.properties[sasl.mechanism] -> camel.component.kafka.sasl-mechanism");
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("sasl-jaas-config")
+        if (!isCamelPropertyBound("sasl-jaas-config")
                 && rawProps.containsKey("sasl.jaas.config")) {
             camelKafkaConfig.setSaslJaasConfig(rawProps.get("sasl.jaas.config"));
             LOG.debug("Bridged spring.kafka.properties[sasl.jaas.config] -> camel.component.kafka.sasl-jaas-config");
             bridged = true;
         }
-        if (!camelKafkaProps.containsKey("sasl-kerberos-service-name")
+        if (!isCamelPropertyBound("sasl-kerberos-service-name")
                 && rawProps.containsKey("sasl.kerberos.service.name")) {
             camelKafkaConfig.setSaslKerberosServiceName(rawProps.get("sasl.kerberos.service.name"));
             LOG.debug("Bridged spring.kafka.properties[sasl.kerberos.service.name] -> camel.component.kafka.sasl-kerberos-service-name");
@@ -194,6 +190,22 @@ public class SpringKafkaPropertiesAutoConfiguration {
         }
 
         return bridged;
+    }
+
+    /**
+     * Check if a Camel Kafka property was explicitly bound by the user.
+     * Uses {@link Binder} which properly handles relaxed binding
+     * (camelCase, kebab-case, underscore variants).
+     */
+    private boolean isCamelPropertyBound(String propertyName) {
+        return binder.bind(CAMEL_KAFKA_PREFIX + propertyName, Bindable.of(String.class)).isBound();
+    }
+
+    /**
+     * Check if a Spring Kafka property was explicitly set by the user.
+     */
+    private boolean isSpringPropertyBound(String propertyName) {
+        return binder.bind(SPRING_KAFKA_PREFIX + propertyName, Bindable.of(Object.class)).isBound();
     }
 
     private static String resourceToPath(Resource resource) {

--- a/components-starter/camel-kafka-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/components-starter/camel-kafka-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -17,3 +17,4 @@
 
 org.apache.camel.component.kafka.springboot.KafkaComponentConverter
 org.apache.camel.component.kafka.springboot.KafkaComponentAutoConfiguration
+org.apache.camel.component.kafka.springboot.SpringKafkaPropertiesAutoConfiguration

--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/BinderKeyFormatTest.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/BinderKeyFormatTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka.springboot;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies Binder behavior with different key formats.
+ * This is a regression test ensuring our per-property binding approach
+ * in {@link SpringKafkaPropertiesAutoConfiguration} works correctly,
+ * since Binder does NOT normalize camelCase keys to kebab-case in map bindings.
+ */
+class BinderKeyFormatTest {
+
+    @Test
+    void binderPerPropertyBindHandlesCamelCase() {
+        var env = new StandardEnvironment();
+        env.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "camel.component.kafka.sslKeystoreLocation", "/path/to/keystore"
+        )));
+
+        Binder binder = Binder.get(env);
+
+        // Per-property bind with kebab-case name finds camelCase source (relaxed binding)
+        assertThat(binder.bind("camel.component.kafka.ssl-keystore-location", Bindable.of(String.class)).isBound())
+                .isTrue();
+    }
+
+    @Test
+    void binderPerPropertyBindHandlesKebabCase() {
+        var env = new StandardEnvironment();
+        env.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "camel.component.kafka.ssl-keystore-location", "/path/to/keystore"
+        )));
+
+        Binder binder = Binder.get(env);
+
+        assertThat(binder.bind("camel.component.kafka.ssl-keystore-location", Bindable.of(String.class)).isBound())
+                .isTrue();
+    }
+}

--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesBridgeTest.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesBridgeTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka.springboot;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.kafka.KafkaComponent;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringKafkaPropertiesBridgeTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    CamelAutoConfiguration.class,
+                    KafkaAutoConfiguration.class,
+                    KafkaComponentAutoConfiguration.class,
+                    SpringKafkaPropertiesAutoConfiguration.class));
+
+    @Test
+    void shouldBridgeBootstrapServers() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.bootstrap-servers=broker1:9092,broker2:9092",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getBrokers())
+                            .isEqualTo("broker1:9092,broker2:9092");
+                });
+    }
+
+    @Test
+    void shouldPreferExplicitCamelProperty() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.bootstrap-servers=broker1:9092",
+                        "camel.component.kafka.brokers=my-broker:9092",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getBrokers())
+                            .isEqualTo("my-broker:9092");
+                });
+    }
+
+    @Test
+    void shouldBridgeSecurityProtocol() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.security.protocol=SASL_SSL",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getSecurityProtocol())
+                            .isEqualTo("SASL_SSL");
+                });
+    }
+
+    @Test
+    void shouldBridgeSslProperties() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.ssl.key-store-password=keypass",
+                        "spring.kafka.ssl.key-store-type=PKCS12",
+                        "spring.kafka.ssl.trust-store-password=trustpass",
+                        "spring.kafka.ssl.trust-store-type=PEM",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getSslKeystorePassword())
+                            .isEqualTo("keypass");
+                    assertThat(kafka.getConfiguration().getSslKeystoreType())
+                            .isEqualTo("PKCS12");
+                    assertThat(kafka.getConfiguration().getSslTruststorePassword())
+                            .isEqualTo("trustpass");
+                    assertThat(kafka.getConfiguration().getSslTruststoreType())
+                            .isEqualTo("PEM");
+                });
+    }
+
+    @Test
+    void shouldBridgeConsumerGroupId() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.consumer.group-id=my-group",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getGroupId())
+                            .isEqualTo("my-group");
+                });
+    }
+
+    @Test
+    void shouldBridgeSaslMechanismFromProperties() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.properties.sasl.mechanism=PLAIN",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getSaslMechanism())
+                            .isEqualTo("PLAIN");
+                });
+    }
+
+    @Test
+    void shouldBridgeSaslJaasConfigFromProperties() {
+        String jaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";";
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.properties.sasl.jaas.config=" + jaasConfig,
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getSaslJaasConfig())
+                            .isEqualTo(jaasConfig);
+                });
+    }
+
+    @Test
+    void shouldNotBridgeWhenSpringKafkaNotConfigured() {
+        contextRunner
+                .withPropertyValues(
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    // Default value should remain
+                    assertThat(kafka.getConfiguration().getSecurityProtocol())
+                            .isEqualTo("PLAINTEXT");
+                });
+    }
+
+    @Test
+    void shouldBridgeClientId() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.client-id=my-client",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    assertThat(kafka.getConfiguration().getClientId())
+                            .isEqualTo("my-client");
+                });
+    }
+}

--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesBridgeTest.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/springboot/SpringKafkaPropertiesBridgeTest.java
@@ -20,7 +20,6 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.component.kafka.KafkaComponent;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -170,6 +169,25 @@ class SpringKafkaPropertiesBridgeTest {
                             .getComponent("kafka", KafkaComponent.class);
                     assertThat(kafka.getConfiguration().getClientId())
                             .isEqualTo("my-client");
+                });
+    }
+
+    @Test
+    void shouldNotBridgeWhenDisabled() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.kafka.bootstrap-servers=broker1:9092",
+                        "spring.kafka.security.protocol=SASL_SSL",
+                        "camel.component.kafka.bridge-spring-kafka-properties=false",
+                        "camel.component.kafka.enabled=true")
+                .run(context -> {
+                    KafkaComponent kafka = context.getBean(CamelContext.class)
+                            .getComponent("kafka", KafkaComponent.class);
+                    // Bridge is disabled, so spring.kafka properties should NOT be applied
+                    assertThat(kafka.getConfiguration().getBrokers())
+                            .isNotEqualTo("broker1:9092");
+                    assertThat(kafka.getConfiguration().getSecurityProtocol())
+                            .isEqualTo("PLAINTEXT");
                 });
     }
 }


### PR DESCRIPTION
## Summary

When using `camel-kafka-starter` with Spring Boot, users previously had to duplicate their Kafka configuration under both `spring.kafka.*` and `camel.component.kafka.*` properties. This PR adds automatic bridging so that Spring Boot's standard Kafka properties are picked up by the Camel Kafka component.

### Properties bridged

| Spring Boot (`spring.kafka.*`) | Camel (`camel.component.kafka.*`) |
|---|---|
| `bootstrap-servers` | `brokers` |
| `client-id` | `client-id` |
| `security.protocol` | `security-protocol` |
| `consumer.group-id` | `group-id` |
| `ssl.key-store-location` | `ssl-keystore-location` |
| `ssl.key-store-password` | `ssl-keystore-password` |
| `ssl.key-store-type` | `ssl-keystore-type` |
| `ssl.key-password` | `ssl-key-password` |
| `ssl.trust-store-location` | `ssl-truststore-location` |
| `ssl.trust-store-password` | `ssl-truststore-password` |
| `ssl.trust-store-type` | `ssl-truststore-type` |
| `ssl.protocol` | `ssl-protocol` |
| `properties[sasl.mechanism]` | `sasl-mechanism` |
| `properties[sasl.jaas.config]` | `sasl-jaas-config` |
| `properties[sasl.kerberos.service.name]` | `sasl-kerberos-service-name` |

### Design

- Uses Spring Boot's `Binder` to detect which `camel.component.kafka.*` properties the user explicitly set
- Only bridges a Spring Boot value when the user has NOT explicitly set the corresponding Camel property
- Explicit `camel.component.kafka.*` settings always take precedence
- `@AutoConfigureBefore(KafkaComponentAutoConfiguration.class)` ensures bridging happens before the generated auto-configuration copies properties to the component
- `@ConditionalOnClass(KafkaProperties.class)` ensures it only activates when `spring-boot-kafka` is on the classpath (optional dependency)

## Test plan

- [x] 9 unit tests covering all bridged properties, precedence, and edge cases
- [x] All tests pass
- [ ] CI build passes
- [ ] Integration test with a real Kafka broker (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)