### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,11 +20,20 @@ github:
   homepage: https://camel.apache.org
   labels:
     - camel
-    - integration
-    - eip
-    - microservices
-    - java
     - spring-boot
+    - integration
+    - integration-framework
+    - enterprise-integration-patterns
+    - java
+    - cloud-native
+    - kubernetes
+    - kafka
+    - rest-api
+    - yaml
+    - data-transformation
+    - middleware
+    - microservices
+    - mcp
   rulesets:
     - name: "Default Branch Protection"
       type: branch


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 6 to 15 (out of 20 max) to improve discoverability
- Replace abbreviated `eip` with full `enterprise-integration-patterns`
- Add `integration-framework` as a category term
- Add deployment/ecosystem: `cloud-native`, `kubernetes`, `kafka`
- Add capabilities: `rest-api`, `yaml`, `data-transformation`, `middleware`
- Add AI integration: `mcp` (Model Context Protocol)
- Keep `camel`, `spring-boot`, `integration`, `java`, `microservices`

Follows the same topic expansion done in apache/camel#23673.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel-spring-boot

_Claude Code on behalf of Claus Ibsen_