### PR TITLE
CAMEL-24025: ship observability-services defaults via EnvironmentPostProcessor

### DIFF
--- a/components-starter/camel-observability-services-starter/pom.xml
+++ b/components-starter/camel-observability-services-starter/pom.xml
@@ -60,6 +60,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-observability-services-starter/src/main/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessor.java
+++ b/components-starter/camel-observability-services-starter/src/main/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.observability.services.springboot;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Contributes the opinionated observability defaults as the lowest precedence property source so that any
+ * user-provided configuration (application.properties, environment variables, system properties, ...) overrides them
+ * following the standard Spring Boot precedence rules.
+ */
+public class ObservabilityServicesEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    public static final String PROPERTY_SOURCE_NAME = "camel-observability-services";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        Map<String, Object> defaults = new LinkedHashMap<>();
+        defaults.put("management.server.port", "9876");
+        defaults.put("management.endpoints.web.exposure.include", "health,prometheus");
+        defaults.put("management.endpoints.web.base-path", "/observe");
+        defaults.put("management.endpoints.web.path-mapping.prometheus", "metrics");
+        // Metrics
+        defaults.put("camel.metrics.log-metrics-on-shutdown", "true");
+        defaults.put("camel.metrics.log-metrics-on-shutdown-filters", "app.info,camel.exchanges.*");
+        // Opentelemetry
+        defaults.put("camel.opentelemetry2.enabled", "true");
+        // Health
+        defaults.put("camel.health.exposure-level", "full");
+        defaults.put("management.endpoint.health.probes.enabled", "true");
+        defaults.put("management.health.readinessState.enabled", "true");
+        defaults.put("management.health.livenessState.enabled", "true");
+        defaults.put("management.endpoint.health.show-details", "always");
+        // /observe/health/live remap
+        defaults.put("management.endpoint.health.group.live.include", "livenessState,camelLivenessState");
+        defaults.put("management.endpoint.health.group.live.show-details", "always");
+        // /observe/health/ready remap
+        defaults.put("management.endpoint.health.group.ready.include", "readinessState,camelReadinessState");
+        defaults.put("management.endpoint.health.group.ready.show-details", "always");
+
+        environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, defaults));
+    }
+
+    @Override
+    public int getOrder() {
+        // run after ConfigDataEnvironmentPostProcessor so user configuration is already present
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/components-starter/camel-observability-services-starter/src/main/resources/META-INF/spring.factories
+++ b/components-starter/camel-observability-services-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,3 @@
-
 ## ---------------------------------------------------------------------------
 ## Licensed to the Apache Software Foundation (ASF) under one or more
 ## contributor license agreements.  See the NOTICE file distributed with
@@ -16,24 +15,5 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-management.server.port=9876
-management.endpoints.web.exposure.include=health,prometheus
-management.endpoints.web.base-path=/observe
-management.endpoints.web.path-mapping.prometheus=metrics
-# Metrics
-camel.metrics.log-metrics-on-shutdown=true
-camel.metrics.log-metrics-on-shutdown-filters=app.info,camel.exchanges.*
-# Opentelemetry
-camel.opentelemetry2.enabled=true
-# Health
-camel.health.exposure-level=full
-management.endpoint.health.probes.enabled=true
-management.health.readinessState.enabled=true
-management.health.livenessState.enabled=true
-management.endpoint.health.show-details=always
-# /observe/health/live remap
-management.endpoint.health.group.live.include=livenessState,camelLivenessState
-management.endpoint.health.group.live.show-details=always
-# /observe/health/ready remap
-management.endpoint.health.group.ready.include=readinessState,camelReadinessState
-management.endpoint.health.group.ready.show-details=always
+org.springframework.boot.EnvironmentPostProcessor=\
+org.apache.camel.observability.services.springboot.ObservabilityServicesEnvironmentPostProcessor

--- a/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessorTest.java
+++ b/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.observability.services.springboot;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = ObservabilityServicesTestApplication.class)
+public class ObservabilityServicesEnvironmentPostProcessorTest {
+
+    @Autowired
+    private ConfigurableEnvironment environment;
+
+    @Test
+    public void defaultsAreApplied() {
+        assertTrue(environment.getPropertySources()
+                .contains(ObservabilityServicesEnvironmentPostProcessor.PROPERTY_SOURCE_NAME));
+
+        assertEquals("health,prometheus", environment.getProperty("management.endpoints.web.exposure.include"));
+        assertEquals("metrics", environment.getProperty("management.endpoints.web.path-mapping.prometheus"));
+        assertEquals("true", environment.getProperty("camel.metrics.log-metrics-on-shutdown"));
+        assertEquals("app.info,camel.exchanges.*",
+                environment.getProperty("camel.metrics.log-metrics-on-shutdown-filters"));
+        assertEquals("full", environment.getProperty("camel.health.exposure-level"));
+        assertEquals("true", environment.getProperty("management.endpoint.health.probes.enabled"));
+        assertEquals("true", environment.getProperty("management.health.readinessState.enabled"));
+        assertEquals("true", environment.getProperty("management.health.livenessState.enabled"));
+        assertEquals("always", environment.getProperty("management.endpoint.health.show-details"));
+        assertEquals("livenessState,camelLivenessState",
+                environment.getProperty("management.endpoint.health.group.live.include"));
+        assertEquals("always", environment.getProperty("management.endpoint.health.group.live.show-details"));
+        assertEquals("readinessState,camelReadinessState",
+                environment.getProperty("management.endpoint.health.group.ready.include"));
+        assertEquals("always", environment.getProperty("management.endpoint.health.group.ready.show-details"));
+    }
+
+    @Test
+    public void userApplicationPropertiesOverrideDefaults() {
+        // these values are set in src/test/resources/application.properties and must win
+        // over the starter defaults, which was not possible when the defaults were
+        // packaged as config/application.properties inside the starter jar
+        assertEquals("9999", environment.getProperty("management.server.port"));
+        assertEquals("/custom-observe", environment.getProperty("management.endpoints.web.base-path"));
+        assertEquals("false", environment.getProperty("camel.opentelemetry2.enabled"));
+    }
+}

--- a/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesTestApplication.java
+++ b/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesTestApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.observability.services.springboot;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ObservabilityServicesTestApplication {
+}

--- a/components-starter/camel-observability-services-starter/src/test/resources/application.properties
+++ b/components-starter/camel-observability-services-starter/src/test/resources/application.properties
@@ -1,0 +1,23 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# User-level overrides of the starter defaults, used by
+# ObservabilityServicesEnvironmentPostProcessorTest to verify that regular
+# application.properties take precedence over the starter defaults
+management.server.port=9999
+management.endpoints.web.base-path=/custom-observe
+camel.opentelemetry2.enabled=false


### PR DESCRIPTION
Resolves [CAMEL-24025](https://issues.apache.org/jira/browse/CAMEL-24025)

## What

`camel-observability-services-starter` packaged its opinionated defaults as a literal `config/application.properties` inside the starter jar. Spring Boot's config-data search gives `classpath:/config/application.properties` higher precedence than the application's own `classpath:/application.properties`, so the starter defaults silently overrode user settings — customization was only possible via environment variables or system properties, and this limitation was even documented in the component docs (referencing spring-projects/spring-boot#24688).

This PR replaces the packaged properties file with an `ObservabilityServicesEnvironmentPostProcessor` registered via `META-INF/spring.factories`. It contributes the exact same defaults as a `MapPropertySource` added with `addLast(...)` (running at `Ordered.LOWEST_PRECEDENCE`, i.e. after `ConfigDataEnvironmentPostProcessor`), so the defaults sit at the bottom of the environment and every user-provided source overrides them following standard Spring Boot precedence rules. This aligns the behaviour with the Camel Main and Quarkus variants of `camel-observability-services`.

## Behavioural change

Previously the packaged defaults **won** over the user's `application.properties`; now the user's configuration wins. This is the intent of the ticket, but applications that set e.g. `management.server.port` and silently got `9876` anyway will now get their own value.

## Tests

New `ObservabilityServicesEnvironmentPostProcessorTest`:
- `defaultsAreApplied` — all defaults resolve from the environment when not overridden
- `userApplicationPropertiesOverrideDefaults` — values from a regular `application.properties` win over the starter defaults (this assertion fails against the previous packaged-file mechanism)

## Follow-up

The WARNING in the `camel-observability-services` docs (apache/camel, `observability-services.adoc`) stating that customization is not available on Spring Boot becomes obsolete once this is merged — will follow up with a docs PR in apache/camel.

---
_This PR was generated by Claude Code on behalf of Federico Mariani_

🤖 Generated with [Claude Code](https://claude.com/claude-code)