### PR TITLE
CAMEL-23615: ErrorRegistry - disable TTL by default

### DIFF
--- a/core/camel-spring-boot/src/main/docs/spring-boot.json
+++ b/core/camel-spring-boot/src/main/docs/spring-boot.json
@@ -346,9 +346,9 @@
     {
       "name": "camel.errorregistry.time-to-live-seconds",
       "type": "java.lang.Integer",
-      "description": "The time-to-live in seconds for error entries. Entries older than this are evicted.",
+      "description": "The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0 (disabled).",
       "sourceType": "org.apache.camel.spring.boot.errorregistry.CamelErrorRegistryConfigurationProperties",
-      "defaultValue": 3600
+      "defaultValue": 0
     },
     {
       "name": "camel.health.async-camel-health-check",

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/errorregistry/CamelErrorRegistryConfigurationProperties.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/errorregistry/CamelErrorRegistryConfigurationProperties.java
@@ -35,10 +35,11 @@ public class CamelErrorRegistryConfigurationProperties {
     private int maximumEntries = 100;
 
     /**
-     * The time-to-live in seconds for error entries. Entries older than this are evicted.
+     * The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0
+     * (disabled).
      */
-    @Metadata(defaultValue = "3600")
-    private int timeToLiveSeconds = 3600;
+    @Metadata(defaultValue = "0")
+    private int timeToLiveSeconds;
 
     /**
      * To limit the message body to a maximum size in the captured error data. Use 0 or negative value to use unlimited


### PR DESCRIPTION
## Summary
- Change the ErrorRegistry TTL default from 1 hour to 0 (disabled) to align with apache/camel#23575
- Entries are retained based only on the maximum entries limit (100) without time-based eviction
- Users can still enable TTL by setting `camel.errorregistry.time-to-live-seconds` to a positive value

## Related
- apache/camel#23575

_Claude Code on behalf of Claus Ibsen_