### PR TITLE
CAMEL-24496: camel-platform-http-starter - align SpringBootPlatformHttpBinding multipart handling

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
@@ -104,50 +104,77 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
             message.setHeader(Exchange.ATTACHMENTS_SIZE, multipartHttpServletRequest.getFileMap().keySet().size());
             multipartHttpServletRequest.getFileMap().forEach((name, multipartFile) -> {
                 try {
-                    Path uploadedTmpFile = Paths.get(tmpFolder.getPath(), UUID.randomUUID().toString());
-                    multipartFile.transferTo(uploadedTmpFile);
-
                     if (name != null) {
                         name = name.replaceAll("[\n\r\t]", "_");
                     }
 
-                    boolean accepted = true;
-
-                    if (getFileNameExtWhitelist() != null) {
-                        String ext = FileUtil.onlyExt(name);
-                        if (ext != null) {
-                            ext = ext.toLowerCase(Locale.US);
-                            if (!getFileNameExtWhitelist().equals("*") && !getFileNameExtWhitelist().contains(ext)) {
-                                accepted = false;
-                            }
-                        }
-                    }
-
-                    if (accepted) {
-                        AttachmentMessage am = new DefaultAttachmentMessage(message);
-                        File uploadedFile = uploadedTmpFile.toFile();
-                        am.addAttachment(name, new DataHandler(new CamelFileDataSource(uploadedFile, name)));
-
-                        // populate body in case there is only one attachment
-                        if (isSingleAttachment) {
-                            message.setHeader(Exchange.FILE_PATH, uploadedFile.getAbsolutePath());
-                            message.setHeader(Exchange.FILE_LENGTH, multipartFile.getSize());
-                            message.setHeader(Exchange.FILE_NAME, multipartFile.getOriginalFilename());
-                            if (multipartFile.getContentType() != null) {
-                                message.setHeader(Exchange.FILE_CONTENT_TYPE, multipartFile.getContentType());
-                            }
-                            message.setBody(uploadedTmpFile);
-                        }
-                    } else {
+                    // the whitelist is evaluated against the submitted file name - the value that is
+                    // propagated downstream - and before the upload is written to the servlet temp
+                    // directory, so a rejected file never reaches disk
+                    if (!isFileNameExtAccepted(multipartFile.getOriginalFilename())) {
                         LOG.debug(
                                 "Cannot add file as attachment: {} because the file is not accepted according to fileNameExtWhitelist: {}",
                                 name, getFileNameExtWhitelist());
+                        return;
+                    }
+
+                    Path uploadedTmpFile = Paths.get(tmpFolder.getPath(), UUID.randomUUID().toString());
+                    multipartFile.transferTo(uploadedTmpFile);
+
+                    AttachmentMessage am = new DefaultAttachmentMessage(message);
+                    File uploadedFile = uploadedTmpFile.toFile();
+                    am.addAttachment(name, new DataHandler(new CamelFileDataSource(uploadedFile, name)));
+
+                    // populate body in case there is only one attachment
+                    if (isSingleAttachment) {
+                        message.setHeader(Exchange.FILE_PATH, uploadedFile.getAbsolutePath());
+                        message.setHeader(Exchange.FILE_LENGTH, multipartFile.getSize());
+                        // FILE_NAME is a Camel control header consumed by file/ftp producers; the raw
+                        // client-supplied multipart filename may contain path segments, so reduce it to a
+                        // leaf name (CAMEL-24293)
+                        message.setHeader(Exchange.FILE_NAME, FileUtil.stripPath(multipartFile.getOriginalFilename()));
+                        if (multipartFile.getContentType() != null) {
+                            message.setHeader(Exchange.FILE_CONTENT_TYPE, multipartFile.getContentType());
+                        }
+                        message.setBody(uploadedTmpFile);
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             });
         }
+    }
+
+    /**
+     * Whether the submitted file name is accepted according to the configured {@code fileNameExtWhitelist}.
+     * <p/>
+     * The whitelist is a comma separated list of extensions, or {@code *} to accept every file. When a whitelist is
+     * configured, a file name that carries no extension is not accepted.
+     *
+     * @param  fileName the submitted file name, as sent by the client
+     * @return          <tt>true</tt> if the file may be added as an attachment
+     */
+    private boolean isFileNameExtAccepted(String fileName) {
+        final String whitelist = getFileNameExtWhitelist();
+        if (whitelist == null) {
+            return true;
+        }
+        final String trimmedWhitelist = whitelist.trim();
+        if ("*".equals(trimmedWhitelist)) {
+            return true;
+        }
+        // keep the multi-extension semantics of FileUtil.onlyExt so a whitelist such as "tar.gz" works
+        final String ext = FileUtil.onlyExt(fileName);
+        if (ext == null) {
+            return false;
+        }
+        final String candidate = ext.toLowerCase(Locale.US);
+        for (String allowed : trimmedWhitelist.split(",")) {
+            if (candidate.equals(allowed.trim().toLowerCase(Locale.US))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void setStreaming(boolean streaming) {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpFileNameExtWhitelistTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpFileNameExtWhitelistTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import io.restassured.RestAssured;
+import org.apache.camel.Exchange;
+import org.apache.camel.attachment.AttachmentMessage;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.nio.charset.StandardCharsets;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Verifies that {@code fileNameExtWhitelist} is enforced against the submitted file name, fails closed when the name
+ * carries no extension, and matches whole extension tokens rather than substrings. Also covers the
+ * {@code CamelFileName} path-segment stripping aligned with CAMEL-24293.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpFileNameExtWhitelistTest.class,
+        SpringBootPlatformHttpFileNameExtWhitelistTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpFileNameExtWhitelistTest {
+
+    private static final byte[] CONTENT = "upload content".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void acceptsWhitelistedExtension() {
+        given().multiPart("file", "invoice.pdf", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("1"));
+    }
+
+    @Test
+    void acceptsSecondWhitelistEntryIgnoringSurroundingSpaces() {
+        given().multiPart("file", "notes.txt", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("1"));
+    }
+
+    @Test
+    void rejectsExtensionOutsideTheWhitelist() {
+        given().multiPart("file", "shell.jsp", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("0"));
+    }
+
+    /**
+     * The whitelist must be evaluated against the submitted file name, not the multipart field name - the field name
+     * is not the value propagated downstream.
+     */
+    @Test
+    void rejectsWhenOnlyTheFieldNameLooksWhitelisted() {
+        given().multiPart("report.pdf", "shell.jsp", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("0"));
+    }
+
+    /**
+     * A file name with no extension must fail closed while a whitelist is configured.
+     */
+    @Test
+    void rejectsFileNameWithoutExtension() {
+        given().multiPart("file", "shell", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("0"));
+    }
+
+    /**
+     * "pd" must not be accepted just because it is a substring of the whitelisted "pdf".
+     */
+    @Test
+    void rejectsSubstringOfAWhitelistedExtension() {
+        given().multiPart("file", "invoice.pd", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("0"));
+    }
+
+    @Test
+    void stripsPathSegmentsFromCamelFileName() {
+        given().multiPart("file", "../../evil.pdf", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header("attachmentCount", is("1"))
+                .header("uploadFileName", is("evil.pdf"));
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .csrf(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder whitelistRoute() {
+            return new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/upload?fileNameExtWhitelist=pdf,txt")
+                            .process(exchange -> {
+                                AttachmentMessage am = exchange.getMessage(AttachmentMessage.class);
+                                int count = am.getAttachments() == null ? 0 : am.getAttachments().size();
+                                Object fileName = exchange.getMessage().getHeader(Exchange.FILE_NAME);
+                                exchange.getMessage().setHeader("attachmentCount", String.valueOf(count));
+                                exchange.getMessage().setHeader("uploadFileName", fileName == null ? "" : fileName.toString());
+                                exchange.getMessage().setBody("ok");
+                            });
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Aligns `SpringBootPlatformHttpBinding.populateAttachments()` with the equivalent bindings in the other
HTTP server components. Three items, all in that one method.

### 1. `fileNameExtWhitelist` was evaluated against the multipart field name

`getFileMap().forEach((name, multipartFile) -> ...)` gives `name` = the multipart **field** key, not the
submitted file name — but line 135 propagated `multipartFile.getOriginalFilename()` downstream regardless.
With `fileNameExtWhitelist=pdf`, a part with field name `file` carrying `filename="shell.jsp"` was accepted,
because `FileUtil.onlyExt("file")` is `null` and the check was skipped.

Two further problems in the same block:

- **Fail-open on a missing extension.** `if (ext != null)` left `accepted = true` when the name had no
  extension, so a whitelist never rejected an extension-less name.
- **Substring matching.** `getFileNameExtWhitelist().contains(ext)` meant a whitelist of `pdf` also matched
  `invoice.pd`.

The check now runs against `getOriginalFilename()`, fails closed when a whitelist is configured and the name
has no extension, and compares whole comma-separated tokens case-insensitively. `FileUtil.onlyExt`'s
first-dot semantics are preserved so a whitelist entry such as `tar.gz` keeps working.

### 2. Rejected uploads were still written to the servlet temp directory

`transferTo()` ran before the whitelist decision and the rejection branch only logged, so a rejected upload
stayed on disk for the lifetime of the process. The decision now happens first — `getOriginalFilename()` is
available without transferring — so a rejected file never reaches disk.

### 3. `CamelFileName` set from the raw submitted name

`Exchange.FILE_NAME` is a control header consumed by the file/ftp producers. CAMEL-24293 applied
`FileUtil.stripPath(...)` to externally-derived names in `camel-platform-http-vertx`, `camel-zipfile` and
`camel-tarfile`; this binding lives in camel-spring-boot and was not covered by that change. Same
normalisation applied here, with the same comment.

`Exchange.FILE_PATH` and `FILE_LENGTH` are left as they are — they are deliberate (added in
`2c0d67f9f87`) and the vertx reference implementation sets `FILE_PATH` too.

### Tests

`SpringBootPlatformHttpFileNameExtWhitelistTest` — 7 cases. Verified meaningful: the 5 defect cases all fail
against the unpatched binding and pass with it; the 2 happy-path cases pass either way as regression guards.
Full module suite: 124 tests, 0 failures.

### Deliberately not in this PR

**Path variables from the raw URI** (also listed on CAMEL-24496). `populateRequestParameters()` evaluates
placeholders against `getRawPath()`, which returns the undecoded `request.getRequestURI()`. Changing that is
wider than it looks: the base-class `getRawPath()` also feeds `Exchange.HTTP_PATH` for every request, and the
override exists on purpose (CAMEL-22116, refined by CAMEL-23191 for context-path handling). Worth doing, but
it deserves its own change and its own discussion rather than riding along here.

### Note for CAMEL-24427

While checking the reference implementations: the **fail-open** and **substring** problems above are not
specific to this starter. `DefaultHttpBinding.populateAttachments()` in `camel-http-common` has both, and so
does `VertxPlatformHttpConsumer`. Only the wrong-value defect is camel-spring-boot's own. Since CAMEL-24427
is already open for camel-servlet/camel-jetty, those two may be worth folding into its scope so all the
engines agree — otherwise this binding is now stricter than the others.

---
_Filed by Claude Code on behalf of Andrea Cosentino._