### PR TITLE
CAMEL-23365: Ensure kafka integration tests run on Jenkins daily builds

### DIFF
--- a/components-starter/camel-kafka-starter/pom.xml
+++ b/components-starter/camel-kafka-starter/pom.xml
@@ -28,6 +28,9 @@
   <packaging>jar</packaging>
   <name>Camel SB Starters :: Kafka</name>
   <description>Spring-Boot Starter for Camel Kafka support</description>
+  <properties>
+    <camel.failsafe.forkTimeout>600</camel.failsafe.forkTimeout>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -97,6 +100,7 @@
             <systemPropertyVariables>
               <visibleassertions.silence>true</visibleassertions.silence>
               <kafka.instance.type>local-kafka-container</kafka.instance.type>
+              <ci.env.name>${ci.env.name}</ci.env.name>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -135,6 +139,32 @@
       <activation>
         <property>
           <name>env.DOCKER_HOST</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- activate integration test on Apache CI (Jenkins daily) -->
+    <profile>
+      <id>kafka-integration-tests-ci</id>
+      <activation>
+        <property>
+          <name>ci.env.name</name>
+          <value>apache.org</value>
         </property>
       </activation>
       <build>


### PR DESCRIPTION
## Summary

- Define `camel.failsafe.forkTimeout` property (600s) in camel-kafka-starter — this property is defined in `camel-parent` but not inherited by `camel-spring-boot` (which inherits from `camel-dependencies`), causing failsafe configuration to fail when profiles activate
- Add `kafka-integration-tests-ci` Maven profile activated by `-Dci.env.name=apache.org` (already passed by `Jenkinsfile.sb`) to guarantee failsafe execution on Jenkins daily builds
- Forward `ci.env.name` to the failsafe forked JVM so `@DisabledIfSystemProperty` annotations evaluate correctly

## Test plan

- [x] `mvn verify -Dci.env.name=apache.org` in `camel-kafka-starter` — 24 tests run, 0 failures, 1 skipped (async manual commit IT, expected)
- [x] Profile activation verified via `mvn help:active-profiles -Dci.env.name=apache.org`
- [ ] Jenkins daily build runs kafka ITs successfully