### PR TITLE
Fix class cast error in camel-aws2-s3

### DIFF
--- a/components-starter/camel-aws-bedrock-starter/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/springboot/BedrockAgentRuntimeComponentConfiguration.java
+++ b/components-starter/camel-aws-bedrock-starter/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/springboot/BedrockAgentRuntimeComponentConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.camel.component.aws2.bedrock.agentruntime.BedrockAgentRuntimeO
 import org.apache.camel.spring.boot.ComponentConfigurationPropertiesCommon;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import software.amazon.awssdk.core.Protocol;
+import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient;
 
 /**
@@ -114,11 +115,35 @@ public class BedrockAgentRuntimeComponentConfiguration
      */
     private Boolean autowiredEnabled = true;
     /**
+     * To use an existing configured AWS Bedrock Agent Runtime async client
+     * (required for invokeFlow which streams events back). The option is a
+     * software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient type.
+     */
+    private BedrockAgentRuntimeAsyncClient bedrockAgentRuntimeAsyncClient;
+    /**
      * To use an existing configured AWS Bedrock Agent Runtime client. The
      * option is a
      * software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient type.
      */
     private BedrockAgentRuntimeClient bedrockAgentRuntimeClient;
+    /**
+     * Enables tracing for the invokeFlow operation. When enabled, the producer
+     * collects FlowTraceEvent entries and publishes them in the
+     * CamelAwsBedrockAgentRuntimeFlowTraces header.
+     */
+    private Boolean enableTrace = false;
+    /**
+     * The unique identifier of the Bedrock flow alias to invoke (used by the
+     * invokeFlow operation). Can be overridden per exchange via the
+     * CamelAwsBedrockAgentRuntimeFlowAliasIdentifier header.
+     */
+    private String flowAliasIdentifier;
+    /**
+     * The unique identifier of the Bedrock flow to invoke (used by the
+     * invokeFlow operation). Can be overridden per exchange via the
+     * CamelAwsBedrockAgentRuntimeFlowIdentifier header.
+     */
+    private String flowIdentifier;
     /**
      * Used for enabling or disabling all consumer based health checks from this
      * component
@@ -275,6 +300,15 @@ public class BedrockAgentRuntimeComponentConfiguration
         this.autowiredEnabled = autowiredEnabled;
     }
 
+    public BedrockAgentRuntimeAsyncClient getBedrockAgentRuntimeAsyncClient() {
+        return bedrockAgentRuntimeAsyncClient;
+    }
+
+    public void setBedrockAgentRuntimeAsyncClient(
+            BedrockAgentRuntimeAsyncClient bedrockAgentRuntimeAsyncClient) {
+        this.bedrockAgentRuntimeAsyncClient = bedrockAgentRuntimeAsyncClient;
+    }
+
     public BedrockAgentRuntimeClient getBedrockAgentRuntimeClient() {
         return bedrockAgentRuntimeClient;
     }
@@ -282,6 +316,30 @@ public class BedrockAgentRuntimeComponentConfiguration
     public void setBedrockAgentRuntimeClient(
             BedrockAgentRuntimeClient bedrockAgentRuntimeClient) {
         this.bedrockAgentRuntimeClient = bedrockAgentRuntimeClient;
+    }
+
+    public Boolean getEnableTrace() {
+        return enableTrace;
+    }
+
+    public void setEnableTrace(Boolean enableTrace) {
+        this.enableTrace = enableTrace;
+    }
+
+    public String getFlowAliasIdentifier() {
+        return flowAliasIdentifier;
+    }
+
+    public void setFlowAliasIdentifier(String flowAliasIdentifier) {
+        this.flowAliasIdentifier = flowAliasIdentifier;
+    }
+
+    public String getFlowIdentifier() {
+        return flowIdentifier;
+    }
+
+    public void setFlowIdentifier(String flowIdentifier) {
+        this.flowIdentifier = flowIdentifier;
     }
 
     public Boolean getHealthCheckConsumerEnabled() {

--- a/components-starter/camel-aws-bedrock-starter/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/springboot/BedrockAgentRuntimeComponentConverter.java
+++ b/components-starter/camel-aws-bedrock-starter/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/springboot/BedrockAgentRuntimeComponentConverter.java
@@ -42,6 +42,7 @@ public class BedrockAgentRuntimeComponentConverter
     public Set<ConvertiblePair> getConvertibleTypes() {
         Set<ConvertiblePair> answer = new LinkedHashSet<>();
         answer.add(new ConvertiblePair(String.class, org.apache.camel.component.aws2.bedrock.agentruntime.BedrockAgentRuntimeConfiguration.class));
+        answer.add(new ConvertiblePair(String.class, software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient.class));
         answer.add(new ConvertiblePair(String.class, software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient.class));
         return answer;
     }
@@ -60,6 +61,7 @@ public class BedrockAgentRuntimeComponentConverter
         ref = ref.startsWith("#bean:") ? ref.substring(6) : ref.substring(1);
         switch (targetType.getName()) {
             case "org.apache.camel.component.aws2.bedrock.agentruntime.BedrockAgentRuntimeConfiguration": return applicationContext.getBean(ref, org.apache.camel.component.aws2.bedrock.agentruntime.BedrockAgentRuntimeConfiguration.class);
+            case "software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient": return applicationContext.getBean(ref, software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient.class);
             case "software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient": return applicationContext.getBean(ref, software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient.class);
         }
         return null;

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -94,8 +95,8 @@ public class SpringBootPlatformHttpAutoConfiguration {
     }
 
     @Bean
-    public CamelRequestHandlerMapping platformHttpEngineRequestMapping(PlatformHttpEngine engine, ObjectProvider<CamelContext> camelContextProvider) {
-        CamelContext camelContext = camelContextProvider.getObject();
+    @Lazy
+    public CamelRequestHandlerMapping platformHttpEngineRequestMapping(PlatformHttpEngine engine, CamelContext camelContext) {
         PlatformHttpComponent component = camelContext.getComponent("platform-http", PlatformHttpComponent.class);
         return new CamelRequestHandlerMapping(component, engine);
     }


### PR DESCRIPTION
Seeing this trying to run tests camel aws2 s3

> [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 3.083 s <<< FAILURE! -- in org.apache.camel.component.aws2.s3.S3PojoAsBodyTest
> [ERROR] org.apache.camel.component.aws2.s3.S3PojoAsBodyTest.sendIn -- Time elapsed: 0.199 s <<< ERROR!
> java.lang.ClassCastException: class software.amazon.awssdk.services.s3.model.ListObjectsRequest cannot be cast to class software.amazon.awssdk.services.s3.model.S3Object (software.amazon.awssdk.services.s3.model.ListObjectsRequest and software.amazon.awssdk.services.s3.model.S3Object are in unnamed module of loader 'app')
> 	at org.apache.camel.component.aws2.s3.S3PojoAsBodyTest.sendIn(S3PojoAsBodyTest.java:68)