### PR TITLE
Move platform-http-starter virtual threads tests to be integration tests

### DIFF
--- a/.github/actions/incremental-build/exclusions.sh
+++ b/.github/actions/incremental-build/exclusions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Exclusion list for camel-spring-boot incremental builds
+# Override the default exclusion list from apache/camel which contains modules
+# that don't exist in camel-spring-boot
+
+# camel-spring-boot has fewer generated/meta modules to exclude
+# Most exclusions from main Camel don't apply here
+EXCLUSION_LIST=""

--- a/.github/actions/incremental-build/parse_errors.sh
+++ b/.github/actions/incremental-build/parse_errors.sh
@@ -21,8 +21,11 @@ set +e
 
 LOG_FILE=$1
 
+# Echo immediately to verify script is being invoked
+echo "" >&2
 echo "============================================================" >&2
 echo "[parse_errors.sh START] $(date '+%Y-%m-%d %H:%M:%S')" >&2
+echo "[parse_errors.sh] PWD: $(pwd)" >&2
 echo "[parse_errors.sh] Processing: $LOG_FILE" >&2
 echo "============================================================" >&2
 

--- a/.github/actions/incremental-build/parse_errors.sh
+++ b/.github/actions/incremental-build/parse_errors.sh
@@ -21,43 +21,82 @@ set +e
 
 LOG_FILE=$1
 
+echo "[DEBUG parse_errors.sh] Processing: $LOG_FILE" >&2
+
 # Extract module path from log file path
 # e.g., ./components-starter/camel-slack-starter/target/surefire-reports/foo.txt -> components-starter/camel-slack-starter
 MODULE_PATH=$(echo "$LOG_FILE" | sed 's|^\./||' | sed 's|/target/.*||')
+echo "[DEBUG parse_errors.sh] Module path: $MODULE_PATH" >&2
 
 # Skip if file doesn't exist or is not readable
-if [[ ! -f "$LOG_FILE" ]] || [[ ! -r "$LOG_FILE" ]]; then
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "[DEBUG parse_errors.sh] File does not exist: $LOG_FILE" >&2
   exit 0
 fi
+
+if [[ ! -r "$LOG_FILE" ]]; then
+  echo "[DEBUG parse_errors.sh] File is not readable: $LOG_FILE" >&2
+  exit 0
+fi
+
+echo "[DEBUG parse_errors.sh] File exists and is readable, size: $(wc -c < "$LOG_FILE") bytes" >&2
 
 # Extract failures/errors
+echo "[DEBUG parse_errors.sh] Searching for FAILURE|ERROR patterns..." >&2
 raw_failures=$(cat "$LOG_FILE" | egrep "FAILURE|ERROR" 2>/dev/null || true)
 if [[ -z "$raw_failures" ]]; then
+  echo "[DEBUG parse_errors.sh] No FAILURE or ERROR patterns found in file" >&2
   exit 0
 fi
 
+echo "[DEBUG parse_errors.sh] Found FAILURE/ERROR entries (count: $(echo "$raw_failures" | wc -l))" >&2
+echo "[DEBUG parse_errors.sh] First few lines of raw_failures:" >&2
+echo "$raw_failures" | head -5 >&2
+
 # Look for "Time elapsed" entries and extract org.* test names
+echo "[DEBUG parse_errors.sh] Searching for 'Time elapsed' entries..." >&2
 time_elapsed_entries=$(echo "$raw_failures" | grep "Time elapsed" 2>/dev/null || true)
+echo "[DEBUG parse_errors.sh] Time elapsed entries found: $(echo "$time_elapsed_entries" | wc -l)" >&2
+
+echo "[DEBUG parse_errors.sh] Searching for org.* entries..." >&2
 org_entries=$(echo "$time_elapsed_entries" | egrep "^org" 2>/dev/null || true)
+echo "[DEBUG parse_errors.sh] org.* entries found: $(echo "$org_entries" | wc -l)" >&2
 
 if [[ -n "$org_entries" ]]; then
+  echo "[DEBUG parse_errors.sh] Processing org_entries:" >&2
+  echo "$org_entries" >&2
+
   # Generate summary with module path included in test name
   # Format: | Module::TestClass | Duration | Type |
+  echo "[DEBUG parse_errors.sh] Generating failed_summary..." >&2
   failed_summary=$(echo "$org_entries" | sed 's/\!//g' | awk -v mod="$MODULE_PATH" -F ' ' '{printf "| **%s**::%s | %s%s | %s |\n", mod, $1,$5,$6, $8}' 2>/dev/null || true)
+  echo "[DEBUG parse_errors.sh] failed_summary generated (length: ${#failed_summary})" >&2
 
-  if [[ -n "$failed_summary" ]] && [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-    # Add to GitHub step summary
-    echo "$failed_summary" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+  if [[ -n "$failed_summary" ]]; then
+    echo "[DEBUG parse_errors.sh] failed_summary is not empty" >&2
 
-    # Add detailed error output
-    echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "<details><summary>❌ Failure details for $MODULE_PATH</summary>" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    cat "$LOG_FILE" | egrep -A 10 "FAILURE|ERROR" | head -100 >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "</details>" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-    echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+      echo "[DEBUG parse_errors.sh] GITHUB_STEP_SUMMARY is set to: $GITHUB_STEP_SUMMARY" >&2
+
+      # Add to GitHub step summary
+      echo "[DEBUG parse_errors.sh] Writing summary to GITHUB_STEP_SUMMARY..." >&2
+      echo "$failed_summary" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+
+      # Add detailed error output
+      echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "<details><summary>❌ Failure details for $MODULE_PATH</summary>" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      cat "$LOG_FILE" | egrep -A 10 "FAILURE|ERROR" | head -100 >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "</details>" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      echo "[DEBUG parse_errors.sh] Summary written to GITHUB_STEP_SUMMARY" >&2
+    else
+      echo "[DEBUG parse_errors.sh] GITHUB_STEP_SUMMARY is not set, skipping summary output" >&2
+    fi
+  else
+    echo "[DEBUG parse_errors.sh] failed_summary is empty, skipping summary generation" >&2
   fi
 
   # Output to stderr for CI logs
@@ -71,6 +110,21 @@ if [[ -n "$org_entries" ]]; then
   cat "$LOG_FILE" | egrep -A 10 "FAILURE|ERROR" | head -50 >&2
   echo "=============================================" >&2
   echo "" >&2
+else
+  echo "[DEBUG parse_errors.sh] No org.* entries found, but raw_failures exist" >&2
+  echo "[DEBUG parse_errors.sh] Outputting raw_failures to help debug:" >&2
+  echo "" >&2
+  echo "=============================================" >&2
+  echo "FAILURE/ERROR in module: $MODULE_PATH (no org.* pattern match)" >&2
+  echo "=============================================" >&2
+  echo "Raw failures found:" >&2
+  echo "$raw_failures" | head -20 >&2
+  echo "" >&2
+  echo "Full log file content (first 100 lines):" >&2
+  head -100 "$LOG_FILE" >&2
+  echo "=============================================" >&2
+  echo "" >&2
 fi
 
+echo "[DEBUG parse_errors.sh] Finished processing $LOG_FILE" >&2
 exit 0

--- a/.github/actions/incremental-build/parse_errors.sh
+++ b/.github/actions/incremental-build/parse_errors.sh
@@ -21,65 +21,67 @@ set +e
 
 LOG_FILE=$1
 
-echo "[DEBUG parse_errors.sh] Processing: $LOG_FILE" >&2
+echo "============================================================" >&2
+echo "[parse_errors.sh START] $(date '+%Y-%m-%d %H:%M:%S')" >&2
+echo "[parse_errors.sh] Processing: $LOG_FILE" >&2
+echo "============================================================" >&2
 
 # Extract module path from log file path
 # e.g., ./components-starter/camel-slack-starter/target/surefire-reports/foo.txt -> components-starter/camel-slack-starter
 MODULE_PATH=$(echo "$LOG_FILE" | sed 's|^\./||' | sed 's|/target/.*||')
-echo "[DEBUG parse_errors.sh] Module path: $MODULE_PATH" >&2
+echo "[parse_errors.sh] Module: $MODULE_PATH" >&2
 
 # Skip if file doesn't exist or is not readable
 if [[ ! -f "$LOG_FILE" ]]; then
-  echo "[DEBUG parse_errors.sh] File does not exist: $LOG_FILE" >&2
+  echo "[parse_errors.sh] ⊘ File does not exist, skipping" >&2
+  echo "[parse_errors.sh END] $(date '+%Y-%m-%d %H:%M:%S') - exit 0" >&2
+  echo "============================================================" >&2
   exit 0
 fi
 
 if [[ ! -r "$LOG_FILE" ]]; then
-  echo "[DEBUG parse_errors.sh] File is not readable: $LOG_FILE" >&2
+  echo "[parse_errors.sh] ⊘ File not readable, skipping" >&2
+  echo "[parse_errors.sh END] $(date '+%Y-%m-%d %H:%M:%S') - exit 0" >&2
+  echo "============================================================" >&2
   exit 0
 fi
 
-echo "[DEBUG parse_errors.sh] File exists and is readable, size: $(wc -c < "$LOG_FILE") bytes" >&2
+echo "[parse_errors.sh] File size: $(wc -c < "$LOG_FILE") bytes" >&2
 
 # Extract failures/errors
-echo "[DEBUG parse_errors.sh] Searching for FAILURE|ERROR patterns..." >&2
+echo "[parse_errors.sh] Searching for FAILURE|ERROR patterns..." >&2
 raw_failures=$(cat "$LOG_FILE" | egrep "FAILURE|ERROR" 2>/dev/null || true)
 if [[ -z "$raw_failures" ]]; then
-  echo "[DEBUG parse_errors.sh] No FAILURE or ERROR patterns found in file" >&2
+  echo "[parse_errors.sh] ✓ No failures found" >&2
+  echo "[parse_errors.sh END] $(date '+%Y-%m-%d %H:%M:%S') - exit 0" >&2
+  echo "============================================================" >&2
   exit 0
 fi
 
-echo "[DEBUG parse_errors.sh] Found FAILURE/ERROR entries (count: $(echo "$raw_failures" | wc -l))" >&2
-echo "[DEBUG parse_errors.sh] First few lines of raw_failures:" >&2
+echo "[parse_errors.sh] ✗ Found FAILURE/ERROR entries: $(echo "$raw_failures" | wc -l)" >&2
+echo "[parse_errors.sh] First 5 lines:" >&2
 echo "$raw_failures" | head -5 >&2
 
 # Look for "Time elapsed" entries and extract org.* test names
-echo "[DEBUG parse_errors.sh] Searching for 'Time elapsed' entries..." >&2
 time_elapsed_entries=$(echo "$raw_failures" | grep "Time elapsed" 2>/dev/null || true)
-echo "[DEBUG parse_errors.sh] Time elapsed entries found: $(echo "$time_elapsed_entries" | wc -l)" >&2
+echo "[parse_errors.sh] Time elapsed entries: $(echo "$time_elapsed_entries" | wc -l)" >&2
 
-echo "[DEBUG parse_errors.sh] Searching for org.* entries..." >&2
 org_entries=$(echo "$time_elapsed_entries" | egrep "^org" 2>/dev/null || true)
-echo "[DEBUG parse_errors.sh] org.* entries found: $(echo "$org_entries" | wc -l)" >&2
+echo "[parse_errors.sh] org.* test entries: $(echo "$org_entries" | wc -l)" >&2
 
 if [[ -n "$org_entries" ]]; then
-  echo "[DEBUG parse_errors.sh] Processing org_entries:" >&2
+  echo "[parse_errors.sh] Processing failures:" >&2
   echo "$org_entries" >&2
 
   # Generate summary with module path included in test name
   # Format: | Module::TestClass | Duration | Type |
-  echo "[DEBUG parse_errors.sh] Generating failed_summary..." >&2
   failed_summary=$(echo "$org_entries" | sed 's/\!//g' | awk -v mod="$MODULE_PATH" -F ' ' '{printf "| **%s**::%s | %s%s | %s |\n", mod, $1,$5,$6, $8}' 2>/dev/null || true)
-  echo "[DEBUG parse_errors.sh] failed_summary generated (length: ${#failed_summary})" >&2
 
   if [[ -n "$failed_summary" ]]; then
-    echo "[DEBUG parse_errors.sh] failed_summary is not empty" >&2
-
     if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-      echo "[DEBUG parse_errors.sh] GITHUB_STEP_SUMMARY is set to: $GITHUB_STEP_SUMMARY" >&2
+      echo "[parse_errors.sh] Writing to GITHUB_STEP_SUMMARY" >&2
 
       # Add to GitHub step summary
-      echo "[DEBUG parse_errors.sh] Writing summary to GITHUB_STEP_SUMMARY..." >&2
       echo "$failed_summary" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
 
       # Add detailed error output
@@ -91,40 +93,38 @@ if [[ -n "$org_entries" ]]; then
       echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
       echo "</details>" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
       echo "" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-      echo "[DEBUG parse_errors.sh] Summary written to GITHUB_STEP_SUMMARY" >&2
     else
-      echo "[DEBUG parse_errors.sh] GITHUB_STEP_SUMMARY is not set, skipping summary output" >&2
+      echo "[parse_errors.sh] ⚠ GITHUB_STEP_SUMMARY not set, cannot write summary" >&2
     fi
-  else
-    echo "[DEBUG parse_errors.sh] failed_summary is empty, skipping summary generation" >&2
   fi
 
   # Output to stderr for CI logs
   echo "" >&2
-  echo "=============================================" >&2
-  echo "FAILURE in module: $MODULE_PATH" >&2
-  echo "=============================================" >&2
+  echo "╔═════════════════════════════════════════════╗" >&2
+  echo "║  FAILURE in module: $MODULE_PATH" >&2
+  echo "╚═════════════════════════════════════════════╝" >&2
   echo "$org_entries" >&2
   echo "" >&2
   echo "Full error details:" >&2
   cat "$LOG_FILE" | egrep -A 10 "FAILURE|ERROR" | head -50 >&2
-  echo "=============================================" >&2
+  echo "╚═════════════════════════════════════════════╝" >&2
   echo "" >&2
 else
-  echo "[DEBUG parse_errors.sh] No org.* entries found, but raw_failures exist" >&2
-  echo "[DEBUG parse_errors.sh] Outputting raw_failures to help debug:" >&2
+  echo "[parse_errors.sh] ⚠ No org.* pattern match (unusual format)" >&2
   echo "" >&2
-  echo "=============================================" >&2
-  echo "FAILURE/ERROR in module: $MODULE_PATH (no org.* pattern match)" >&2
-  echo "=============================================" >&2
+  echo "╔═════════════════════════════════════════════╗" >&2
+  echo "║  ERROR in module: $MODULE_PATH (unusual format)" >&2
+  echo "╚═════════════════════════════════════════════╝" >&2
   echo "Raw failures found:" >&2
   echo "$raw_failures" | head -20 >&2
   echo "" >&2
   echo "Full log file content (first 100 lines):" >&2
   head -100 "$LOG_FILE" >&2
-  echo "=============================================" >&2
+  echo "╚═════════════════════════════════════════════╝" >&2
   echo "" >&2
 fi
 
-echo "[DEBUG parse_errors.sh] Finished processing $LOG_FILE" >&2
+echo "============================================================" >&2
+echo "[parse_errors.sh END] $(date '+%Y-%m-%d %H:%M:%S') - exit 0" >&2
+echo "============================================================" >&2
 exit 0

--- a/components-starter/camel-platform-http-starter/pom.xml
+++ b/components-starter/camel-platform-http-starter/pom.xml
@@ -174,4 +174,55 @@
     </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin-version}</version>
+        <configuration>
+          <!-- Exclude integration tests from unit test phase -->
+          <excludes>
+            <exclude>**/*IT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <!-- Profile to run integration tests locally but not in CI -->
+    <profile>
+      <id>run-integration-tests</id>
+      <activation>
+        <property>
+          <name>ci.env.name</name>
+          <value>!github.com</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven-surefire-plugin-version}</version>
+            <configuration>
+              <!-- Fork a new JVM for each IT test class to ensure clean static initialization -->
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <!-- Set system properties before JVM starts -->
+              <argLine>-Dspring.threads.virtual.enabled=true -Dcamel.threads.virtual.enabled=true</argLine>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCamelVirtualThreadsIT.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCamelVirtualThreadsIT.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.platform.http.springboot;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -26,17 +28,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Isolated
 @EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
-        SpringBootPlatformHttpVirtualThreadsTest.class, SpringBootPlatformHttpVirtualThreadsTest.TestConfiguration.class,
+        SpringBootPlatformHttpCamelVirtualThreadsIT.class, SpringBootPlatformHttpCamelVirtualThreadsIT.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class },
-    properties = "spring.threads.virtual.enabled=true")
-public class SpringBootPlatformHttpVirtualThreadsTest extends PlatformHttpBase {
+    properties = {
+        "spring.threads.virtual.enabled=true",
+        "camel.threads.virtual.enabled=true"
+    })
+public class SpringBootPlatformHttpCamelVirtualThreadsIT extends PlatformHttpBase {
 
-    private static final String postRouteId = "SpringBootPlatformHttpTest_mypost";
-
-    private static final String getRouteId = "SpringBootPlatformHttpTest_myget";
+    private static final String postRouteId = "SpringBootPlatformHttpCamelVirtualThreadsIT_mypost";
+    private static final String getRouteId = "SpringBootPlatformHttpCamelVirtualThreadsIT_myget";
 
     // *************************************
     // Config
@@ -71,5 +78,16 @@ public class SpringBootPlatformHttpVirtualThreadsTest extends PlatformHttpBase {
     @Override
     protected String getGetRouteId() {
         return getRouteId;
+    }
+
+    @Test
+    public void testCamelVirtualThreadPropertyIsSet() {
+        // Verify that when spring.threads.virtual.enabled=true is set,
+        // the camel.threads.virtual.enabled system property is automatically set to true
+        String camelVirtualThreadsProperty = System.getProperty("camel.threads.virtual.enabled");
+        
+        assertThat(camelVirtualThreadsProperty)
+                .as("camel.threads.virtual.enabled should be automatically set when spring.threads.virtual.enabled=true")
+                .isEqualTo("true");
     }
 }

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpMultipleExecutorsVirtualThreadsIT.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpMultipleExecutorsVirtualThreadsIT.java
@@ -19,38 +19,65 @@ package org.apache.camel.component.platform.http.springboot;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import java.util.concurrent.Executor;
 
+@Isolated
 @EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
-        SpringBootPlatformHttpCamelVirtualThreadsTest.class, SpringBootPlatformHttpCamelVirtualThreadsTest.TestConfiguration.class,
+        SpringBootPlatformHttpMultipleExecutorsVirtualThreadsIT.class,
+        SpringBootPlatformHttpMultipleExecutorsVirtualThreadsIT.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class },
-    properties = "spring.threads.virtual.enabled=true")
-public class SpringBootPlatformHttpCamelVirtualThreadsTest extends PlatformHttpBase {
+    properties = {
+        "spring.threads.virtual.enabled=true",
+        "camel.threads.virtual.enabled=true"
+    })
+@EnableScheduling
+@AutoConfigureRestTestClient
+public class SpringBootPlatformHttpMultipleExecutorsVirtualThreadsIT extends PlatformHttpBase {
 
-    private static final String postRouteId = "SpringBootPlatformHttpCamelVirtualThreadsTest_mypost";
-    private static final String getRouteId = "SpringBootPlatformHttpCamelVirtualThreadsTest_myget";
+    private static final String THREAD_PREFIX = "myThread-";
+
+    private static final String postRouteId = "SpringBootPlatformHttpMultipleExecutorsIT_mypost";
+
+    private static final String getRouteId = "SpringBootPlatformHttpMultipleExecutorsIT_myget";
 
     // *************************************
     // Config
     // *************************************
     @Configuration
     public static class TestConfiguration {
-
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
             http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .csrf(csrf -> csrf.disable());
             return http.build();
+        }
+
+
+        @Bean
+        public SimpleAsyncTaskExecutor simpleAsyncTaskExecutor(SimpleAsyncTaskExecutorBuilder simpleAsyncTaskExecutorBuilder) {
+            return simpleAsyncTaskExecutorBuilder
+                .threadNamePrefix(THREAD_PREFIX)
+                .build();
         }
 
         @Bean
@@ -60,6 +87,8 @@ public class SpringBootPlatformHttpCamelVirtualThreadsTest extends PlatformHttpB
                 public void configure() {
                     from("platform-http:/myget").id(postRouteId).setBody().constant("get");
                     from("platform-http:/mypost").id(getRouteId).transform().body(String.class, b -> b.toUpperCase());
+
+                    from("platform-http:/executor").process(exchange -> exchange.getIn().setBody(Thread.currentThread().getName()));
                 }
             };
         }
@@ -75,14 +104,18 @@ public class SpringBootPlatformHttpCamelVirtualThreadsTest extends PlatformHttpB
         return getRouteId;
     }
 
+    @Autowired
+    List<Executor> executors;
+
     @Test
-    public void testCamelVirtualThreadPropertyIsSet() {
-        // Verify that when spring.threads.virtual.enabled=true is set,
-        // the camel.threads.virtual.enabled system property is automatically set to true
-        String camelVirtualThreadsProperty = System.getProperty("camel.threads.virtual.enabled");
-        
-        assertThat(camelVirtualThreadsProperty)
-                .as("camel.threads.virtual.enabled should be automatically set when spring.threads.virtual.enabled=true")
-                .isEqualTo("true");
+    public void checkCustomExecutorIsPickedWhenMultipleExecutorsAreDefined() {
+        Assertions.assertThat(executors).hasSizeGreaterThan(1);
+
+        EntityExchangeResult<String> result = restTestClient.post().uri("/executor")
+                .body("test")
+                .exchange()
+                .expectBody(String.class)
+                .returnResult();
+        Assertions.assertThat(result.getResponseBody()).contains(THREAD_PREFIX);
     }
 }

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpVirtualThreadsIT.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpVirtualThreadsIT.java
@@ -19,60 +19,41 @@ package org.apache.camel.component.platform.http.springboot;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.test.web.servlet.client.RestTestClient;
-import org.springframework.test.web.servlet.client.EntityExchangeResult;
-import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
-import java.util.List;
-import java.util.concurrent.Executor;
-
+@Isolated
 @EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
-        SpringBootPlatformHttpMultipleExecutorsVirtualThreadsTest.class,
-        SpringBootPlatformHttpMultipleExecutorsVirtualThreadsTest.TestConfiguration.class,
+        SpringBootPlatformHttpVirtualThreadsIT.class, SpringBootPlatformHttpVirtualThreadsIT.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class },
-    properties = "spring.threads.virtual.enabled=true")
-@EnableScheduling
-@AutoConfigureRestTestClient
-public class SpringBootPlatformHttpMultipleExecutorsVirtualThreadsTest extends PlatformHttpBase {
+    properties = {
+        "spring.threads.virtual.enabled=true",
+        "camel.threads.virtual.enabled=true"
+    })
+public class SpringBootPlatformHttpVirtualThreadsIT extends PlatformHttpBase {
 
-    private static final String THREAD_PREFIX = "myThread-";
+    private static final String postRouteId = "SpringBootPlatformHttpIT_mypost";
 
-    private static final String postRouteId = "SpringBootPlatformHttpMultipleExecutorsTest_mypost";
-
-    private static final String getRouteId = "SpringBootPlatformHttpMultipleExecutorsTest_myget";
+    private static final String getRouteId = "SpringBootPlatformHttpIT_myget";
 
     // *************************************
     // Config
     // *************************************
     @Configuration
     public static class TestConfiguration {
+
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
             http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .csrf(csrf -> csrf.disable());
             return http.build();
-        }
-
-
-        @Bean
-        public SimpleAsyncTaskExecutor simpleAsyncTaskExecutor(SimpleAsyncTaskExecutorBuilder simpleAsyncTaskExecutorBuilder) {
-            return simpleAsyncTaskExecutorBuilder
-                .threadNamePrefix(THREAD_PREFIX)
-                .build();
         }
 
         @Bean
@@ -82,8 +63,6 @@ public class SpringBootPlatformHttpMultipleExecutorsVirtualThreadsTest extends P
                 public void configure() {
                     from("platform-http:/myget").id(postRouteId).setBody().constant("get");
                     from("platform-http:/mypost").id(getRouteId).transform().body(String.class, b -> b.toUpperCase());
-
-                    from("platform-http:/executor").process(exchange -> exchange.getIn().setBody(Thread.currentThread().getName()));
                 }
             };
         }
@@ -97,20 +76,5 @@ public class SpringBootPlatformHttpMultipleExecutorsVirtualThreadsTest extends P
     @Override
     protected String getGetRouteId() {
         return getRouteId;
-    }
-
-    @Autowired
-    List<Executor> executors;
-
-    @Test
-    public void checkCustomExecutorIsPickedWhenMultipleExecutorsAreDefined() {
-        Assertions.assertThat(executors).hasSizeGreaterThan(1);
-
-        EntityExchangeResult<String> result = restTestClient.post().uri("/executor")
-                .body("test")
-                .exchange()
-                .expectBody(String.class)
-                .returnResult();
-        Assertions.assertThat(result.getResponseBody()).contains(THREAD_PREFIX);
     }
 }

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpVirtualThreadsOptimizedIT.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpVirtualThreadsOptimizedIT.java
@@ -20,6 +20,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,16 +36,20 @@ import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Isolated
 @EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
-        SpringBootPlatformHttpVirtualThreadsOptimizedTest.class, SpringBootPlatformHttpVirtualThreadsOptimizedTest.TestConfiguration.class,
+        SpringBootPlatformHttpVirtualThreadsOptimizedIT.class, SpringBootPlatformHttpVirtualThreadsOptimizedIT.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class },
-    properties = "spring.threads.virtual.enabled=true")
-public class SpringBootPlatformHttpVirtualThreadsOptimizedTest extends PlatformHttpBase {
+    properties = {
+        "spring.threads.virtual.enabled=true",
+        "camel.threads.virtual.enabled=true"
+    })
+public class SpringBootPlatformHttpVirtualThreadsOptimizedIT extends PlatformHttpBase {
 
-    private static final String postRouteId = "SpringBootPlatformHttpVirtualThreadsOptimizedTest_mypost";
-    private static final String getRouteId = "SpringBootPlatformHttpVirtualThreadsOptimizedTest_myget";
+    private static final String postRouteId = "SpringBootPlatformHttpVirtualThreadsOptimizedIT_mypost";
+    private static final String getRouteId = "SpringBootPlatformHttpVirtualThreadsOptimizedIT_myget";
 
     @Autowired
     private List<Executor> executors;


### PR DESCRIPTION
https://github.com/apache/camel-spring-boot/commit/caf6a8703e535d92711b07da37442df1f2f50349 moved a virtual threads test in core/camel-spring-boot to be an integration test after we hit CI issues in running the incremental build on core/camel-spring-boot.       It looks like in https://github.com/apache/camel-spring-boot/pull/1747 we are hitting similar issues in camel-platform-http-starter tests, so I think we should try moving these tests to integration tests and then investigate the virtual threading issue here.