### PR TITLE
ci: set ci.env.name to skip large streaming test on CI

### DIFF
--- a/Jenkinsfile.sb
+++ b/Jenkinsfile.sb
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {

--- a/Jenkinsfile.sb.ppc64le
+++ b/Jenkinsfile.sb.ppc64le
@@ -68,7 +68,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                    spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dci.env.name=apache.org -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                 }
             }
             post {


### PR DESCRIPTION
Cherry-pick of #1760 to camel-spring-boot-4.18.x.

  Adds `-Dci.env.name=apache.org` to Jenkinsfile.sb and Jenkinsfile.sb.ppc64le so that `@DisabledIfSystemProperty(named = "ci.env.name")` properly skips the 4GB
  streaming test on CI.