### PR TITLE
ci: set ci.env.name to skip large streaming test on CI

### DIFF
--- a/Jenkinsfile.sb
+++ b/Jenkinsfile.sb
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {

--- a/Jenkinsfile.sb.ppc64le
+++ b/Jenkinsfile.sb.ppc64le
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {


### PR DESCRIPTION
## Summary
- Set `-Dci.env.name=apache.org` in `Jenkinsfile.sb` and `Jenkinsfile.sb.ppc64le` Maven commands

## Context
The `streamingWithLargeRequestAndResponseBody` test creates a 4GB file and OOMs on CI because RestAssured buffers the entire HTTP response into memory. The test already has `@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*")` to skip on CI, but Jenkins wasn't setting the property.

Fixes Camel-Spring-Boot Daily main #75 (FAILURE) and Camel-Spring-Boot Daily ppc64le #1490 (UNSTABLE).