### PR TITLE
CAMEL-24508: vault and secrets starters - fail closed when early property resolution fails

### DIFF
--- a/components-starter/camel-aws-secrets-manager-starter/src/main/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParser.java
+++ b/components-starter/camel-aws-secrets-manager-starter/src/main/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParser.java
@@ -44,6 +44,10 @@ public class SpringBootAwsSecretsManagerPropertiesParser implements ApplicationL
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         SecretsManagerClient client;
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         if (Boolean.parseBoolean(environment.getProperty("camel.component.aws-secrets-manager.early-resolve-properties"))) {
             String accessKey = environment.getProperty("camel.vault.aws.accessKey");
             String secretKey = environment.getProperty("camel.vault.aws.secretKey");
@@ -94,8 +98,17 @@ public class SpringBootAwsSecretsManagerPropertiesParser implements ApplicationL
                                         .replace("}}", ""));
                                 props.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-azure-key-vault-starter/src/main/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParser.java
+++ b/components-starter/camel-azure-key-vault-starter/src/main/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParser.java
@@ -44,6 +44,10 @@ public class SpringBootAzureKeyVaultPropertiesParser implements ApplicationListe
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         SecretClient client;
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         if (Boolean.parseBoolean(environment.getProperty("camel.component.azure-key-vault.early-resolve-properties"))) {
             String vaultName = environment.getProperty("camel.vault.azure.vaultName");
             String clientId = environment.getProperty("camel.vault.azure.clientId");
@@ -103,8 +107,17 @@ public class SpringBootAzureKeyVaultPropertiesParser implements ApplicationListe
                                         .replace("}}", ""));
                                 props.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-cyberark-vault-starter/src/main/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParser.java
+++ b/components-starter/camel-cyberark-vault-starter/src/main/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParser.java
@@ -40,6 +40,10 @@ public class SpringBootCyberArkVaultPropertiesParser implements ApplicationListe
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConjurClient client;
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         if (Boolean.parseBoolean(environment.getProperty("camel.component.cyberark-vault.early-resolve-properties"))) {
             String url = environment.getProperty("camel.vault.cyberark.url");
             String account = environment.getProperty("camel.vault.cyberark.account");
@@ -92,8 +96,17 @@ public class SpringBootCyberArkVaultPropertiesParser implements ApplicationListe
                                         .replace("}}", ""));
                                 props.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-google-secret-manager-starter/src/main/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParser.java
+++ b/components-starter/camel-google-secret-manager-starter/src/main/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParser.java
@@ -41,6 +41,10 @@ public class SpringBootGoogleSecretManagerPropertiesParser implements Applicatio
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         SecretManagerServiceClient client;
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         String projectId;
         if (Boolean.parseBoolean(environment.getProperty("camel.component.google-secret-manager.early-resolve-properties"))) {
             projectId = environment.getProperty("camel.vault.gcp.projectId");
@@ -79,8 +83,17 @@ public class SpringBootGoogleSecretManagerPropertiesParser implements Applicatio
                                         .replace("}}", ""));
                                 props.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-hashicorp-vault-starter/src/main/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParser.java
+++ b/components-starter/camel-hashicorp-vault-starter/src/main/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.hashicorp.vault.springboot;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.hashicorp.vault.HashicorpVaultPropertiesFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,10 @@ public class SpringBootHashicorpVaultPropertiesParser implements ApplicationList
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         if (Boolean.parseBoolean(environment.getProperty("camel.component.hashicorp-vault.early-resolve-properties"))) {
             Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.token"), "Hashicorp Vault token is required");
             Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.host"), "Hashicorp Vault host is required");
@@ -82,8 +87,17 @@ public class SpringBootHashicorpVaultPropertiesParser implements ApplicationList
                                         .replace("{{hashicorp:", "")
                                         .replace("}}", "")));
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/EarlyResolutionFailureTest.java
+++ b/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/EarlyResolutionFailureTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hashicorp.vault.springboot;
+
+import org.apache.camel.RuntimeCamelException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.bootstrap.DefaultBootstrapContext;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A placeholder that matched the vault prefix but could not be resolved must not be left in place, since the literal
+ * placeholder text would then become the effective value of whatever it configures.
+ */
+public class EarlyResolutionFailureTest {
+
+    private static final String SECRET_KEY = "my.secret";
+
+    private static ApplicationEnvironmentPreparedEvent eventWith(boolean ignoreResolutionFailures) {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("camel.component.hashicorp-vault.early-resolve-properties", "true");
+        props.put("camel.vault.hashicorp.token", "not-a-real-token");
+        props.put("camel.vault.hashicorp.host", "127.0.0.1");
+        // nothing listens here, so the lookup fails locally without touching the network
+        props.put("camel.vault.hashicorp.port", "1");
+        props.put("camel.vault.hashicorp.scheme", "http");
+        props.put(SECRET_KEY, "{{hashicorp:secret:does/not/exist#value}}");
+        if (ignoreResolutionFailures) {
+            props.put("camel.vault.ignore-resolution-failures", "true");
+        }
+
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test-properties", props));
+
+        return new ApplicationEnvironmentPreparedEvent(
+                new DefaultBootstrapContext(), new SpringApplication(), new String[0], environment);
+    }
+
+    @Test
+    public void unresolvableSecretAbortsStartup() {
+        SpringBootHashicorpVaultPropertiesParser parser = new SpringBootHashicorpVaultPropertiesParser();
+
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.onApplicationEvent(eventWith(false)));
+
+        assertTrue(thrown.getMessage().contains(SECRET_KEY),
+                "the failure should name the property that could not be resolved, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("camel.vault.ignore-resolution-failures"),
+                "the failure should point at the opt-back property, was: " + thrown.getMessage());
+    }
+
+    @Test
+    public void ignoreResolutionFailuresRestoresTheTolerantBehaviour() {
+        SpringBootHashicorpVaultPropertiesParser parser = new SpringBootHashicorpVaultPropertiesParser();
+
+        assertDoesNotThrow(() -> parser.onApplicationEvent(eventWith(true)));
+    }
+}

--- a/components-starter/camel-ibm-secrets-manager-starter/src/main/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParser.java
+++ b/components-starter/camel-ibm-secrets-manager-starter/src/main/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParser.java
@@ -40,6 +40,10 @@ public class IBMSecretsManagerVaultPropertiesParser implements ApplicationListen
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         SecretsManager client;
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
         String token;
         String serviceUrl;
         if (Boolean.parseBoolean(environment.getProperty("camel.component.ibm-secrets-manager.early-resolve-properties"))) {
@@ -77,8 +81,17 @@ public class IBMSecretsManagerVaultPropertiesParser implements ApplicationListen
                                         .replace("}}", ""));
                                 props.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
@@ -38,7 +38,7 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
         Properties properties = new Properties();
         ConfigurableEnvironment environment = event.getEnvironment();
         // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        // configuration value, so resolution failures abort startup unless the operator opts back in
         final boolean ignoreResolutionFailures
                 = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
 
@@ -65,12 +65,12 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
                                 properties.put(key, element);
                             } catch (Exception e) {
                                 if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                    LOG.warn("Failed to resolve property {} from Spring Cloud Config; the placeholder is left "
                                              + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
                                 } else {
                                     throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
+                                            "Failed to resolve property " + key + " from Spring Cloud Config. Startup is aborted "
+                                                            + "so that the unresolved placeholder cannot become the effective "
                                                             + "value; set camel.vault.ignore-resolution-failures=true to "
                                                             + "continue anyway.",
                                             e);

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.spring.cloud.config.springboot;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.spring.cloud.config.SpringCloudConfigPropertiesFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,10 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         Properties properties = new Properties();
         ConfigurableEnvironment environment = event.getEnvironment();
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
 
         if (Boolean.parseBoolean(
                 environment.getProperty("camel.component.spring-cloud-config.early-resolve-properties"))) {
@@ -59,8 +64,17 @@ public class SpringBootCloudConfigPropertiesParser implements ApplicationListene
                                         .apply(stringValue.replace("{{spring-config:", "").replace("}}", ""));
                                 properties.put(key, element);
                             } catch (Exception e) {
-                                // Log and do nothing
-                                LOG.debug("failed to parse property {}. This exception is ignored.", key, e);
+                                if (ignoreResolutionFailures) {
+                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
+                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
+                                } else {
+                                    throw new RuntimeCamelException(
+                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
+                                                            + "that the unresolved placeholder cannot become the effective "
+                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
+                                                            + "continue anyway.",
+                                            e);
+                                }
                             }
                         }
                     });

--- a/core/camel-spring-boot/src/main/docs/spring-boot.json
+++ b/core/camel-spring-boot/src/main/docs/spring-boot.json
@@ -2080,6 +2080,12 @@
       "sourceType": "org.apache.camel.spring.boot.vault.IBMVaultConfigurationProperties"
     },
     {
+      "name": "camel.vault.ignore-resolution-failures",
+      "type": "java.lang.Boolean",
+      "description": "Whether a vault or secrets placeholder that cannot be resolved during early property resolution should be tolerated. When false (the default) an unresolvable placeholder aborts startup, so the literal placeholder text can never become the effective value. When true the failure is logged at WARN and the placeholder is left in place.",
+      "defaultValue": false
+    },
+    {
       "name": "camel.vault.kubernetes.refresh-enabled",
       "type": "java.lang.Boolean",
       "description": "Define if we want to refresh the secrets on update",

--- a/core/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/camel-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,6 +1,12 @@
 {
   "properties": [
     {
+      "name": "camel.vault.ignore-resolution-failures",
+      "type": "java.lang.Boolean",
+      "description": "Whether a vault or secrets placeholder that cannot be resolved during early property resolution should be tolerated. When false (the default) an unresolvable placeholder aborts startup, so the literal placeholder text can never become the effective value. When true the failure is logged at WARN and the placeholder is left in place.",
+      "defaultValue": false
+    },
+    {
       "name": "management.info.camel.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Camel info.",


### PR DESCRIPTION

### Changed after review

Addressing @davsclaus's findings:

- **`SpringBootCloudConfigPropertiesParser` no longer says "from the vault".** Spring Cloud Config isn't a
  vault — that was a wording defect from applying the same message text uniformly across all seven parsers.
- **`camel.vault.ignore-resolution-failures` is now declared in config metadata.** It's read from the
  `Environment` before any bean exists, so it can't hang off a `@ConfigurationProperties` bean like the
  per-vault options; it's declared in `core/camel-spring-boot`'s `additional-spring-configuration-metadata.json`
  (the mechanism already used there for `management.info.camel.enabled` and
  `management.server.accesslog.enabled`) and regenerates into `spring-boot.json`, so it surfaces in IDE
  completion.

Two of his findings are deliberately not addressed here: replicating the regression test across the other six
parsers (worth doing, kept out to keep this changeset reviewable — happy to do it here or as a follow-up), and
the upgrade-guide entry, which will be opened against `apache/camel` before this merges.

---
_Filed by Claude Code on behalf of Andrea Cosentino._