### PR TITLE
chore: fix antora version for 4.22.x branch

### DIFF
--- a/components-starter/antora.yml
+++ b/components-starter/antora.yml
@@ -18,4 +18,4 @@
 # A distributed part of main camel "components" doc component.asciidoc:
 
 name: components
-version: next
+version: 4.22


### PR DESCRIPTION
## Summary
- Change Antora `version` from `next` to `4.22` in `components-starter/antora.yml` on the 4.22.x branch
- Fixes `FATAL (antora): Duplicate example` collision when the website build pulls both `main` and `camel-spring-boot-4.22.x` (both declared `version: next`, causing identical resource IDs)

## Test plan
- [ ] Verify the camel-website Antora build no longer produces `Duplicate example` errors for `activemq.json`

_Claude Code on behalf of Claus Ibsen_