### PR TITLE
Configure GitHub workflow to cancel previous PR check in case of new

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -28,6 +28,10 @@ on:
       - Jenkinsfile.*
       - '*.txt'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
commits on same PR

It will save some resources in case of new commit on a branch PR and PR checks were not finished
Apache committers can see recommendations here
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices