### PR TITLE
CAMEL-23378: avoid String to InputStream conversion

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringTypeConverter.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringTypeConverter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.spring.boot;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,13 @@ public class SpringTypeConverter extends TypeConverterSupport {
 
         // do not attempt to convert List -> Map. Ognl expression may use this converter as a fallback expecting null
         if (type.isAssignableFrom(Map.class) && isArrayOrCollection(value)) {
+            return null;
+        }
+
+        // do not attempt to convert String -> InputStream (or subclasses like FileInputStream).
+        // Spring's ObjectToObjectConverter finds FileInputStream(String) constructor and treats
+        // the String value as a file path instead of data content.
+        if (value instanceof String && InputStream.class.isAssignableFrom(type)) {
             return null;
         }
 

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SpringTypeConverterTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SpringTypeConverterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.spring.boot;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -68,6 +70,19 @@ public class SpringTypeConverterTest {
         }
 
         Assertions.assertNull(converter.convertTo(String.class, source));
+    }
+
+    @Test
+    public void testStringToFileInputStreamConversionIsBlocked() {
+        // Spring's ObjectToObjectConverter sees FileInputStream(String) constructor and
+        // treats String content as a file path — must return null so Camel's own converters
+        // handle String -> InputStream correctly
+        Assertions.assertNull(converter.convertTo(FileInputStream.class, null, "some file content"));
+    }
+
+    @Test
+    public void testStringToInputStreamConversionIsBlocked() {
+        Assertions.assertNull(converter.convertTo(InputStream.class, null, "some file content"));
     }
 
     public static class Person {


### PR DESCRIPTION
Spring's ObjectToObjectConverter finds FileInputStream(String) constructor and treats the String value as a file path instead of data content.