### PR TITLE
CAMEL-23716: align RawPayloadTest header constants with renamed Salesforce headers

### DIFF
--- a/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
+++ b/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
@@ -167,8 +167,8 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
                 requestBody = "{ \"request\" : \"mock\" }";
             }
             headers = new HashMap<>();
-            headers.put("sObjectId", "mockId");
-            headers.put("sObjectIdValue", "mockIdValue");
+            headers.put(SalesforceEndpointConfig.SOBJECT_ID, "mockId");
+            headers.put(SalesforceEndpointConfig.SOBJECT_EXT_ID_VALUE, "mockIdValue");
             headers.put("id", "mockId");
             headers.put(SalesforceEndpointConfig.APEX_QUERY_PARAM_PREFIX + "id", "mockId");
 


### PR DESCRIPTION
## Summary

Use `SalesforceEndpointConfig.SOBJECT_ID` and `SalesforceEndpointConfig.SOBJECT_EXT_ID_VALUE` constants instead of hardcoded literal strings `"sObjectId"` and `"sObjectIdValue"` in the camel-spring-boot `RawPayloadTest`.

## Root Cause

CAMEL-23716 renamed Salesforce header string values from short names to `CamelSalesforce`-prefixed names. The plain Camel `RawPayloadTest` was updated in the same commit, but the camel-spring-boot copy still used the old literal strings, causing 10/39 test variants to fail when run against Camel 4.18.1 with the renamed constants.

## Test plan

- [ ] CI passes