### PR TITLE
Migrate infinispan-commons-test to infinispan-testing

### DIFF
--- a/components-starter/camel-infinispan-starter/pom.xml
+++ b/components-starter/camel-infinispan-starter/pom.xml
@@ -102,7 +102,7 @@
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-commons-test</artifactId>
+      <artifactId>infinispan-testing</artifactId>
       <version>${infinispan-version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Summary
- Migrate `infinispan-commons-test` → `infinispan-testing` in camel-infinispan-starter
- Required for Infinispan 16.1.4 alignment (artifact removed in 16.1.x)
- Companion to https://github.com/apache/camel/pull/23924

## Test plan
- [ ] CI build passes
- [ ] camel-infinispan-starter compiles against infinispan 16.1.4