### PR TITLE
CAMEL-24351: camel-platform-http-starter - correct the comments on the request mapping bean

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -90,14 +90,11 @@ public class SpringBootPlatformHttpAutoConfiguration {
         return new SpringBootPlatformHttpEngine(port, executor);
     }
 
-    /**
-     * The mapping registers itself as a {@link org.apache.camel.component.platform.http.PlatformHttpListener} and is
-     * only notified of endpoints created after it exists, so it must be eager. A lazy mapping is created on first
-     * demand, which is unordered with respect to CamelContext startup: if Camel starts first, every platform-http
-     * endpoint is already registered and the mapping never learns about any of them, leaving all of them unreachable
-     * with a 404 while the routes report themselves as started. CamelContext is taken as an ObjectProvider and
-     * resolved inside the method to avoid the circular dependency that injecting it directly would create.
-     */
+    // Must not be @Lazy: eager beans are created before Camel starts, so the mapping is listening before the first
+    // endpoint exists. Lazily it is created at DispatcherServlet init, which Boot defers to the first request, too late
+    // to hear about any endpoint. See CAMEL-24351.
+    // The ObjectProvider avoids an initialization cycle by keeping CamelContext out of this method's dependency set,
+    // not by deferring the lookup.
     @Bean
     public CamelRequestHandlerMapping platformHttpEngineRequestMapping(
             PlatformHttpEngine engine, ObjectProvider<CamelContext> camelContextProvider) {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEagerMappingTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEagerMappingTest.java
@@ -32,12 +32,9 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * {@link CamelRequestHandlerMapping} registers itself as a platform-http listener and is only notified of endpoints
- * created after it exists. It must therefore be instantiated eagerly: creating it on first demand is unordered with
- * respect to CamelContext startup, and when Camel starts first the mapping never learns about the endpoints that
- * already exist, so every platform-http route is answered with 404 while reporting itself as started.
- * <p>
- * That the context starts at all also covers the circular dependency the ObjectProvider avoids.
+ * Regression test for <a href="https://issues.apache.org/jira/browse/CAMEL-24351">CAMEL-24351</a>: the mapping only
+ * learns about endpoints created after it exists, so a lazily created one can miss every platform-http endpoint and
+ * answer 404. Asserts the bean definition rather than behaviour, because the runtime failure depends on startup timing.
  */
 @EnableAutoConfiguration
 @CamelSpringBootTest


### PR DESCRIPTION
Just a small update to CAMEL-24351 (#1874); the docs were slightly off.