### PR TITLE
Replace sleep with assert period in file tests

### DIFF
--- a/components-starter/camel-file-starter/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentTest.java
+++ b/components-starter/camel-file-starter/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentTest.java
@@ -66,7 +66,7 @@ public class FileConsumerIdempotentTest extends BaseFile {
 
         // should NOT consume the file again, let a bit time pass to let the
         // consumer try to consume it but it should not
-        Thread.sleep(100);
+        resultEndpoint.setAssertPeriod(100);
         assertMockEndpointsSatisfied();
 
         FileEndpoint fe = context.getEndpoint(fileUri(), FileEndpoint.class);

--- a/components-starter/camel-file-starter/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNamePrefixTest.java
+++ b/components-starter/camel-file-starter/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNamePrefixTest.java
@@ -49,7 +49,7 @@ public class FilerConsumerDoneFileNamePrefixTest extends BaseFile {
 
         // wait a bit and it should not pickup the written file as there are no
         // done file
-        Thread.sleep(250);
+        resultEndpoint.setAssertPeriod(250);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.reset();


### PR DESCRIPTION
This replaces `Thread.sleep()` with `MockEndpoint#setAssertPeriod(...)` in two file component tests.

These tests are checking that no exchanges are received during a period of time, so using an assert period makes the intent clearer and avoids relying on sleep-based timing.

Updated tests:

- `FileConsumerIdempotentTest`
- `FilerConsumerDoneFileNamePrefixTest`
