### PR TITLE
CAMEL-24503: camel-spring-boot - see camel properties supplied as environment variables

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -45,6 +46,7 @@ import org.springframework.core.env.Environment;
 public class CamelSecurityPolicyAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSecurityPolicyAutoConfiguration.class);
+    private static final String CAMEL_PREFIX = "camel.";
 
     @Bean
     SecurityPolicyResult camelSecurityPolicyResult(CamelContext camelContext,
@@ -111,10 +113,11 @@ public class CamelSecurityPolicyAutoConfiguration {
             ce.getPropertySources().forEach(ps -> {
                 if (ps instanceof EnumerablePropertySource<?> eps) {
                     for (String name : eps.getPropertyNames()) {
-                        if (name != null && name.startsWith("camel.") && !name.startsWith("camel.security.")) {
-                            Object value = environment.getProperty(name);
+                        String canonical = canonicalCamelName(name);
+                        if (canonical != null && !canonical.startsWith("camel.security.")) {
+                            Object value = environment.getProperty(canonical);
                             if (value != null) {
-                                properties.putIfAbsent(name, value);
+                                properties.putIfAbsent(canonical, value);
                             }
                         }
                     }
@@ -123,6 +126,28 @@ public class CamelSecurityPolicyAutoConfiguration {
         }
 
         return properties;
+    }
+
+    /**
+     * Canonicalizes a property name as its source reports it, returning <tt>null</tt> when it is not a Camel
+     * property.
+     * <p/>
+     * Property sources report names in their own form: an option set in application.properties arrives as
+     * <tt>camel.component.foo.bar</tt>, while the same option set as an environment variable arrives as
+     * <tt>CAMEL_COMPONENT_FOO_BAR</tt>. Spring's relaxed binding applies both to the same option, so both have to
+     * be recognised here - otherwise every option configured through the environment, which is the usual way to
+     * configure a containerised application, is invisible to the policy check.
+     */
+    private static String canonicalCamelName(String name) {
+        if (name == null) {
+            return null;
+        }
+        if (name.startsWith(CAMEL_PREFIX)) {
+            return name;
+        }
+        ConfigurationPropertyName adapted = ConfigurationPropertyName.adapt(name, '_');
+        String canonical = adapted.toString();
+        return canonical.startsWith(CAMEL_PREFIX) ? canonical : null;
     }
 
     private static boolean containsSensitive(CamelContext camelContext, String key, Object value) {

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
@@ -22,6 +22,9 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.main.SecurityPolicyResult;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import java.util.Map;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -129,6 +132,40 @@ public class CamelSecurityPolicyAutoConfigurationTest {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isTrue();
+                });
+    }
+
+
+    /**
+     * The same option configured as an environment variable arrives as CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES,
+     * which never matched the "camel." prefix - so every option set through the environment, the usual way to
+     * configure a containerised application, escaped the policy check entirely.
+     */
+    @Test
+    public void policyShouldSeeInsecureOptionsSetThroughTheEnvironment() {
+        runner.withPropertyValues("camel.security.policy=warn")
+                .withInitializer(ctx -> ctx.getEnvironment().getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource("testSystemEnvironment",
+                                Map.of("CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES", "true"))))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isTrue();
+                    assertThat(result.getViolations())
+                            .anySatisfy(v -> assertThat(v.propertyKey()).endsWith("trustallcertificates"));
+                });
+    }
+
+    @Test
+    public void environmentVariablesUnrelatedToCamelAreIgnored() {
+        runner.withPropertyValues("camel.security.policy=warn")
+                .withInitializer(ctx -> ctx.getEnvironment().getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource("testSystemEnvironment",
+                                Map.of("SOME_OTHER_TRUSTALLCERTIFICATES", "true"))))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isFalse();
                 });
     }
 


### PR DESCRIPTION
`CamelSecurityPolicyAutoConfiguration.extractCamelProperties()` collects the properties the `camel.security`
policy framework (CAMEL-23250) evaluates, filtering on the name exactly as the source reports it:

```java
if (name != null && name.startsWith("camel.") && !name.startsWith("camel.security.")) {
```

Property sources report names in their own form. An option set in `application.properties` arrives as
`camel.component.http.trustAllCertificates`; the *same option* set as an environment variable arrives as
`CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES`, which never matches the `camel.` prefix — even though Spring's
relaxed binding applies it to the component just the same.

So every Camel option configured through the environment escaped the policy check. That is the usual way to
configure a containerised application, so the check was blind to a large part of real deployments.

### Change

Names are canonicalized with Spring Boot's own `ConfigurationPropertyName.adapt(name, '_')` before the prefix
test, and the canonical name is used for the value lookup so relaxed binding resolves it back to the variable.

This works end to end because `SecurityUtils.getSecurityOption` already takes the last segment, lowercases it
and strips dashes — so the canonical `camel.component.http.trustallcertificates` resolves to the same
`trustallcertificates` option as the camelCase form. No change was needed on the camel-core side.

`camel.security.*` stays excluded, in both forms.

### Tests

Two added to `CamelSecurityPolicyAutoConfigurationTest`, injecting a real `SystemEnvironmentPropertySource` so
the name arrives in native form rather than being pre-normalised by the test:

- `policyShouldSeeInsecureOptionsSetThroughTheEnvironment` — `CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES=true`
  now raises a violation, and the reported `propertyKey` is the canonical name
- `environmentVariablesUnrelatedToCamelAreIgnored` — a non-Camel variable whose last segment happens to be a
  security option name (`SOME_OTHER_TRUSTALLCERTIFICATES`) must not raise one

Verified meaningful: the first fails against `main` (no violation detected), the second passes either way as a
negative control. Full `core/camel-spring-boot` suite: 140 tests, 0 failures. Root reactor build green.