### PR TITLE
Don't protect release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,8 +40,6 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
-          - "rel/*"
           - "camel-spring-boot-*"
         excludes: []
       bypass_teams:


### PR DESCRIPTION
Since we tag releases but don't keep release branches, I suggest we exclude release branches from the branch protection rule.

Also see: https://camel.apache.org/manual/release-guide.html#ReleaseGuide-PublishingTheRelease-Camel