### PR TITLE
[4.14.x] Upgrade spring-boot to 3.5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <compiler.fork>false</compiler.fork>
 
         <!-- Spring-Boot target version -->
-        <spring-boot-version>3.5.12</spring-boot-version>
+        <spring-boot-version>3.5.14</spring-boot-version>
 
         <!-- Camel target version -->
         <camel-version>4.14.8-SNAPSHOT</camel-version>


### PR DESCRIPTION
Upgrade spring-boot to 3.5.14 (intended for 4.14 LTS)