### PR TITLE
Fix SqsProducerAutoCreateQueueTest sending Integer instead of String

### DIFF
--- a/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsProducerAutoCreateQueueTest.java
+++ b/components-starter/camel-aws2-sqs-starter/src/test/java/org/apache/camel/component/aws2/sqs/SqsProducerAutoCreateQueueTest.java
@@ -67,12 +67,12 @@ public class SqsProducerAutoCreateQueueTest extends BaseSqs {
 
         template.send("direct:start", ExchangePattern.InOnly, new Processor() {
             public void process(Exchange exchange) {
-                Collection<Integer> c = new ArrayList<Integer>();
-                c.add(1);
-                c.add(2);
-                c.add(3);
-                c.add(4);
-                c.add(5);
+                Collection<String> c = new ArrayList<>();
+                c.add("1");
+                c.add("2");
+                c.add("3");
+                c.add("4");
+                c.add("5");
                 exchange.getIn().setBody(c);
             }
         });


### PR DESCRIPTION
## Summary
- The recent "fix warnings" commit (`a8da88d6de7`) changed the batch message body collection from raw `Collection` with String literals to `Collection<Integer>` with integer literals
- `Sqs2Producer.sendBatchMessage()` casts each element to `String`, causing a `ClassCastException` at runtime
- Restore the collection to `Collection<String>` with string literals

## Test plan
- [x] `mvn verify` in `components-starter/camel-aws2-sqs-starter` passes all 10 tests with 0 failures