### PR TITLE
CAMEL-23755 - force jooq version compatible with JDK 17

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,6 +61,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq</artifactId>
+                <version>${jooq-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -5201,6 +5201,11 @@
         <version>3.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq</artifactId>
+        <version>3.19.30</version>
+      </dependency>
+      <dependency>
         <groupId>org.jspecify</groupId>
         <artifactId>jspecify</artifactId>
         <version>1.0.0</version>


### PR DESCRIPTION
the spring boot dependencies bom 4.1.0 has upgraded to jooq 4.21 which requires JDK 21 with
https://github.com/spring-projects/spring-boot/issues/48619 It says that it allows to be compatible with Jackson 3, I think we still have jackson 2 in Camel so should be working still.

IF agree with this fix, i will create a Jira issue linked to JDK 17 removal to not forget to remove this specific jooq declaration from camel spring boot

