### PR TITLE
CAMEL-23250: Add Spring Boot auto-configuration for security policy properties

### DIFF
--- a/core/camel-spring-boot/src/main/docs/spring-boot.adoc
+++ b/core/camel-spring-boot/src/main/docs/spring-boot.adoc
@@ -502,6 +502,75 @@ management.server.accesslog.pattern=combined
 ----
 
 
+== Security Policy
+
+Camel Spring Boot automatically enforces security policies at startup, detecting insecure configuration such as disabled SSL verification, plain-text secrets, enabled Java deserialization, or development-only features.
+
+The global policy controls how Camel reacts when insecure configuration is detected:
+
+[source,properties]
+----
+# allow  — no warnings, allow the configuration
+# warn   — log a warning at startup (default)
+# fail   — throw an exception and prevent startup
+camel.security.policy=warn
+----
+
+=== Category Overrides
+
+Each security category can override the global policy independently:
+
+[source,properties]
+----
+camel.security.policy=fail
+camel.security.insecure-ssl-policy=warn
+camel.security.insecure-serialization-policy=warn
+camel.security.insecure-dev-policy=allow
+camel.security.secret-policy=fail
+----
+
+To exclude specific properties from all checks, use `allowed-properties`:
+
+[source,properties]
+----
+camel.security.allowed-properties=camel.component.http.trustAllCertificates,camel.component.netty.allowJavaSerializedObject
+----
+
+=== Per-Environment Policies with Spring Profiles
+
+Spring profiles allow you to enforce strict security in production while keeping a relaxed policy during development.
+
+In `application-prod.properties`:
+
+[source,properties]
+----
+camel.security.policy=fail
+----
+
+In `application-dev.properties`:
+
+[source,properties]
+----
+camel.security.policy=allow
+----
+
+Activate the profile via `spring.profiles.active`:
+
+[source,properties]
+----
+# application.properties
+spring.profiles.active=dev
+----
+
+Or at runtime:
+
+[source,bash]
+----
+java -Dspring.profiles.active=prod -jar myApp.jar
+----
+
+This way, developers can freely use options like `trustAllCertificates=true` locally, while production deployments will fail fast if any insecure configuration is detected.
+
 == Virtual Threads Support
 
 Camel Spring Boot provides comprehensive support for JDK 21+ Virtual Threads, offering significant performance improvements for I/O-intensive applications. Virtual threads are lightweight threads that can dramatically reduce memory overhead and improve scalability compared to traditional platform threads.

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot.security;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.main.SecurityConfigurationProperties;
+import org.apache.camel.main.SecurityPolicyResult;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.support.CamelContextHelper;
+import org.apache.camel.util.SecurityUtils;
+import org.apache.camel.util.SecurityViolation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+
+@AutoConfiguration(after = CamelAutoConfiguration.class)
+@ConditionalOnBean(CamelAutoConfiguration.class)
+@EnableConfigurationProperties(CamelSecurityPolicyConfigurationProperties.class)
+public class CamelSecurityPolicyAutoConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSecurityPolicyAutoConfiguration.class);
+
+    @Bean
+    SecurityPolicyResult camelSecurityPolicyResult(
+            CamelContext camelContext,
+            CamelSecurityPolicyConfigurationProperties config,
+            Environment environment) {
+
+        SecurityConfigurationProperties securityConfig = applySecurityProperties(camelContext, config);
+
+        Map<String, Object> camelProperties = extractCamelProperties(environment);
+
+        List<SecurityViolation> violations = SecurityUtils.detectViolations(
+                camelProperties,
+                (k, v) -> containsSensitive(camelContext, k, v),
+                securityConfig::resolvePolicy,
+                securityConfig.getAllowedPropertySet());
+
+        SecurityPolicyResult result = new SecurityPolicyResult(violations);
+        camelContext.getCamelContextExtension().addContextPlugin(SecurityPolicyResult.class, result);
+
+        enforceViolations(violations);
+
+        return result;
+    }
+
+    private SecurityConfigurationProperties applySecurityProperties(
+            CamelContext camelContext,
+            CamelSecurityPolicyConfigurationProperties config) {
+
+        // get the security config from camel-main's MainConfigurationProperties
+        // which is already bound by CamelAutoConfiguration via CamelConfigurationProperties
+        SecurityConfigurationProperties securityConfig
+                = new SecurityConfigurationProperties(null);
+
+        securityConfig.setPolicy(config.getPolicy());
+        if (config.getSecretPolicy() != null) {
+            securityConfig.setSecretPolicy(config.getSecretPolicy());
+        }
+        if (config.getInsecureSslPolicy() != null) {
+            securityConfig.setInsecureSslPolicy(config.getInsecureSslPolicy());
+        }
+        if (config.getInsecureSerializationPolicy() != null) {
+            securityConfig.setInsecureSerializationPolicy(config.getInsecureSerializationPolicy());
+        }
+        if (config.getInsecureDevPolicy() != null) {
+            securityConfig.setInsecureDevPolicy(config.getInsecureDevPolicy());
+        }
+        if (config.getAllowedProperties() != null) {
+            securityConfig.setAllowedProperties(config.getAllowedProperties());
+        }
+
+        return securityConfig;
+    }
+
+    private static Map<String, Object> extractCamelProperties(Environment environment) {
+        Map<String, Object> properties = new LinkedHashMap<>();
+
+        if (environment instanceof ConfigurableEnvironment ce) {
+            ce.getPropertySources().forEach(ps -> {
+                if (ps instanceof EnumerablePropertySource<?> eps) {
+                    for (String name : eps.getPropertyNames()) {
+                        if (name.startsWith("camel.") && !name.startsWith("camel.security.")) {
+                            Object value = environment.getProperty(name);
+                            if (value != null) {
+                                properties.putIfAbsent(name, value);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        return properties;
+    }
+
+    private static boolean containsSensitive(CamelContext camelContext, String key, Object value) {
+        boolean answer = CamelContextHelper.containsSensitive(camelContext, key);
+        if (!answer && value != null) {
+            String v = value.toString();
+            answer = v.startsWith("RAW(");
+        }
+        return answer;
+    }
+
+    private static void enforceViolations(List<SecurityViolation> violations) {
+        List<String> failures = new ArrayList<>();
+        for (SecurityViolation v : violations) {
+            if ("fail".equals(v.policy())) {
+                failures.add(v.toString());
+            } else {
+                LOG.warn("SECURITY WARNING: {}", v);
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new RuntimeCamelException(
+                    "Security policy violations detected (policy=fail):\n - " + String.join("\n - ", failures)
+                                            + "\nTo allow specific properties, add them to camel.security.allowed-properties"
+                                            + " or change the policy to 'warn' or 'allow'.");
+        }
+    }
+
+}

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
@@ -21,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.main.SecurityConfigurationProperties;
@@ -48,19 +47,15 @@ public class CamelSecurityPolicyAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(CamelSecurityPolicyAutoConfiguration.class);
 
     @Bean
-    SecurityPolicyResult camelSecurityPolicyResult(
-            CamelContext camelContext,
-            CamelSecurityPolicyConfigurationProperties config,
-            Environment environment) {
+    SecurityPolicyResult camelSecurityPolicyResult(CamelContext camelContext,
+            CamelSecurityPolicyConfigurationProperties config, Environment environment) {
 
         SecurityConfigurationProperties securityConfig = applySecurityProperties(camelContext, config);
 
         Map<String, Object> camelProperties = extractCamelProperties(environment);
 
-        List<SecurityViolation> violations = SecurityUtils.detectViolations(
-                camelProperties,
-                (k, v) -> containsSensitive(camelContext, k, v),
-                securityConfig::resolvePolicy,
+        List<SecurityViolation> violations = SecurityUtils.detectViolations(camelProperties,
+                (k, v) -> containsSensitive(camelContext, k, v), securityConfig::resolvePolicy,
                 securityConfig.getAllowedPropertySet());
 
         SecurityPolicyResult result = new SecurityPolicyResult(violations);
@@ -71,14 +66,12 @@ public class CamelSecurityPolicyAutoConfiguration {
         return result;
     }
 
-    private SecurityConfigurationProperties applySecurityProperties(
-            CamelContext camelContext,
+    private SecurityConfigurationProperties applySecurityProperties(CamelContext camelContext,
             CamelSecurityPolicyConfigurationProperties config) {
 
         // get the security config from camel-main's MainConfigurationProperties
         // which is already bound by CamelAutoConfiguration via CamelConfigurationProperties
-        SecurityConfigurationProperties securityConfig
-                = new SecurityConfigurationProperties(null);
+        SecurityConfigurationProperties securityConfig = new SecurityConfigurationProperties(null);
 
         securityConfig.setPolicy(config.getPolicy());
         if (config.getSecretPolicy() != null) {
@@ -143,8 +136,8 @@ public class CamelSecurityPolicyAutoConfiguration {
         if (!failures.isEmpty()) {
             throw new RuntimeCamelException(
                     "Security policy violations detected (policy=fail):\n - " + String.join("\n - ", failures)
-                                            + "\nTo allow specific properties, add them to camel.security.allowed-properties"
-                                            + " or change the policy to 'warn' or 'allow'.");
+                            + "\nTo allow specific properties, add them to camel.security.allowed-properties"
+                            + " or change the policy to 'warn' or 'allow'.");
         }
     }
 

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyConfigurationProperties.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyConfigurationProperties.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Security policy configuration for Camel Spring Boot applications.
+ * <p>
+ * Controls how Camel reacts to insecure configuration at startup. Policies can be set globally or per security
+ * category:
+ * <ul>
+ * <li>{@code allow} — no warnings, allow the configuration</li>
+ * <li>{@code warn} — log a warning at startup (default)</li>
+ * <li>{@code fail} — throw an exception and prevent startup</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "camel.security")
+public class CamelSecurityPolicyConfigurationProperties {
+
+    /**
+     * Global security policy applied to all categories unless overridden. Controls how Camel reacts when insecure
+     * configuration is detected at startup.
+     */
+    private String policy = "warn";
+
+    /**
+     * Security policy for plain-text secrets. When set, overrides the global policy for properties that contain
+     * sensitive values configured as plain text.
+     */
+    private String secretPolicy;
+
+    /**
+     * Security policy for insecure SSL/TLS configuration. When set, overrides the global policy for options that
+     * disable certificate validation or hostname verification.
+     */
+    private String insecureSslPolicy;
+
+    /**
+     * Security policy for insecure deserialization configuration. When set, overrides the global policy for options that
+     * enable dangerous deserialization of untrusted data.
+     */
+    private String insecureSerializationPolicy;
+
+    /**
+     * Security policy for development-only features. When set, overrides the global policy for options intended only for
+     * development environments.
+     */
+    private String insecureDevPolicy;
+
+    /**
+     * Comma-separated list of property keys to exclude from security policy checks. Use full property paths (e.g.,
+     * camel.component.aws2-s3.trustAllCertificates) to allow specific properties regardless of the configured policy.
+     */
+    private String allowedProperties;
+
+    public String getPolicy() {
+        return policy;
+    }
+
+    public void setPolicy(String policy) {
+        this.policy = policy;
+    }
+
+    public String getSecretPolicy() {
+        return secretPolicy;
+    }
+
+    public void setSecretPolicy(String secretPolicy) {
+        this.secretPolicy = secretPolicy;
+    }
+
+    public String getInsecureSslPolicy() {
+        return insecureSslPolicy;
+    }
+
+    public void setInsecureSslPolicy(String insecureSslPolicy) {
+        this.insecureSslPolicy = insecureSslPolicy;
+    }
+
+    public String getInsecureSerializationPolicy() {
+        return insecureSerializationPolicy;
+    }
+
+    public void setInsecureSerializationPolicy(String insecureSerializationPolicy) {
+        this.insecureSerializationPolicy = insecureSerializationPolicy;
+    }
+
+    public String getInsecureDevPolicy() {
+        return insecureDevPolicy;
+    }
+
+    public void setInsecureDevPolicy(String insecureDevPolicy) {
+        this.insecureDevPolicy = insecureDevPolicy;
+    }
+
+    public String getAllowedProperties() {
+        return allowedProperties;
+    }
+
+    public void setAllowedProperties(String allowedProperties) {
+        this.allowedProperties = allowedProperties;
+    }
+
+}

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyConfigurationProperties.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyConfigurationProperties.java
@@ -51,14 +51,14 @@ public class CamelSecurityPolicyConfigurationProperties {
     private String insecureSslPolicy;
 
     /**
-     * Security policy for insecure deserialization configuration. When set, overrides the global policy for options that
-     * enable dangerous deserialization of untrusted data.
+     * Security policy for insecure deserialization configuration. When set, overrides the global policy for options
+     * that enable dangerous deserialization of untrusted data.
      */
     private String insecureSerializationPolicy;
 
     /**
-     * Security policy for development-only features. When set, overrides the global policy for options intended only for
-     * development environments.
+     * Security policy for development-only features. When set, overrides the global policy for options intended only
+     * for development environments.
      */
     private String insecureDevPolicy;
 

--- a/core/camel-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/core/camel-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -25,6 +25,7 @@ org.apache.camel.spring.boot.actuate.health.CamelAvailabilityCheckAutoConfigurat
 org.apache.camel.spring.boot.actuate.info.CamelInfoAutoConfiguration
 org.apache.camel.spring.boot.cluster.ClusteredRouteControllerAutoConfiguration
 org.apache.camel.spring.boot.routecontroller.SupervisingRouteControllerAutoConfiguration
+org.apache.camel.spring.boot.security.CamelSecurityPolicyAutoConfiguration
 org.apache.camel.spring.boot.security.CamelSSLAutoConfiguration
 org.apache.camel.spring.boot.threadpool.CamelThreadPoolAutoConfiguration
 org.apache.camel.spring.boot.trace.CamelTraceAutoConfiguration

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.main.SecurityPolicyResult;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+public class CamelSecurityPolicyAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    CamelAutoConfiguration.class,
+                    CamelSecurityPolicyAutoConfiguration.class));
+
+    @Test
+    public void noSecurityPropertiesShouldStartNormally() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+            assertThat(result).isNotNull();
+            assertThat(result.hasViolations()).isFalse();
+        });
+    }
+
+    @Test
+    public void policyAllowShouldIgnoreInsecureConfig() {
+        runner.withPropertyValues(
+                "camel.security.policy=allow",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isFalse();
+                });
+    }
+
+    @Test
+    public void policyWarnShouldStartWithViolations() {
+        runner.withPropertyValues(
+                "camel.security.policy=warn",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isTrue();
+                    assertThat(result.getViolations()).anyMatch(
+                            v -> v.propertyKey().contains("trustAllCertificates") && "warn".equals(v.policy()));
+                });
+    }
+
+    @Test
+    public void policyFailShouldPreventStartup() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(RuntimeCamelException.class)
+                            .hasMessageContaining("Security policy violations detected");
+                });
+    }
+
+    @Test
+    public void categoryOverrideShouldTakePrecedence() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.security.insecure-ssl-policy=allow",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isFalse();
+                });
+    }
+
+    @Test
+    public void categoryOverrideWarnWhileGlobalFail() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.security.insecure-ssl-policy=warn",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isTrue();
+                    assertThat(result.getViolations()).anyMatch(
+                            v -> "warn".equals(v.policy()));
+                });
+    }
+
+    @Test
+    public void allowedPropertiesShouldExcludeFromChecks() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.security.allowed-properties=camel.component.http.trustAllCertificates",
+                "camel.component.http.trustAllCertificates=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isFalse();
+                });
+    }
+
+    @Test
+    public void multipleViolationsDetected() {
+        runner.withPropertyValues(
+                "camel.security.policy=warn",
+                "camel.component.http.trustAllCertificates=true",
+                "camel.component.netty.allowJavaSerializedObject=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.getViolationCount()).isGreaterThanOrEqualTo(2);
+                });
+    }
+
+    @Test
+    public void insecureDevPolicyOverride() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.security.insecure-dev-policy=allow",
+                "camel.main.devConsoleEnabled=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                });
+    }
+
+    @Test
+    public void insecureSerializationPolicyOverride() {
+        runner.withPropertyValues(
+                "camel.security.policy=fail",
+                "camel.security.insecure-serialization-policy=warn",
+                "camel.component.netty.allowJavaSerializedObject=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isTrue();
+                });
+    }
+
+}

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
@@ -27,10 +27,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 public class CamelSecurityPolicyAutoConfigurationTest {
 
-    private final ApplicationContextRunner runner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(
-                    CamelAutoConfiguration.class,
-                    CamelSecurityPolicyAutoConfiguration.class));
+    private final ApplicationContextRunner runner = new ApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(CamelAutoConfiguration.class, CamelSecurityPolicyAutoConfiguration.class));
 
     @Test
     public void noSecurityPropertiesShouldStartNormally() {
@@ -44,9 +42,7 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void policyAllowShouldIgnoreInsecureConfig() {
-        runner.withPropertyValues(
-                "camel.security.policy=allow",
-                "camel.component.http.trustAllCertificates=true")
+        runner.withPropertyValues("camel.security.policy=allow", "camel.component.http.trustAllCertificates=true")
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
@@ -56,9 +52,7 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void policyWarnShouldStartWithViolations() {
-        runner.withPropertyValues(
-                "camel.security.policy=warn",
-                "camel.component.http.trustAllCertificates=true")
+        runner.withPropertyValues("camel.security.policy=warn", "camel.component.http.trustAllCertificates=true")
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
@@ -70,25 +64,18 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void policyFailShouldPreventStartup() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
-                "camel.component.http.trustAllCertificates=true")
+        runner.withPropertyValues("camel.security.policy=fail", "camel.component.http.trustAllCertificates=true")
                 .run(context -> {
                     assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure())
-                            .rootCause()
-                            .isInstanceOf(RuntimeCamelException.class)
+                    assertThat(context.getStartupFailure()).rootCause().isInstanceOf(RuntimeCamelException.class)
                             .hasMessageContaining("Security policy violations detected");
                 });
     }
 
     @Test
     public void categoryOverrideShouldTakePrecedence() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
-                "camel.security.insecure-ssl-policy=allow",
-                "camel.component.http.trustAllCertificates=true")
-                .run(context -> {
+        runner.withPropertyValues("camel.security.policy=fail", "camel.security.insecure-ssl-policy=allow",
+                "camel.component.http.trustAllCertificates=true").run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isFalse();
@@ -97,26 +84,20 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void categoryOverrideWarnWhileGlobalFail() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
-                "camel.security.insecure-ssl-policy=warn",
-                "camel.component.http.trustAllCertificates=true")
-                .run(context -> {
+        runner.withPropertyValues("camel.security.policy=fail", "camel.security.insecure-ssl-policy=warn",
+                "camel.component.http.trustAllCertificates=true").run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isTrue();
-                    assertThat(result.getViolations()).anyMatch(
-                            v -> "warn".equals(v.policy()));
+                    assertThat(result.getViolations()).anyMatch(v -> "warn".equals(v.policy()));
                 });
     }
 
     @Test
     public void allowedPropertiesShouldExcludeFromChecks() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
+        runner.withPropertyValues("camel.security.policy=fail",
                 "camel.security.allowed-properties=camel.component.http.trustAllCertificates",
-                "camel.component.http.trustAllCertificates=true")
-                .run(context -> {
+                "camel.component.http.trustAllCertificates=true").run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isFalse();
@@ -125,11 +106,8 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void multipleViolationsDetected() {
-        runner.withPropertyValues(
-                "camel.security.policy=warn",
-                "camel.component.http.trustAllCertificates=true",
-                "camel.component.netty.allowJavaSerializedObject=true")
-                .run(context -> {
+        runner.withPropertyValues("camel.security.policy=warn", "camel.component.http.trustAllCertificates=true",
+                "camel.component.netty.allowJavaSerializedObject=true").run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.getViolationCount()).isGreaterThanOrEqualTo(2);
@@ -138,22 +116,16 @@ public class CamelSecurityPolicyAutoConfigurationTest {
 
     @Test
     public void insecureDevPolicyOverride() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
-                "camel.security.insecure-dev-policy=allow",
-                "camel.main.devConsoleEnabled=true")
-                .run(context -> {
+        runner.withPropertyValues("camel.security.policy=fail", "camel.security.insecure-dev-policy=allow",
+                "camel.main.devConsoleEnabled=true").run(context -> {
                     assertThat(context).hasNotFailed();
                 });
     }
 
     @Test
     public void insecureSerializationPolicyOverride() {
-        runner.withPropertyValues(
-                "camel.security.policy=fail",
-                "camel.security.insecure-serialization-policy=warn",
-                "camel.component.netty.allowJavaSerializedObject=true")
-                .run(context -> {
+        runner.withPropertyValues("camel.security.policy=fail", "camel.security.insecure-serialization-policy=warn",
+                "camel.component.netty.allowJavaSerializedObject=true").run(context -> {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isTrue();


### PR DESCRIPTION
## Summary

- Add `CamelSecurityPolicyConfigurationProperties` to expose `camel.security.*` properties via Spring Boot's `@ConfigurationProperties`
- Add `CamelSecurityPolicyAutoConfiguration` that scans all `camel.*` properties from the Spring Environment for security violations (insecure SSL, plain-text secrets, unsafe deserialization, dev features) and enforces the configured policy (allow/warn/fail)
- Stores `SecurityPolicyResult` as a CamelContext plugin for health check integration

### Properties exposed

```properties
camel.security.policy=warn                            # global: allow | warn | fail
camel.security.secret-policy=                         # override for plain-text secrets
camel.security.insecure-ssl-policy=                   # override for SSL/TLS
camel.security.insecure-serialization-policy=          # override for deserialization
camel.security.insecure-dev-policy=                   # override for dev features
camel.security.allowed-properties=                    # comma-separated exclusions
```

## Test plan

- [x] `noSecurityPropertiesShouldStartNormally` — context starts without security config
- [x] `policyAllowShouldIgnoreInsecureConfig` — allow policy suppresses violations
- [x] `policyWarnShouldStartWithViolations` — warn policy logs but allows startup
- [x] `policyFailShouldPreventStartup` — fail policy throws and blocks startup
- [x] `categoryOverrideShouldTakePrecedence` — per-category override (e.g., SSL=allow) overrides global fail
- [x] `categoryOverrideWarnWhileGlobalFail` — per-category warn while global is fail
- [x] `allowedPropertiesShouldExcludeFromChecks` — exclusion list works
- [x] `multipleViolationsDetected` — multiple violations reported
- [x] `insecureDevPolicyOverride` — dev category override
- [x] `insecureSerializationPolicyOverride` — serialization category override
- [x] Full module test suite: 118 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_