### PR TITLE
CAMEL-24003: Add activityEnabled and activitySize options to Spring Boot tracer

### DIFF
--- a/core/camel-spring-boot/src/main/docs/spring-boot.json
+++ b/core/camel-spring-boot/src/main/docs/spring-boot.json
@@ -1586,6 +1586,20 @@
       "sourceType": "org.apache.camel.spring.boot.threadpool.CamelThreadPoolConfigurationProperties"
     },
     {
+      "name": "camel.trace.activity-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether activity tracking is enabled.",
+      "sourceType": "org.apache.camel.spring.boot.trace.CamelTraceConfigurationProperties",
+      "defaultValue": false
+    },
+    {
+      "name": "camel.trace.activity-size",
+      "type": "java.lang.Integer",
+      "description": "Number of completed exchange summaries to keep in the activity queue (should be between 1 - 1000). Default is 100.",
+      "sourceType": "org.apache.camel.spring.boot.trace.CamelTraceConfigurationProperties",
+      "defaultValue": 100
+    },
+    {
       "name": "camel.trace.backlog-size",
       "type": "java.lang.Integer",
       "description": "Defines how many of the last messages to keep in the tracer.",

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceAutoConfiguration.java
@@ -63,6 +63,11 @@ public class CamelTraceAutoConfiguration {
         tracer.setTraceTemplates(config.isTraceTemplates());
         tracer.setTracePattern(config.getTracePattern());
         tracer.setTraceFilter(config.getTraceFilter());
+        tracer.setActivitySize(config.getActivitySize());
+        // dev profile enables activity tracking so tooling (TUI) gets enriched data
+        boolean activityEnabled = config.isActivityEnabled()
+                || "dev".equals(camelContext.getCamelContextExtension().getProfile());
+        tracer.setActivityEnabled(activityEnabled);
 
         camelContext.getCamelContextExtension().addContextPlugin(BacklogTracer.class, tracer);
         camelContext.addService(tracer);

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceConfigurationProperties.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceConfigurationProperties.java
@@ -94,6 +94,18 @@ public class CamelTraceConfigurationProperties {
     private boolean traceTemplates;
 
     /**
+     * Whether activity tracking is enabled.
+     */
+    private boolean activityEnabled;
+
+    /**
+     * Number of completed exchange summaries to keep in the activity queue (should be between 1 - 1000). Default is
+     * 100.
+     */
+    @Metadata(label = "advanced", defaultValue = "100")
+    private int activitySize = 100;
+
+    /**
      * Filter for tracing by route or node id
      */
     private String tracePattern;
@@ -197,6 +209,22 @@ public class CamelTraceConfigurationProperties {
 
     public void setTraceTemplates(boolean traceTemplates) {
         this.traceTemplates = traceTemplates;
+    }
+
+    public boolean isActivityEnabled() {
+        return activityEnabled;
+    }
+
+    public void setActivityEnabled(boolean activityEnabled) {
+        this.activityEnabled = activityEnabled;
+    }
+
+    public int getActivitySize() {
+        return activitySize;
+    }
+
+    public void setActivitySize(int activitySize) {
+        this.activitySize = activitySize;
     }
 
     public String getTracePattern() {


### PR DESCRIPTION
## Summary

- Add `camel.trace.activity-enabled` and `camel.trace.activity-size` properties to `CamelTraceConfigurationProperties`
- Wire both options in `CamelTraceAutoConfiguration`, with dev profile auto-enabling activity tracking
- Mirrors the same options added to camel-main's `TracerConfigurationProperties` in [apache/camel#24606](https://github.com/apache/camel/pull/24606)

## Test plan

- [ ] Verify `camel-spring-boot` module compiles
- [ ] Verify `camel.trace.activity-enabled=true` activates activity tracking
- [ ] Verify dev profile auto-enables activity without explicit config

_Claude Code on behalf of davsclaus_