### PR TITLE
camel-platform-http-starter: code review fixes (cookies, method restrict, exchange lifecycle, executors, ByteBuffer, unregister, SB4 idioms)

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping implements PlatformHttpListener {
@@ -159,8 +160,13 @@ public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping imp
             }
         }
         if (verbs != null) {
-            for (String v : model.getVerbs().split(",")) {
-                RequestMethod rm = RequestMethod.resolve(v);
+            for (String v : verbs.split(",")) {
+                RequestMethod rm = RequestMethod.resolve(v.trim().toUpperCase(Locale.US));
+                if (rm == null) {
+                    // fail closed: an unknown verb must not widen the mapping to all methods
+                    throw new IllegalArgumentException(
+                            "Unsupported HTTP method '" + v.trim() + "' in verbs '" + verbs + "' for uri: " + model.getUri());
+                }
                 methods.add(rm);
             }
         }

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/CamelRequestHandlerMapping.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.platform.http.springboot;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.camel.Consumer;
 import org.apache.camel.component.platform.http.HttpEndpointModel;
 import org.apache.camel.component.platform.http.PlatformHttpComponent;
 import org.apache.camel.component.platform.http.PlatformHttpEndpoint;
@@ -38,11 +39,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping implements PlatformHttpListener {
 
     private final PlatformHttpComponent component;
     private final PlatformHttpEngine engine;
+    private final Map<Consumer, List<RequestMappingInfo>> registrations = new ConcurrentHashMap<>();
 
     private CorsConfiguration corsConfiguration;
 
@@ -134,16 +138,24 @@ public class CamelRequestHandlerMapping extends RequestMappingHandlerMapping imp
         List<RequestMappingInfo> requestMappingInfos = asRequestMappingInfo(model);
         Method m = ReflectionHelper.findMethod(SpringBootPlatformHttpConsumer.class, "service",
                 HttpServletRequest.class, HttpServletResponse.class);
+        List<RequestMappingInfo> registered
+                = registrations.computeIfAbsent(model.getConsumer(), c -> new CopyOnWriteArrayList<>());
         for (RequestMappingInfo info : requestMappingInfos) {
             // Needed in case of context reload
             unregisterMapping(info);
             registerMapping(info, model.getConsumer(), m);
+            registered.add(info);
         }
     }
 
     @Override
     public void unregisterHttpEndpoint(HttpEndpointModel model) {
-        // noop
+        // mappings are tracked per consumer so unregistering an endpoint does not
+        // affect other consumers serving the same uri with different methods
+        List<RequestMappingInfo> registered = registrations.remove(model.getConsumer());
+        if (registered != null) {
+            registered.forEach(this::unregisterMapping);
+        }
     }
 
     private List<RequestMappingInfo> asRequestMappingInfo(HttpEndpointModel model) {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -22,11 +22,11 @@ import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
 import org.apache.camel.spring.boot.ComponentConfigurationProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.webmvc.autoconfigure.WebMvcProperties;
+import org.springframework.boot.thread.Threading;
+import org.springframework.boot.web.server.autoconfigure.ServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
@@ -36,61 +36,57 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import java.util.List;
 import java.util.concurrent.Executor;
 
-@AutoConfiguration(afterName = { "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentAutoConfiguration",
-        "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConverter" })
-@EnableConfigurationProperties({ComponentConfigurationProperties.class,PlatformHttpComponentConfiguration.class, WebMvcProperties.class})
+@AutoConfiguration(after = { PlatformHttpComponentAutoConfiguration.class, PlatformHttpComponentConverter.class })
+@EnableConfigurationProperties({ ComponentConfigurationProperties.class, PlatformHttpComponentConfiguration.class })
 public class SpringBootPlatformHttpAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(SpringBootPlatformHttpAutoConfiguration.class);
 
     @Bean(name = "platform-http-engine")
     @ConditionalOnMissingBean(PlatformHttpEngine.class)
-    public PlatformHttpEngine springBootPlatformHttpEngine(Environment env, List<Executor> executors) {
-        Executor executor;
-
-        if (executors != null && !executors.isEmpty()) {
-            executors.forEach(e -> LOG.debug("Analyzing executor: {}", e.getClass().getName()));
-            
-            // Check if virtual threads are enabled
-            boolean virtualThreadsEnabled = Boolean.parseBoolean(env.getProperty("spring.threads.virtual.enabled", "false"));
-            
-            executor = executors.stream()
-                    .filter(e -> {
-                        try {
-                            return Class.forName("org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor").isInstance(e);
-                        } catch (ClassNotFoundException ex) {
-                            // No problem, spring-security is not configured
-                            return false;
-                        }
-                    }).findAny().orElseGet(() -> {
-                        if (virtualThreadsEnabled) {
-                            // Prefer SimpleAsyncTaskExecutor when virtual threads are enabled
-                            return executors.stream()
-                                    .filter(e -> e instanceof SimpleAsyncTaskExecutor)
-                                    .findFirst()
-                                    .orElseGet(() -> 
-                                            executors.stream()
-                                                    .filter(e -> e instanceof ThreadPoolTaskExecutor)
-                                                    .findFirst()
-                                                    .orElseThrow(() -> new RuntimeException("No SimpleAsyncTaskExecutor or ThreadPoolTaskExecutor configured"))
-                                    );
-                        } else {
-                            // Traditional behavior: prefer ThreadPoolTaskExecutor
-                            return executors.stream()
-                                    .filter(e -> e instanceof ThreadPoolTaskExecutor || e instanceof SimpleAsyncTaskExecutor)
-                                    .findFirst()
-                                    .orElseThrow(() -> new RuntimeException("No ThreadPoolTaskExecutor, SimpleAsyncTaskExecutor or DelegatingSecurityContextAsyncTaskExecutor configured"));
-                        }
-                    });
-        } else {
-            throw new RuntimeException("No Executor configured");
+    public PlatformHttpEngine springBootPlatformHttpEngine(Environment env, ServerProperties serverProperties,
+                                                           List<Executor> executors) {
+        if (executors == null || executors.isEmpty()) {
+            throw new IllegalStateException("No Executor configured");
         }
+        executors.forEach(e -> LOG.debug("Analyzing executor: {}", e.getClass().getName()));
 
-        if (Boolean.parseBoolean(env.getProperty("spring.threads.virtual.enabled", "false"))) {
+        boolean virtualThreadsEnabled = Threading.VIRTUAL.isActive(env);
+
+        Executor executor = executors.stream()
+                .filter(e -> {
+                    try {
+                        return Class.forName("org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor").isInstance(e);
+                    } catch (ClassNotFoundException ex) {
+                        // No problem, spring-security is not configured
+                        return false;
+                    }
+                }).findAny().orElseGet(() -> {
+                    if (virtualThreadsEnabled) {
+                        // Prefer SimpleAsyncTaskExecutor when virtual threads are enabled
+                        return executors.stream()
+                                .filter(e -> e instanceof SimpleAsyncTaskExecutor)
+                                .findFirst()
+                                .orElseGet(() ->
+                                        executors.stream()
+                                                .filter(e -> e instanceof ThreadPoolTaskExecutor)
+                                                .findFirst()
+                                                .orElseThrow(() -> new IllegalStateException("No SimpleAsyncTaskExecutor or ThreadPoolTaskExecutor configured"))
+                                );
+                    } else {
+                        // Traditional behavior: prefer ThreadPoolTaskExecutor
+                        return executors.stream()
+                                .filter(e -> e instanceof ThreadPoolTaskExecutor || e instanceof SimpleAsyncTaskExecutor)
+                                .findFirst()
+                                .orElseThrow(() -> new IllegalStateException("No ThreadPoolTaskExecutor, SimpleAsyncTaskExecutor or DelegatingSecurityContextAsyncTaskExecutor configured"));
+                    }
+                });
+
+        if (virtualThreadsEnabled) {
             LOG.info("Virtual threads enabled - using executor: {} for platform-http", executor.getClass().getName());
         } else {
             LOG.debug("Using executor: {}", executor.getClass().getName());
         }
-        int port = Integer.parseInt(env.getProperty("server.port", "8080"));
+        int port = serverProperties.getPort() != null ? serverProperties.getPort() : 8080;
         return new SpringBootPlatformHttpEngine(port, executor);
     }
 

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
@@ -36,6 +36,7 @@ import org.apache.camel.component.platform.http.spi.Method;
 import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.camel.http.base.HttpHelper;
 import org.apache.camel.http.common.DefaultHttpBinding;
+import org.apache.camel.http.common.HttpConstants;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
@@ -46,7 +47,6 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.multipart.support.StandardMultipartHttpServletRequest;
 
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -218,102 +218,114 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
                 METHODS_WITH_REQUEST_ALREADY_READ.contains(Method.valueOf(request.getMethod()));
     }
 
+    @Override
     protected void doWriteDirectResponse(Message message, HttpServletResponse response, Exchange exchange) throws IOException {
-        String contentType = (String)message.getHeader("Content-Type", String.class);
-        if ("application/x-java-serialized-object".equals(contentType)) {
-            if (!isAllowJavaSerializedObject() && !this.isTransferException()) {
-                throw new RuntimeCamelException("Content-type application/x-java-serialized-object is not allowed");
-            } else {
+        // if content type is serialized Java object, then serialize and write it to the response
+        String contentType = message.getHeader(Exchange.CONTENT_TYPE, String.class);
+        if (HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT.equals(contentType)) {
+            if (!isAllowJavaSerializedObject() && !isTransferException()) {
+                throw new RuntimeCamelException(
+                        "Content-type " + HttpConstants.CONTENT_TYPE_JAVA_SERIALIZED_OBJECT + " is not allowed");
+            }
+            try {
+                Object object = message.getMandatoryBody(Serializable.class);
+                org.apache.camel.http.common.HttpHelper.writeObjectToServletResponse(response, object);
+                return;
+            } catch (InvalidPayloadException e) {
+                throw new IOException(e);
+            }
+        }
+
+        // prefer streaming
+        InputStream is = null;
+        if (checkChunked(message, exchange)) {
+            is = message.getBody(InputStream.class);
+        } else if (!isText(contentType)) {
+            // try to use input stream first, so we can copy directly
+            is = exchange.getContext().getTypeConverter().tryConvertTo(InputStream.class, message.getBody());
+        }
+
+        if (is != null) {
+            ServletOutputStream os = response.getOutputStream();
+            if (!checkChunked(message, exchange)) {
+                CachedOutputStream stream = new CachedOutputStream(exchange);
                 try {
-                    Object object = message.getMandatoryBody(Serializable.class);
-                    org.apache.camel.http.common.HttpHelper.writeObjectToServletResponse(response, object);
-                } catch (InvalidPayloadException var19) {
-                    InvalidPayloadException e = var19;
-                    throw new IOException(e);
+                    // copy directly from input stream to the cached output stream to get the content length
+                    int len = copyStream(is, stream, response.getBufferSize());
+                    // we need to setup the length if message is not chunked
+                    response.setContentLength(len);
+                    OutputStream current = stream.getCurrentStream();
+                    if (current instanceof ByteArrayOutputStream bos) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Streaming (direct) response in non-chunked mode with content-length {}", len);
+                        }
+                        bos.writeTo(os);
+                    } else {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Streaming response in non-chunked mode with content-length {} and buffer size: {}",
+                                    len, len);
+                        }
+                        copyStream(stream.getInputStream(), os, len);
+                    }
+                } finally {
+                    IOHelper.close(is, os);
+                    stream.close();
                 }
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Streaming response in chunked mode with buffer size {}", response.getBufferSize());
+                }
+                copyStream(is, os, response.getBufferSize());
             }
         } else {
-            InputStream is = null;
-            if (this.checkChunked(message, exchange)) {
-                is = message.getBody(InputStream.class);
-            } else if (!this.isText(contentType)) {
-                is = exchange.getContext().getTypeConverter().tryConvertTo(InputStream.class, message.getBody());
-            }
-
-            int len;
-            if (is != null) {
-                ServletOutputStream os = response.getOutputStream();
-                if (!this.checkChunked(message, exchange)) {
-                    CachedOutputStream stream = new CachedOutputStream(exchange);
-
-                    try {
-                        len = this.copyStream(is, stream, response.getBufferSize());
-                        response.setContentLength(len);
-                        OutputStream current = stream.getCurrentStream();
-                        if (current instanceof ByteArrayOutputStream) {
-                            ByteArrayOutputStream bos = (ByteArrayOutputStream)current;
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Streaming (direct) response in non-chunked mode with content-length {}", len);
-                            }
-
-                            bos.writeTo(os);
-                        } else {
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Streaming response in non-chunked mode with content-length {} and buffer size: {}", len, len);
-                            }
-
-                            this.copyStream(stream.getInputStream(), os, len);
-                        }
-                    } finally {
-                        IOHelper.close(new Closeable[]{is, os});
-                        stream.close();
-                    }
-                } else {
+            Object body = message.getBody();
+            if (body instanceof String) {
+                String data = message.getBody(String.class);
+                if (data != null) {
+                    // set content length and encoding before we write data
+                    String charset = ExchangeHelper.getCharsetName(exchange, true);
+                    int len = data.getBytes(charset).length;
+                    response.setCharacterEncoding(charset);
+                    response.setContentLength(len);
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Streaming response in chunked mode with buffer size {}", response.getBufferSize());
+                        LOG.debug("Writing response in non-chunked mode as plain text with content-length {} and buffer size: {}",
+                                len, response.getBufferSize());
                     }
-
-                    this.copyStream(is, os, response.getBufferSize());
+                    try {
+                        response.getWriter().print(data);
+                    } finally {
+                        response.getWriter().flush();
+                    }
                 }
+            } else if (body instanceof InputStream bodyIS) {
+                bodyIS.transferTo(response.getOutputStream());
             } else {
-                Object body = message.getBody();
-                if (body instanceof String) {
-                    String data = message.getBody(String.class);
-
-                    if (data != null) {
-                        String charset = ExchangeHelper.getCharsetName(exchange, true);
-                        len = data.getBytes(charset).length;
-                        response.setCharacterEncoding(charset);
-                        response.setContentLength(len);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Writing response in non-chunked mode as plain text with content-length {} and buffer size: {}", len, response.getBufferSize());
-                        }
-
-                        try {
-                            response.getWriter().print(data);
-                        } finally {
-                            response.getWriter().flush();
-                        }
-                    }
-                } else if (body instanceof InputStream) {
-                    InputStream bodyIS = message.getBody(InputStream.class);
-                    bodyIS.transferTo(response.getOutputStream());
+                final TypeConverter tc = exchange.getContext().getTypeConverter();
+                // try to convert to ByteBuffer for performance reasons
+                final ByteBuffer bb = tc.tryConvertTo(ByteBuffer.class, exchange, body);
+                if (bb != null) {
+                    writeByteBuffer(response, bb);
                 } else {
-                    final TypeConverter tc = exchange.getContext().getTypeConverter();
-                    // Try to convert to ByteBuffer for performance reason
-                    final ByteBuffer bb = tc.tryConvertTo(ByteBuffer.class, exchange, body);
-                    if (bb != null) {
-                        response.getOutputStream().write(bb.array());
-                    } else {
-                        try {
-                            final InputStream bodyIS = tc.mandatoryConvertTo(InputStream.class, exchange, body);
-                            bodyIS.transferTo(response.getOutputStream());
-                        } catch (NoTypeConversionAvailableException e) {
-                            throw new RuntimeException(e);
-                        }
+                    try {
+                        final InputStream bodyIS = tc.mandatoryConvertTo(InputStream.class, exchange, body);
+                        bodyIS.transferTo(response.getOutputStream());
+                    } catch (NoTypeConversionAvailableException e) {
+                        throw new IOException(e);
                     }
                 }
             }
+        }
+    }
+
+    private static void writeByteBuffer(HttpServletResponse response, ByteBuffer bb) throws IOException {
+        // only write the remaining window of the buffer, the backing array may be
+        // larger (sliced or partially consumed buffer) or absent (direct buffer)
+        if (bb.hasArray()) {
+            response.getOutputStream().write(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining());
+        } else {
+            byte[] bytes = new byte[bb.remaining()];
+            bb.duplicate().get(bytes);
+            response.getOutputStream().write(bytes);
         }
     }
 

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -115,23 +115,25 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
             return;
         }
 
-        Exchange exchange = createExchange(true);
-        exchange.setPattern(ExchangePattern.InOut);
-        HttpHelper.setCharsetFromContentType(request.getContentType(), exchange);
-        boolean streaming = getEndpoint().isUseStreaming();
-        PlatformHttpMessage msg = new PlatformHttpMessage(request, response, exchange, binding, streaming);
-        exchange.setIn(msg);
-        msg.init(exchange, binding, request, response);
-        String contextPath = getEndpoint().getPath();
-        exchange.getIn().setHeader(SpringBootPlatformHttpConstants.CONTEXT_PATH, contextPath);
-        if (getEndpoint().isUseCookieHandler()) {
-            exchange.setProperty(Exchange.COOKIE_HANDLER, new SpringBootCookieHandler(request, response));
-        }
-
-        // we want to handle the UoW
+        Exchange exchange = createExchange(false);
         try {
+            exchange.setPattern(ExchangePattern.InOut);
+            HttpHelper.setCharsetFromContentType(request.getContentType(), exchange);
+            boolean streaming = getEndpoint().isUseStreaming();
+            PlatformHttpMessage msg = new PlatformHttpMessage(request, response, exchange, binding, streaming);
+            exchange.setIn(msg);
+            msg.init(exchange, binding, request, response);
+            String contextPath = getEndpoint().getPath();
+            exchange.getIn().setHeader(SpringBootPlatformHttpConstants.CONTEXT_PATH, contextPath);
+            if (getEndpoint().isUseCookieHandler()) {
+                exchange.setProperty(Exchange.COOKIE_HANDLER, new SpringBootCookieHandler(request, response));
+            }
+
+            // we want to handle the UoW
             createUoW(exchange);
         } catch (Exception e) {
+            // the exchange did not reach afterProcess, so it must be released here
+            releaseExchange(exchange, false);
             throw new ServletException(e);
         }
         if (LOG.isTraceEnabled()) {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.component.platform.http.springboot;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import jakarta.servlet.ServletException;
@@ -49,9 +51,19 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
     private HttpBinding binding;
     private final boolean handleWriteResponseError;
     private final CookieConfiguration cookieConfiguration;
-    private Executor executor;
+    private final Executor executor;
+    private final boolean shutdownExecutor;
 
     public SpringBootPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
+        this(endpoint, processor, Executors.newSingleThreadExecutor(), true);
+    }
+
+    public SpringBootPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor, Executor executor) {
+        this(endpoint, processor, Objects.requireNonNull(executor, "executor"), false);
+    }
+
+    private SpringBootPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor, Executor executor,
+                                           boolean shutdownExecutor) {
         super(endpoint, processor);
         SpringBootPlatformHttpBinding httpBinding = new SpringBootPlatformHttpBinding();
         httpBinding.setStreaming(endpoint.isUseStreaming());
@@ -61,12 +73,16 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
         this.binding.setFileNameExtWhitelist(endpoint.getFileNameExtWhitelist());
         this.handleWriteResponseError = endpoint.isHandleWriteResponseError();
         this.cookieConfiguration = endpoint.getCookieConfiguration();
-        this.executor = Executors.newSingleThreadExecutor();
+        this.executor = executor;
+        this.shutdownExecutor = shutdownExecutor;
     }
 
-    public SpringBootPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor, Executor executor) {
-        this(endpoint, processor);
-        this.executor = executor;
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        if (shutdownExecutor && executor instanceof ExecutorService executorService) {
+            executorService.shutdown();
+        }
     }
 
     /**

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -40,7 +40,6 @@ import org.apache.camel.http.common.HttpHelper;
 import org.apache.camel.support.DefaultConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements PlatformHttpConsumer, Suspendable, SuspendableService {
@@ -49,7 +48,7 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
 
     private HttpBinding binding;
     private final boolean handleWriteResponseError;
-    private CookieConfiguration cookieConfiguration;
+    private final CookieConfiguration cookieConfiguration;
     private Executor executor;
 
     public SpringBootPlatformHttpConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
@@ -61,6 +60,7 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
         this.binding.setMuteException(endpoint.isMuteException());
         this.binding.setFileNameExtWhitelist(endpoint.getFileNameExtWhitelist());
         this.handleWriteResponseError = endpoint.isHandleWriteResponseError();
+        this.cookieConfiguration = endpoint.getCookieConfiguration();
         this.executor = Executors.newSingleThreadExecutor();
     }
 
@@ -125,7 +125,6 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
         String contextPath = getEndpoint().getPath();
         exchange.getIn().setHeader(SpringBootPlatformHttpConstants.CONTEXT_PATH, contextPath);
         if (getEndpoint().isUseCookieHandler()) {
-            cookieConfiguration = getEndpoint().getCookieConfiguration();
             exchange.setProperty(Exchange.COOKIE_HANDLER, new SpringBootCookieHandler(request, response));
         }
 
@@ -233,11 +232,11 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
             // set max age to 0 to delete the cookie
             cookieToRemove.setMaxAge(0);
             response.addCookie(cookieToRemove);
-            return cookieName;
+            return getCookieValue(cookieName);
         }
 
         @Override
-        public String getCookieValue(@CookieValue String cookieName) {
+        public String getCookieValue(String cookieName) {
             Cookie[] cookie = request.getCookies();
             // ensure cookies are not null
             if (cookie != null) {
@@ -247,7 +246,7 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
                     }
                 }
             }
-            return "Cookie not found";
+            return null;
         }
     }
 }

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
@@ -26,19 +26,23 @@ import java.util.concurrent.Executor;
 public class SpringBootPlatformHttpEngine implements PlatformHttpEngine {
 
     private final int port;
-    private Executor executor;
+    private final Executor executor;
 
     public SpringBootPlatformHttpEngine(int port) {
-        this.port = port;
+        this(port, null);
     }
 
     public SpringBootPlatformHttpEngine(int port, Executor executor) {
-        this(port);
+        this.port = port;
         this.executor = executor;
     }
 
     @Override
     public PlatformHttpConsumer createConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
+        if (executor == null) {
+            // engine created without an executor: let the consumer manage its own
+            return new SpringBootPlatformHttpConsumer(endpoint, processor);
+        }
         return new SpringBootPlatformHttpConsumer(endpoint, processor, executor);
     }
 

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformWebMvcConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformWebMvcConfiguration.java
@@ -17,18 +17,18 @@
 package org.apache.camel.component.platform.http.springboot;
 
 import org.apache.camel.spring.boot.ComponentConfigurationProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcProperties;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration
-@EnableConfigurationProperties({ComponentConfigurationProperties.class,PlatformHttpComponentConfiguration.class, WebMvcProperties.class})
+@AutoConfiguration
+@EnableConfigurationProperties({ ComponentConfigurationProperties.class, PlatformHttpComponentConfiguration.class })
 public class SpringBootPlatformWebMvcConfiguration implements WebMvcConfigurer {
 
-    private PlatformHttpComponentConfiguration platformHttpComponentConfiguration;
-    private WebMvcProperties webMvcProperties;
+    private final PlatformHttpComponentConfiguration platformHttpComponentConfiguration;
+    private final WebMvcProperties webMvcProperties;
 
     public SpringBootPlatformWebMvcConfiguration(PlatformHttpComponentConfiguration platformHttpComponentConfiguration,
                                                  WebMvcProperties webMvcProperties) {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpByteBufferResponseTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpByteBufferResponseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import io.restassured.RestAssured;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that a ByteBuffer response body only writes the buffer's remaining window, not the whole backing array,
+ * and that direct buffers (no backing array) are supported.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpByteBufferResponseTest.class,
+        SpringBootPlatformHttpByteBufferResponseTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpByteBufferResponseTest {
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void slicedByteBufferWritesOnlyRemainingWindow() {
+        given()
+                .get("/bytebuffer-sliced")
+                .then()
+                .statusCode(200)
+                .body(equalTo("hello"));
+    }
+
+    @Test
+    void directByteBufferIsWritten() {
+        given()
+                .get("/bytebuffer-direct")
+                .then()
+                .statusCode(200)
+                .body(equalTo("direct"));
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder routeBuilder() {
+            return new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/bytebuffer-sliced")
+                            .process(exchange -> {
+                                byte[] data = "XXXhelloYYY".getBytes(StandardCharsets.UTF_8);
+                                exchange.getMessage().setBody(ByteBuffer.wrap(data, 3, 5));
+                                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                                exchange.getMessage().setHeader(Exchange.HTTP_CHUNKED, false);
+                            });
+
+                    from("platform-http:/bytebuffer-direct")
+                            .process(exchange -> {
+                                ByteBuffer direct = ByteBuffer.allocateDirect(6);
+                                direct.put("direct".getBytes(StandardCharsets.UTF_8));
+                                direct.flip();
+                                exchange.getMessage().setBody(direct);
+                                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                                exchange.getMessage().setHeader(Exchange.HTTP_CHUNKED, false);
+                            });
+                }
+            };
+        }
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumerExecutorTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumerExecutorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.platform.http.PlatformHttpComponent;
+import org.apache.camel.component.platform.http.PlatformHttpConstants;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SpringBootPlatformHttpConsumerExecutorTest {
+
+    @Test
+    void engineWithoutExecutorServicesRequests() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.getRegistry().bind(PlatformHttpConstants.PLATFORM_HTTP_ENGINE_NAME,
+                    new SpringBootPlatformHttpEngine(8080));
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/fallback").setBody().constant("ok");
+                }
+            });
+            context.start();
+
+            SpringBootPlatformHttpConsumer consumer = getConsumer(context);
+            MockHttpServletResponse response = serviceRequest(consumer);
+
+            assertEquals(200, response.getStatus());
+            assertEquals("ok", response.getContentAsString());
+        }
+    }
+
+    @Test
+    void consumerOwnedExecutorIsShutDownOnStop() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.getRegistry().bind(PlatformHttpConstants.PLATFORM_HTTP_ENGINE_NAME,
+                    new SpringBootPlatformHttpEngine(8080));
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/owned").setBody().constant("ok");
+                }
+            });
+            context.start();
+
+            SpringBootPlatformHttpConsumer consumer = getConsumer(context);
+            // trigger the lazy thread creation so shutdown has something to stop
+            serviceRequest(consumer);
+
+            context.stop();
+        }
+        // no leaked non-daemon executor thread keeps the JVM from exiting; the
+        // assertion happens implicitly by the test JVM terminating, but check
+        // explicitly that a provided executor is NOT shut down by the consumer
+        ExecutorService provided = Executors.newSingleThreadExecutor();
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.getRegistry().bind(PlatformHttpConstants.PLATFORM_HTTP_ENGINE_NAME,
+                    new SpringBootPlatformHttpEngine(8080, provided));
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/provided").setBody().constant("ok");
+                }
+            });
+            context.start();
+            serviceRequest(getConsumer(context));
+            context.stop();
+        }
+        assertFalse(provided.isShutdown(), "externally provided executor must not be shut down by the consumer");
+        provided.shutdown();
+    }
+
+    @Test
+    void nullExecutorIsRejected() {
+        assertThrows(NullPointerException.class, () -> new SpringBootPlatformHttpConsumer(null, null, null));
+    }
+
+    private static SpringBootPlatformHttpConsumer getConsumer(DefaultCamelContext context) {
+        PlatformHttpComponent component = context.getComponent("platform-http", PlatformHttpComponent.class);
+        return (SpringBootPlatformHttpConsumer) component.getHttpEndpoints().iterator().next().getConsumer();
+    }
+
+    private static MockHttpServletResponse serviceRequest(SpringBootPlatformHttpConsumer consumer) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/any");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // service runs asynchronously on the consumer executor; wait for completion
+        consumer.service(request, response).get(20, TimeUnit.SECONDS);
+        return response;
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
@@ -103,6 +103,20 @@ public class SpringBootPlatformHttpCookiesTest {
                             })
                             .setBody().constant("get");
 
+                    from("platform-http:/readCookie?useCookieHandler=true")
+                            .process(exchange -> {
+                                String value = exchange.getProperty(Exchange.COOKIE_HANDLER, CookieHandler.class)
+                                        .getCookieValue("foo");
+                                exchange.getMessage().setBody(String.valueOf(value));
+                            });
+
+                    from("platform-http:/removeCookieValue?useCookieHandler=true")
+                            .process(exchange -> {
+                                String value = exchange.getProperty(Exchange.COOKIE_HANDLER, CookieHandler.class)
+                                        .removeCookie("foo");
+                                exchange.getMessage().setBody(String.valueOf(value));
+                            });
+
                     from("platform-http:/replace")
                             .process(exchange -> {
                                 PlatformHttpMessage message = (PlatformHttpMessage) exchange.getMessage();
@@ -161,6 +175,48 @@ public class SpringBootPlatformHttpCookiesTest {
                         detailedCookie()
                                 .value("bar"))
                 .body(equalTo("get"));
+    }
+
+    @Test
+    public void testReadCookieValue() {
+        given()
+                .header("cookie", "foo=sent")
+                .when()
+                .get("/readCookie")
+                .then()
+                .statusCode(200)
+                .body(equalTo("sent"));
+    }
+
+    @Test
+    public void testReadMissingCookieValueReturnsNull() {
+        given()
+                .when()
+                .get("/readCookie")
+                .then()
+                .statusCode(200)
+                .body(equalTo("null"));
+    }
+
+    @Test
+    public void testRemoveCookieReturnsRemovedValue() {
+        given()
+                .header("cookie", "foo=old")
+                .when()
+                .get("/removeCookieValue")
+                .then()
+                .statusCode(200)
+                .body(equalTo("old"));
+    }
+
+    @Test
+    public void testRemoveMissingCookieReturnsNull() {
+        given()
+                .when()
+                .get("/removeCookieValue")
+                .then()
+                .statusCode(200)
+                .body(equalTo("null"));
     }
 
     @Test

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpMethodRestrictTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpMethodRestrictTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import io.restassured.RestAssured;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpMethodRestrictTest.class,
+        SpringBootPlatformHttpMethodRestrictTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpMethodRestrictTest {
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void restrictedMethodIsServed() {
+        given()
+                .get("/restricted")
+                .then()
+                .statusCode(200)
+                .body(equalTo("restricted"));
+    }
+
+    @Test
+    void nonRestrictedMethodIsRejected() {
+        given()
+                .post("/restricted")
+                .then()
+                .statusCode(405);
+    }
+
+    @Test
+    void restrictWithWhitespaceServesListedMethods() {
+        given()
+                .get("/restricted-spaced")
+                .then()
+                .statusCode(200)
+                .body(equalTo("spaced"));
+
+        given()
+                .post("/restricted-spaced")
+                .then()
+                .statusCode(200)
+                .body(equalTo("spaced"));
+    }
+
+    @Test
+    void restrictWithWhitespaceMustNotWidenToAllMethods() {
+        // before the fix an unresolvable verb (" POST") registered a mapping
+        // without any method restriction, so DELETE was served as well
+        given()
+                .delete("/restricted-spaced")
+                .then()
+                .statusCode(405);
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder routeBuilder() {
+            return new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/restricted?httpMethodRestrict=GET")
+                            .setBody().constant("restricted");
+
+                    from("platform-http:/restricted-spaced?httpMethodRestrict=GET, POST")
+                            .setBody().constant("spaced");
+                }
+            };
+        }
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpPooledExchangeTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpPooledExchangeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import io.restassured.RestAssured;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies the consumer exchange lifecycle with pooled exchanges: the exchange must be released exactly once, so
+ * concurrent requests never observe each other's state through a double-released pooled exchange.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpPooledExchangeTest.class,
+        SpringBootPlatformHttpPooledExchangeTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class },
+              properties = { "camel.main.exchange-factory=pooled" })
+public class SpringBootPlatformHttpPooledExchangeTest {
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void sequentialRequestsWithPooledExchanges() {
+        for (int i = 0; i < 10; i++) {
+            given()
+                    .body("hello-" + i)
+                    .post("/pooled")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("echo-hello-" + i));
+        }
+    }
+
+    @Test
+    void concurrentRequestsWithPooledExchanges() {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            final String payload = "payload-" + i;
+            futures.add(CompletableFuture.runAsync(() -> given()
+                    .body(payload)
+                    .post("/pooled")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("echo-" + payload))));
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder routeBuilder() {
+            return new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/pooled")
+                            .transform().simple("echo-${body}");
+                }
+            };
+        }
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpRouteLifecycleTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpRouteLifecycleTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import io.restassured.RestAssured;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that stopping a route unregisters its Spring MVC mapping (404 instead of dispatching to a stopped
+ * consumer) and that restarting the route registers it again.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpRouteLifecycleTest.class,
+        SpringBootPlatformHttpRouteLifecycleTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpRouteLifecycleTest {
+
+    @Autowired
+    private Environment env;
+
+    @Autowired
+    CamelContext camelContext;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void stoppedRouteIsUnregistered() throws Exception {
+        given().get("/lifecycle").then().statusCode(200).body(equalTo("alive"));
+
+        camelContext.getRouteController().stopRoute("lifecycle-route");
+        given().get("/lifecycle").then().statusCode(404);
+
+        camelContext.getRouteController().startRoute("lifecycle-route");
+        given().get("/lifecycle").then().statusCode(200).body(equalTo("alive"));
+    }
+
+    @Test
+    void stoppingRouteDoesNotUnregisterOtherConsumerOnSamePath() throws Exception {
+        given().get("/shared").then().statusCode(200).body(equalTo("shared-get"));
+        given().post("/shared").then().statusCode(200).body(equalTo("shared-post"));
+
+        camelContext.getRouteController().stopRoute("shared-get");
+        try {
+            // the POST consumer of the same path must keep working
+            given().post("/shared").then().statusCode(200).body(equalTo("shared-post"));
+        } finally {
+            camelContext.getRouteController().startRoute("shared-get");
+        }
+        given().get("/shared").then().statusCode(200).body(equalTo("shared-get"));
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder routeBuilder() {
+            return new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/lifecycle").routeId("lifecycle-route")
+                            .setBody().constant("alive");
+
+                    from("platform-http:/shared?httpMethodRestrict=GET").routeId("shared-get")
+                            .setBody().constant("shared-get");
+
+                    from("platform-http:/shared?httpMethodRestrict=POST").routeId("shared-post")
+                            .setBody().constant("shared-post");
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR addresses the findings of a code review of `camel-platform-http-starter`. Each finding is an isolated commit so they can be reviewed (or reverted) independently:

1. **Honor `CookieHandler` contract in `SpringBootCookieHandler`** — `getCookieValue` returned the sentinel string `"Cookie not found"` and `removeCookie` returned the cookie *name*; the `CookieHandler` contract (and the Vert.x implementation) return the value, or `null` when the cookie does not exist.
2. **Do not widen `httpMethodRestrict` to all methods on unparsable verbs** — `httpMethodRestrict=GET, POST` (note the space) silently registered a mapping serving **all** HTTP methods because the unresolved token became a null `RequestMethod`. Tokens are now trimmed/upper-cased and an unknown verb fails closed. Also fixes a latent NPE (`model.getVerbs()` vs the local `verbs` variable).
3. **Fix consumer exchange lifecycle** — `createExchange(true)` combined with the manual `releaseExchange(exchange, false)` in `afterProcess` double-releases pooled exchanges (`camel.main.exchange-factory=pooled`); aligned with `CamelServlet`/`VertxPlatformHttpConsumer` (`createExchange(false)` + manual release). Also releases the exchange when request parsing or `createUoW` fails.
4. **Fix consumer executor ownership** — every consumer allocated a throwaway single-thread `ExecutorService` that was immediately overwritten; when the fallback executor *was* used it was never shut down; an engine created via the port-only constructor produced consumers that NPE'd on the first request.
5. **Write only the ByteBuffer window in direct responses** — `bb.array()` dumped the whole backing array (sliced/partially-consumed buffers leaked adjacent bytes; direct buffers threw). Also replaces the visibly decompiled `doWriteDirectResponse` body (`var19` locals) with readable source re-aligned to `DefaultHttpBinding`.
6. **Unregister Spring MVC mappings when a route stops** — `unregisterHttpEndpoint` was a noop, so stopped/removed routes kept dispatching to a stopped consumer instead of returning 404. Mappings are now tracked per consumer, which keeps same-path/different-method consumers independent and sidesteps the shared-OPTIONS-handler issue noted in the code.
7. **Align auto-configuration with Spring Boot 4 idioms** — `@AutoConfiguration` for the imports-file-registered WebMvc configuration, `Threading.VIRTUAL.isActive()` instead of manual property parsing, `ServerProperties` instead of raw `server.port` parsing, type-safe `after =` references, no re-enabling of Boot-owned `WebMvcProperties`, specific exceptions. Executor selection semantics are unchanged.

Every fix comes with tests (new test classes: `SpringBootPlatformHttpMethodRestrictTest`, `SpringBootPlatformHttpPooledExchangeTest`, `SpringBootPlatformHttpConsumerExecutorTest`, `SpringBootPlatformHttpByteBufferResponseTest`, `SpringBootPlatformHttpRouteLifecycleTest`, plus extended cookie tests). Full `mvn verify` on the module passes.

# Target

- [x] main
- [ ] backport needed

_Claude Code on behalf of Federico Mariani (@Croway)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)