### PR TITLE
chore: fix antora version for core on 4.22.x branch

### DIFF
--- a/components-starter/antora.yml
+++ b/components-starter/antora.yml
@@ -18,4 +18,4 @@
 # A distributed part of main camel "components" doc component.asciidoc:
 
 name: components
-version: 4.22
+version: 4.22.x

--- a/core/antora.yml
+++ b/core/antora.yml
@@ -16,4 +16,4 @@
 #
 
 name: camel-spring-boot
-version: next
+version: 4.22.x


### PR DESCRIPTION
## Summary
- Fix `core/antora.yml` version from `next` to `4.22.x` — same collision issue as #1887 but for the `camel-spring-boot` component
- Also align `components-starter/antora.yml` from `4.22` to `4.22.x` to match the `docs/` descriptors (`docs/components/antora.yml` and `docs/spring-boot/antora.yml` already use `4.22.x`)

## Test plan
- [ ] Verify the camel-website Antora build no longer produces `Duplicate page` errors for `spring-boot.adoc`

_Claude Code on behalf of Claus Ibsen_