### PR TITLE
CAMEL-24380: Fix platform-http timeout returning Whitelabel Error Page

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -110,12 +110,6 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
             }
             return null;
         });
-        task.onTimeout(() -> {
-            if (!response.isCommitted()) {
-                response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-            }
-            return null;
-        });
         return task;
     }
 


### PR DESCRIPTION
## Summary
- Remove the `WebAsyncTask.onTimeout()` callback that called `response.sendError(503)` directly, bypassing Spring MVC's exception resolution chain
- Without the callback, Spring's default `AsyncRequestTimeoutException` propagates normally, populating the `jakarta.servlet.error.*` request attributes so that Boot's `BasicErrorController` renders the standard JSON error response
- This aligns with how `main` and `4.22.x` handle timeouts (neither has a custom `onTimeout` callback)

## Test plan
- [ ] Verify that a platform-http route with a slow downstream returns Spring Boot's standard JSON error response (`{"status":503,"error":"Service Unavailable",...}`) when the request timeout is exceeded
- [ ] Verify that non-timeout requests are unaffected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)