### PR TITLE
CAMEL-23132: Fix S3PojoAsBodyTest to use ListObjectsV2Request

### DIFF
--- a/components-starter/camel-aws2-s3-starter/src/test/java/org/apache/camel/component/aws2/s3/S3PojoAsBodyTest.java
+++ b/components-starter/camel-aws2-s3-starter/src/test/java/org/apache/camel/component/aws2/s3/S3PojoAsBodyTest.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.util.List;
@@ -59,7 +59,7 @@ public class S3PojoAsBodyTest extends BaseS3 {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setBody(ListObjectsRequest.builder().bucket("mycamel").build());
+                exchange.getIn().setBody(ListObjectsV2Request.builder().bucket("mycamel").build());
             }
         });
 


### PR DESCRIPTION
## Summary
- Fix `S3PojoAsBodyTest` to use `ListObjectsV2Request` instead of deprecated `ListObjectsRequest`
- CAMEL-23132 updated the camel-aws2-s3 `listObjects` operation to use the V2 API, but this test was not updated accordingly

## Test plan
- [x] `S3PojoAsBodyTest.sendIn` passes locally after the fix