### PR TITLE
Use JUnit 5 for Camel 4.14.x platform-http-starter tests

### DIFF
--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.platform.http.springboot;
 import io.restassured.RestAssured;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;


### PR DESCRIPTION
## Summary

- Fix compilation failure in `camel-platform-http-starter` on the 4.14.x branch
- The CAMEL-23320 backport introduced 3 test files with `camel-test-spring-junit6` imports, which only exists in 4.19+
- Changed imports from `org.apache.camel.test.spring.junit6` to `org.apache.camel.test.spring.junit5`

Same fix as `fc98fa4f7c5` on `camel-spring-boot-4.18.x`.

## Affected files

- `PlatformHttpBinaryUploadTest.java`
- `SpringBootPlatformHttpHeaderFilterStrategyTest.java`
- `SpringBootPlatformHttpResponseCodeTest.java`