### PR TITLE
ci: fix platform-http test failures on 4.14.x

### DIFF
--- a/Jenkinsfile.sb
+++ b/Jenkinsfile.sb
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {

--- a/Jenkinsfile.sb.ppc64le
+++ b/Jenkinsfile.sb.ppc64le
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTest.java
@@ -20,13 +20,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
-@EnableAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, SecurityAutoConfiguration.class})
+@EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
         SpringBootPlatformHttpTest.class, SpringBootPlatformHttpTest.TestConfiguration.class,
@@ -42,6 +42,13 @@ public class SpringBootPlatformHttpTest extends PlatformHttpBase {
     // *************************************
     @Configuration
     public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
 
         @Bean
         public RouteBuilder servletPlatformHttpRouteBuilder() {


### PR DESCRIPTION
Cherry-pick of #1759 and #1760 to camel-spring-boot-4.14.x.

  - Fix Spring Security config in SpringBootPlatformHttpTest to use SecurityFilterChain instead of excluding SecurityAutoConfiguration (fixes
  PlatformHttpBinaryUploadTest ApplicationContext failure)
  - Add `-Dci.env.name=apache.org` to Jenkinsfile.sb so the 4GB streaming test is properly skipped on CI