### PR TITLE
CAMEL-24057: check actually-used classes in @ConditionalOnClass for access log configurations

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/customizer/UndertowAccessLogConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/customizer/UndertowAccessLogConfiguration.java
@@ -35,7 +35,11 @@ import org.springframework.core.env.Environment;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(UndertowAccessLogProperties.class)
-@ConditionalOnClass(name = "io.undertow.Undertow")
+@ConditionalOnClass(name = {
+    "io.undertow.Undertow",
+    "io.undertow.server.handlers.accesslog.AccessLogHandler",
+    "io.undertow.server.handlers.accesslog.JBossLoggingAccessLogReceiver"
+})
 @ConditionalOnProperties( {
     @ConditionalOnProperty(name = "server.undertow.accesslog.enabled", havingValue = "false"),
     @ConditionalOnProperty(name = "camel.component.platform-http.server.undertow.accesslog.use-camel-logging", havingValue = "true"),

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/accesslog/ManagementAccessLogConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/accesslog/ManagementAccessLogConfiguration.java
@@ -47,7 +47,11 @@ public class ManagementAccessLogConfiguration {
      * Undertow-specific configuration.
      */
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(name = "io.undertow.Undertow")
+    @ConditionalOnClass(name = {
+            "io.undertow.Undertow",
+            "io.undertow.server.handlers.accesslog.AccessLogHandler",
+            "io.undertow.server.handlers.accesslog.JBossLoggingAccessLogReceiver"
+    })
     static class UndertowAccessLogCustomizerConfiguration {
 
         // TODO reintroduce once spring-boot-starter-undertow will be available
@@ -78,7 +82,10 @@ public class ManagementAccessLogConfiguration {
      * Tomcat-specific configuration to disable access logging in the management context.
      */
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(name = "org.apache.catalina.startup.Tomcat")
+    @ConditionalOnClass(name = {
+            "org.apache.catalina.startup.Tomcat",
+            "org.apache.catalina.valves.AccessLogValve"
+    })
     @ConditionalOnProperty(name = "management.server.accesslog.enabled", havingValue = "false")
     static class TomcatAccessLogCustomizerConfiguration {
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Federico Mariani_

`@ConditionalOnClass(name = "io.undertow.Undertow")` only checks for the top-level Undertow class, but the access log configurations use internal classes from `io.undertow.server.handlers.accesslog.*`. On JBoss EAP, the top-level class is visible (JBoss is built on Undertow) but the modular classloader doesn't export all internal packages, causing `ClassNotFoundException`.

- Updated `ManagementAccessLogConfiguration.UndertowAccessLogCustomizerConfiguration` to also check for `AccessLogHandler` and `JBossLoggingAccessLogReceiver`
- Updated `ManagementAccessLogConfiguration.TomcatAccessLogCustomizerConfiguration` to also check for `AccessLogValve` (defensive consistency)
- Updated `UndertowAccessLogConfiguration` to also check for `AccessLogHandler` and `JBossLoggingAccessLogReceiver`

On main, the Undertow code is commented out pending Spring Boot 4.0 `spring-boot-starter-undertow`, but the annotations are fixed now so the bug won't return when the code is uncommented.

## Test plan

- [x] `core/camel-spring-boot` builds successfully
- [x] `camel-platform-http-starter` builds successfully
- [ ] CI passes