### PR TITLE
chore: exclude camel-micrometer-prometheus from observability-services-starter

### DIFF
--- a/components-starter/camel-observability-services-starter/pom.xml
+++ b/components-starter/camel-observability-services-starter/pom.xml
@@ -53,6 +53,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-observability-services</artifactId>
       <version>${camel-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-micrometer-prometheus</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>


### PR DESCRIPTION
## Summary

- Exclude `camel-micrometer-prometheus` from the `camel-observability-services` transitive dependency in `camel-observability-services-starter`
- `camel-micrometer-prometheus` is a Camel Main-only module that depends on `camel-platform-http-main` (embedded Vert.x management server). In Spring Boot it silently disables itself (`MicrometerPrometheus not enabled`) since `ManagementHttpServer` is absent
- The starter already provides equivalent functionality via `camel-micrometer-starter` + `micrometer-registry-prometheus` + Spring Boot Actuator

This removes unnecessary Camel Main and Vert.x classes from the Spring Boot classpath.

_Claude Code on behalf of Federico Mariani_