### PR TITLE
Add OSS Helper project rules for AI-assisted contributions

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -1,0 +1,18 @@
+# Project Guidelines
+
+This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
+
+- **Fix branch:** `fix/<ISSUE_ID>`
+- **Feature branch:** `feature/<ISSUE_ID>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_ID>`
+- **Quick-fix branch:** `quick-fix/<short-slug>`
+- **Commit format (fix):** `<ISSUE_ID>: <brief description of fix>`
+- **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
+- **PR creation:** always
+- **Find-task source:** Jira
+- **Find-task beginner JQL:** `project = CAMEL AND status = Open AND labels = good-first-issue` (maxResults=10)
+- **Find-task intermediate:** Filter 12352792 (easy issues)
+- **Find-task experienced JQL:** `project = CAMEL AND status = Open AND labels = help-wanted` (maxResults=10)
+- **Scope-too-large redirect:** create a Jira issue directly

--- a/.oss-ai-helper-rules/project-info.md
+++ b/.oss-ai-helper-rules/project-info.md
@@ -1,0 +1,15 @@
+# Project Information
+
+This rule file contains project-specific metadata used by OSS Helper commands. Commands detect the current project by matching `git remote get-url origin` against the remote pattern below.
+
+- **Remote pattern:** `apache/camel-spring-boot`
+- **GitHub repo:** `apache/camel-spring-boot`
+- **Issue tracker:** Jira
+- **Issue tracker URL:** `https://issues.apache.org/jira/browse/`
+- **Issue ID format:** alphanumeric (e.g., `CAMEL-20410`)
+- **SonarCloud component key:** _(none)_
+- **Documentation URL:** _(none)_
+- **Related repositories:**
+  - `apache/camel` - Apache Camel core
+- **Jira project key:** `CAMEL`
+- **Create-issue supported:** yes

--- a/.oss-ai-helper-rules/project-security.md
+++ b/.oss-ai-helper-rules/project-security.md
@@ -1,0 +1,35 @@
+# Project Security
+
+This rule file contains the security and CVE-handling workflow for the project — how a vulnerability is reported, triaged, fixed, assigned a CVE, and published. Commands read this file to determine the private reporting channel, the CVE Numbering Authority (CNA), the advisory format and publication location, and the supported release lines a fix must be backported to.
+
+This file is **optional**. Commands that do not deal with security ignore it; the security commands (`/oss-triage-security-report`, `/oss-create-security-advisory`, `/oss-draft-cve`, `/oss-analyze-third-party-cve`) read it when present and fall back to interactive prompts when it is absent.
+
+Apache Camel Spring Boot is part of the Apache Camel project and follows the same PMC, CNA, and disclosure process as Camel core; the differences below are the issue tracker (Jira) and that releases track Camel core's version numbers.
+
+- **Private reporting channel:** `security@apache.org` — the ASF Security Team. Apache Camel does not operate a dedicated `security@camel.apache.org` list, so reports go to the foundation address per https://www.apache.org/security/. Never use Jira, GitHub issues/PRs, or any public mailing list to report an undisclosed vulnerability.
+- **GitHub private vulnerability reporting:** not used. Coordination happens on `security@apache.org`, not GitHub Security Advisories. `/oss-create-security-advisory` should direct reporters to `security@apache.org` rather than the GitHub `/reports` endpoint for this project.
+- **CVE Numbering Authority (CNA):** The Apache Software Foundation Security Team — the only body that can allocate CVE IDs for ASF projects. Reserve an ID through the internal portal https://cveprocess.apache.org (or email `security@apache.org` with subject `CVE request for ...`). The portal also generates draft announcement text and provides a REVIEW state for Security-Team sign-off. The OSS Helper never reserves, requests, or generates CVE IDs; it only drafts against an already-reserved ID.
+- **Severity:** the advisory's `Severity` field is a qualitative rating (Low / Medium / High / Critical). Camel advisory pages do **not** publish a CVSS score or vector string — only the qualitative rating. Compute a CVSS vector solely for the CNA/NVD record if one is required there.
+- **Advisory source format:** a Hugo Markdown page named `CVE-YYYY-NNNNN.md`, plus a PGP-clearsigned plaintext `CVE-YYYY-NNNNN.txt.asc` linked from the advisory's `References` section. `/oss-draft-cve` should emit the `.md` page and the matching `.txt` body; the maintainer signs the `.txt` into `.txt.asc` after review.
+- **Advisory section structure (exact labels, in order):** `Severity`, `Summary`, `Versions affected`, `Versions fixed`, `Description`, `Notes`, `Mitigation`, `Credit`, `References`. Reproduce these labels exactly when drafting.
+- **Advisory template (reference):** https://camel.apache.org/security/CVE-2025-27636.html (rendered) or its source https://github.com/apache/camel-website/blob/main/content/security/CVE-2025-27636.md. The advisory format is shared across all Camel sub-projects. Pass either as the `/oss-draft-cve template=` argument.
+- **Publication location:** advisories for all Camel sub-projects are published centrally — commit to `apache/camel-website` under `content/security/` (`CVE-YYYY-NNNNN.md` + `CVE-YYYY-NNNNN.txt.asc`); it renders live at `https://camel.apache.org/security/CVE-YYYY-NNNNN.html`.
+- **Signing key:** the Camel release/PMC GPG key published in https://downloads.apache.org/camel/KEYS. `gpg --clearsign CVE-YYYY-NNNNN.txt` produces `CVE-YYYY-NNNNN.txt.asc`. The OSS Helper never runs `gpg` — the maintainer signs after review.
+- **Supported release lines / backport branches:** Camel Spring Boot is released in lockstep with Camel core and shares its version numbers, so its supported lines match core — **4.14.x** and **4.18.x** as of May 2026 (4.10.x and all 3.x releases are EOL). Backport the fix to every supported line in `apache/camel-spring-boot`, then derive fixed versions with `git tag --contains <fix-commit> | sort -V`. Confirm the current lines against https://camel.apache.org/categories/Roadmap/ before choosing backport targets.
+- **Disclosure & announcement:** publish only after the fixed releases are available. Announce to `announce@apache.org` and `users@camel.apache.org`, notify the reporter, and post to `oss-security@lists.openwall.com`; the CVE is pushed to MITRE/NVD through the ASF CNA. The post to `oss-security` is the first public mention of the issue — never disclose specifics before the fix is released.
+- **Third-party CVE notes ("not affected" rationale):** where `/oss-analyze-third-party-cve` should record a verified exposure analysis. (TODO: decide whether to track these in release notes, a dedicated security page, or a private PMC tracking issue.)
+
+## CVE Handling Workflow
+
+End-to-end process. The OSS Helper command that assists each step is named in brackets; steps marked *(manual)* are maintainer/PMC actions with no command.
+
+1. **Receipt & confidentiality** — a report arrives privately on `security@apache.org`. Treat all specifics as confidential and acknowledge receipt to the reporter. *(manual)*
+2. **Triage** — verify each claim against the current code and git history; assess scope and severity. Decide: valid / invalid / duplicate. [`/oss-triage-security-report`]
+3. **Reserve a CVE** — if valid, the PMC reserves a CVE ID through the ASF Security Team via https://cveprocess.apache.org. *(manual — the OSS Helper never reserves IDs)*
+4. **Fix privately** — develop the fix without referencing the vulnerability in public commits/PRs; backport to every supported line.
+5. **Release** — cut and vote the fixed releases through the normal ASF release process so the patched versions are available before disclosure. *(manual)*
+6. **Draft & sign the advisory** — draft `CVE-YYYY-NNNNN.md` and the matching `.txt` body from the triage notes and fix PR, then GPG-clearsign the `.txt` into `.txt.asc`. [`/oss-draft-cve` for the draft; signing is manual]
+7. **Publish** — commit the `.md` page and `.txt.asc` to `apache/camel-website` under `content/security/` so the advisory appears at `https://camel.apache.org/security/CVE-YYYY-NNNNN.html`. *(manual)*
+8. **Announce & register** — announce to `announce@apache.org`, `users@camel.apache.org`, and `oss-security@lists.openwall.com`, and push the CVE to MITRE/NVD via the ASF CNA. *(manual)*
+
+For a CVE in a third-party dependency (rather than in Camel Spring Boot's own code), use [`/oss-analyze-third-party-cve`] to decide exposure and whether a dependency bump or a documented "not affected" note is the right outcome.

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -3,7 +3,7 @@
 This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
 
 - **Build tool:** Maven
-- **Build command:** `mvn verify`
+- **Build command:** `mvn install -DskipTests`
 - **Test command:** `mvn verify`
 - **Format command:** `cd <module> && mvn -DskipTests install`
 - **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -1,0 +1,16 @@
+# Project Standards
+
+This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
+
+- **Build tool:** Maven
+- **Build command:** `mvn verify`
+- **Test command:** `mvn verify`
+- **Format command:** `cd <module> && mvn -DskipTests install`
+- **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)
+- **Parallelized Maven:** no (resource intensive, do NOT parallelize Maven jobs)
+- **Code style restrictions:**
+  - Do NOT use Lombok (unless already present in the file)
+  - Records are allowed for internal/non-API classes; do NOT convert existing public API classes to Records
+  - Do NOT change public API signatures without justification
+  - Do NOT add new dependencies without justification
+  - Maintain backwards compatibility for public APIs


### PR DESCRIPTION
_Claude Code on behalf of Otavio Rodolfo Piske_

## Summary

- Add `.oss-ai-helper-rules/` directory with project-specific rules (project info, guidelines, standards, and security) for use with the [OSS Helper](https://github.com/Open-Harness-Engineering/ai-agents-oss-helper) toolset
- Companion to [apache/camel#24251](https://github.com/apache/camel/pull/24251) which adds the same for Camel core

These rules provide AI coding assistants with project-specific context (build commands, code style, branching conventions, issue tracker details, security workflow) so that AI-assisted contributions follow the same standards as manual ones.

### Review feedback addressed
- Changed build command from `mvn verify` to `mvn install -DskipTests` (avoid running tests in a build-only command)
- Confirmed Jira filter 12352792 ("Camel - Easy Tickets") exists and is globally shared/public

## Test plan

- [x] Verify `.oss-ai-helper-rules/` files contain correct camel-spring-boot metadata (remote pattern, repo, related repos, Jira tracker)
- [x] Review feedback from camel#24251 applied (no Version sections, no SonarCloud lines)
- [x] Build command updated per reviewer feedback