### PR TITLE
CAMEL-24532: Preserve property-source precedence during early vault resolution

### DIFF
--- a/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/SpringBootJasyptPropertiesParser.java
+++ b/components-starter/camel-jasypt-starter/src/main/java/org/apache/camel/component/jasypt/springboot/SpringBootJasyptPropertiesParser.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.jasypt.springboot;
 
 import org.apache.camel.component.jasypt.JasyptPropertiesParser;
 import org.apache.camel.component.properties.PropertiesParser;
+import org.apache.camel.spring.boot.EarlyResolutionPropertySources;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.jasypt.encryption.StringEncryptor;
@@ -74,10 +75,15 @@ public class SpringBootJasyptPropertiesParser implements ApplicationListener<App
                                 originTrackedValue.getValue() instanceof String stringValue &&
                                 stringValue.startsWith(JasyptPropertiesParser.JASYPT_PREFIX_TOKEN) &&
                                 stringValue.endsWith(JasyptPropertiesParser.JASYPT_SUFFIX_TOKEN)) {
+                            if (EarlyResolutionPropertySources.shouldSkipBecauseHigherPrecedenceDefines(
+                                    event.getEnvironment().getPropertySources(), mutablePropertySources, key, LOG)) {
+                                return;
+                            }
 
                             LOG.debug("decrypting and overriding property {}", key);
                             try {
-                                props.put(key, propertiesParser.parseProperty(key.toString(), stringValue, null));
+                                EarlyResolutionPropertySources.putIfAbsent(props, key,
+                                        propertiesParser.parseProperty(key.toString(), stringValue, null));
                             } catch (Exception e) {
                                 // Log and do nothing
                                 LOG.debug("failed to parse property {}", key, e);

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
@@ -24,7 +24,6 @@ import org.apache.camel.spi.PropertiesFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
@@ -105,8 +104,12 @@ public abstract class AbstractEarlyResolutionPropertiesParser
         for (PropertySource<?> propertySource : environment.getPropertySources()) {
             if (propertySource instanceof MapPropertySource mapPropertySource) {
                 mapPropertySource.getSource().forEach((key, value) -> {
-                    String stringValue = asString(value);
+                    String stringValue = EarlyResolutionPropertySources.asString(value);
                     if (stringValue != null && stringValue.startsWith(prefix) && stringValue.endsWith(SUFFIX)) {
+                        if (EarlyResolutionPropertySources.shouldSkipBecauseHigherPrecedenceDefines(
+                                environment.getPropertySources(), propertySource, key, LOG)) {
+                            return;
+                        }
                         String remainder = stringValue.substring(prefix.length(),
                                 stringValue.length() - SUFFIX.length());
                         LOG.debug("Resolving and overriding property {}", key);
@@ -117,7 +120,7 @@ public abstract class AbstractEarlyResolutionPropertiesParser
                                         "The " + propertiesFunction.getName()
                                                 + " properties function returned no value for " + remainder);
                             }
-                            props.put(key, resolved);
+                            EarlyResolutionPropertySources.putIfAbsent(props, key, resolved);
                         } catch (Exception e) {
                             if (ignoreResolutionFailures) {
                                 LOG.warn("Failed to resolve property {} from {}; the placeholder is left "
@@ -148,16 +151,5 @@ public abstract class AbstractEarlyResolutionPropertiesParser
 
         environment.getPropertySources()
                 .addFirst(new PropertiesPropertySource(getOverridePropertySourceName(), props));
-    }
-
-    private static String asString(Object value) {
-        if (value instanceof OriginTrackedValue originTrackedValue
-                && originTrackedValue.getValue() instanceof String v) {
-            return v;
-        }
-        if (value instanceof String v) {
-            return v;
-        }
-        return null;
     }
 }

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/EarlyResolutionPropertySources.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/EarlyResolutionPropertySources.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.springframework.boot.origin.OriginTrackedValue;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Helpers for early property resolution listeners that inject a flat {@link Properties} override via
+ * {@code PropertySources.addFirst}.
+ * <p/>
+ * Spring iterates property sources in precedence order (highest first). When the same key appears in multiple
+ * sources, callers must retain the first resolved value so the override map reflects Spring's normal precedence
+ * after it is added with {@code addFirst}.
+ */
+public final class EarlyResolutionPropertySources {
+
+    private EarlyResolutionPropertySources() {
+    }
+
+    /**
+     * Returns the string value from a property source entry, including {@link OriginTrackedValue} wrappers.
+     */
+    public static String asString(Object value) {
+        if (value instanceof OriginTrackedValue originTrackedValue
+                && originTrackedValue.getValue() instanceof String stringValue) {
+            return stringValue;
+        }
+        if (value instanceof String stringValue) {
+            return stringValue;
+        }
+        return null;
+    }
+
+    /**
+     * Stores a resolved value only when the key is not already present, preserving highest-precedence values
+     * collected while iterating property sources.
+     */
+    public static void putIfAbsent(Properties props, Object key, String resolvedValue) {
+        props.putIfAbsent(key.toString(), resolvedValue);
+    }
+
+    /**
+     * Returns whether a property source with higher precedence defines the same key.
+     * <p/>
+     * Only {@link MapPropertySource} instances are inspected, matching the scanning loop used by the early-resolution
+     * parsers. Higher-precedence non-map sources (for example command-line arguments via
+     * {@code SimpleCommandLinePropertySource}) are not detected by this helper.
+     */
+    public static boolean hasHigherPrecedenceProperty(
+            Iterable<PropertySource<?>> propertySources, PropertySource<?> currentPropertySource, Object key) {
+        for (PropertySource<?> propertySource : propertySources) {
+            if (propertySource == currentPropertySource) {
+                return false;
+            }
+            if (propertySource instanceof MapPropertySource && propertySource.containsProperty(key.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Logs and returns {@code true} when early resolution should be skipped because a higher-precedence source
+     * already defines the key.
+     */
+    public static boolean shouldSkipBecauseHigherPrecedenceDefines(
+            Iterable<PropertySource<?>> propertySources, PropertySource<?> currentPropertySource, Object key,
+            Logger log) {
+        if (hasHigherPrecedenceProperty(propertySources, currentPropertySource, key)) {
+            log.debug(
+                    "Skipping early resolution for property {} from property source {} because a "
+                            + "higher-precedence property source already defines it",
+                    key, currentPropertySource.getName());
+            return true;
+        }
+        return false;
+    }
+}

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
@@ -309,4 +309,42 @@ public class AbstractEarlyResolutionPropertiesParserTest {
         assertEquals("{{test:missing}}", environment.getProperty("bad.secret"),
                 "in tolerant mode the unresolved placeholder is deliberately left in place");
     }
+
+    @Test
+    public void preservesHighestPrecedencePlaceholderForDuplicateKeys() {
+        RecordingEnvironment environment = new RecordingEnvironment();
+        environment.getPropertySources().addLast(new MapPropertySource("application.properties", Map.of(
+                "my.secret", "{{test:default-secret}}")));
+        environment.getPropertySources().addFirst(new MapPropertySource("application-prod.properties", Map.of(
+                "my.secret", "{{test:prod-secret}}")));
+        environment.getPropertySources().addFirst(new MapPropertySource("guard", Map.of(GUARD, "true")));
+        StubPropertiesFunction function = new StubPropertiesFunction(
+                Map.of("prod-secret", "from-prod", "default-secret", "from-default"), Set.of());
+        TestParser parser = new TestParser(function);
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals("from-prod", environment.getProperty("my.secret"),
+                "the highest-precedence placeholder must win when the same key appears in multiple sources");
+        assertEquals(List.of("prod-secret"), function.applied,
+                "the lower-precedence duplicate must not contact the vault backend");
+    }
+
+    @Test
+    public void skipsLowerPrecedencePlaceholderWhenHigherPrecedenceDefinesKey() {
+        RecordingEnvironment environment = new RecordingEnvironment();
+        environment.getPropertySources().addLast(new MapPropertySource("application.properties", Map.of(
+                "my.secret", "{{test:missing}}")));
+        environment.getPropertySources().addFirst(new MapPropertySource("application-prod.properties", Map.of(
+                "my.secret", "plain-value")));
+        environment.getPropertySources().addFirst(new MapPropertySource("guard", Map.of(GUARD, "true")));
+        StubPropertiesFunction function = new StubPropertiesFunction(Map.of(), Set.of("missing"));
+        TestParser parser = new TestParser(function);
+
+        assertDoesNotThrow(() -> parser.onApplicationEvent(eventFor(environment)));
+
+        assertEquals(List.of(), function.applied,
+                "a shadowed lower-precedence placeholder must not be resolved");
+        assertEquals("plain-value", environment.getProperty("my.secret"));
+    }
 }

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/EarlyResolutionPropertySourcesTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/EarlyResolutionPropertySourcesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.origin.OriginTrackedValue;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EarlyResolutionPropertySourcesTest {
+
+    @Test
+    void shouldExtractStringFromOriginTrackedValue() {
+        OriginTrackedValue tracked = OriginTrackedValue.of("{{vault:secret}}");
+        assertEquals("{{vault:secret}}", EarlyResolutionPropertySources.asString(tracked));
+    }
+
+    @Test
+    void shouldPreserveHighestPrecedenceValueForDuplicateKeys() {
+        Properties props = new Properties();
+        EarlyResolutionPropertySources.putIfAbsent(props, "key", "from-prod");
+        EarlyResolutionPropertySources.putIfAbsent(props, "key", "from-default");
+
+        assertEquals("from-prod", props.getProperty("key"));
+    }
+
+    @Test
+    void shouldDetectHigherPrecedencePropertyInMapPropertySource() {
+        MutablePropertySources sources = new MutablePropertySources();
+        MapPropertySource high = new MapPropertySource("high", Map.of("my.secret", "plain"));
+        MapPropertySource low = new MapPropertySource("low", Map.of("my.secret", "{{vault:secret}}"));
+        sources.addFirst(high);
+        sources.addLast(low);
+
+        assertTrue(EarlyResolutionPropertySources.hasHigherPrecedenceProperty(sources, low, "my.secret"));
+        assertFalse(EarlyResolutionPropertySources.hasHigherPrecedenceProperty(sources, high, "my.secret"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24532](https://issues.apache.org/jira/browse/CAMEL-24532).

Early-resolution listeners iterate Spring `PropertySources` highest-precedence first but used `Properties.put`, so duplicate keys were overwritten by lower-precedence sources before the flat override map was added with `addFirst`.

This PR introduces `EarlyResolutionPropertySources` with `putIfAbsent` and higher-precedence guards, applies them in `AbstractEarlyResolutionPropertiesParser` (all vault starters via #1917) and the Jasypt parser, and adds regression tests.

## Rebase on main (#1917)

Rebased onto current `main` after #1917 merged `AbstractEarlyResolutionPropertiesParser`. Precedence logic now lives in the shared base class instead of duplicating across eight parsers.

## Review feedback addressed

| Reviewer | Item | Status |
|----------|------|--------|
| @Croway | Skip resolution before contacting backends when higher-precedence source defines key | ✅ |
| @Croway | DEBUG log key + source name only | ✅ |
| @davsclaus | Parser-level test: duplicate placeholders across property sources | ✅ |
| @davsclaus | Parser-level test: higher-precedence plain value suppresses lower placeholder | ✅ |
| @davsclaus | Jasypt: keep OriginTrackedValue-only matching | ✅ |
| @davsclaus | Document MapPropertySource limitation | ✅ |

## Test plan

- [x] `mvn test -pl core/camel-spring-boot -Dtest=EarlyResolutionPropertySourcesTest,AbstractEarlyResolutionPropertiesParserTest`
- [x] `mvn test -pl components-starter/camel-jasypt-starter -am`
- [ ] CI build on PR

_AI-generated PR description on behalf of atiaomar1978-hub_