### PR TITLE
CAMEL-24507: camel-mcp-server-starter - correct the authentication claim in the docs

### DIFF
--- a/components-starter/camel-mcp-server-starter/src/main/doc/intro.adoc
+++ b/components-starter/camel-mcp-server-starter/src/main/doc/intro.adoc
@@ -9,6 +9,36 @@ Tool semantics — tag-based opt-in (the untagged default pool is never
 exposed), flat-namespace collision refusal, per-call timeout and error
 sanitization — are owned by the runtime-agnostic `camel-mcp-server-api`
 bridge and are identical on every Camel runtime. Serving concerns (endpoint
-path, protocol, server identity, authentication) are owned by the Spring AI
-MCP server and configured via `spring.ai.mcp.server.*`; use
+path, protocol, server identity) are owned by the Spring AI MCP server and
+configured via `spring.ai.mcp.server.*`; use
 `spring.ai.mcp.server.protocol=STREAMABLE` for the streamable HTTP transport.
+
+== Securing the MCP endpoint
+
+`spring.ai.mcp.server.*` provides **no authentication**. The MCP endpoint is
+served on the application's own HTTP port, and anything that can reach it can
+list and call every exposed tool. Protecting it is the application's
+responsibility.
+
+Nothing is exposed until `camel.mcp-server.tags` is set — the untagged default
+pool is never served — so the surface is opt-in. Once tags are configured,
+secure the endpoint path, for example with a Spring Security filter chain:
+
+[source,java]
+----
+@Bean
+SecurityFilterChain mcpSecurity(HttpSecurity http) throws Exception {
+    return http.securityMatcher("/mcp/**")
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .build();
+}
+----
+
+Adjust the matcher to whatever `spring.ai.mcp.server` is configured to serve on.
+A network policy that keeps the port off untrusted networks is an alternative
+where the deployment allows it.
+
+See the camel-mcp-server component documentation for the trust boundary this
+sits in: external MCP clients are untrusted senders under the Camel security
+model.

--- a/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/CamelMcpServerAutoConfiguration.java
+++ b/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/CamelMcpServerAutoConfiguration.java
@@ -22,6 +22,8 @@ import org.apache.camel.component.mcp.server.McpServerBridge;
 import org.apache.camel.component.mcp.server.McpServerConfiguration;
 import org.apache.camel.component.mcp.server.McpServerEngine;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -39,6 +41,8 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnProperty(value = "camel.mcp-server.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(McpServerConfigurationProperties.class)
 public class CamelMcpServerAutoConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CamelMcpServerAutoConfiguration.class);
 
     @Bean(initMethod = "", destroyMethod = "")
     // Camel handles the lifecycle of this bean
@@ -58,6 +62,14 @@ public class CamelMcpServerAutoConfiguration {
         configuration.setToolTimeout(properties.getToolTimeout());
         McpServerBridge bridge = new McpServerBridge(configuration);
         camelContext.addService(bridge);
+        if (properties.getTags() != null && !properties.getTags().isBlank()) {
+            // exposing tools is opt-in, but once opted in the endpoint is reachable by anything that can reach
+            // the application HTTP port - spring.ai.mcp.server.* has no authentication of its own
+            LOG.info("Exposing ai-tool routes tagged [{}] as MCP tools. The MCP endpoint is served on the"
+                     + " application HTTP port and is not authenticated by the Spring AI MCP server; secure it in"
+                     + " the application, for example with a Spring Security filter chain on its path.",
+                    properties.getTags());
+        }
         return bridge;
     }
 }

--- a/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/McpServerConfigurationProperties.java
+++ b/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/McpServerConfigurationProperties.java
@@ -19,8 +19,12 @@ package org.apache.camel.springboot.mcp.server;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Bridge-owned configuration of the Camel MCP server. Serving concerns (endpoint path, protocol, server identity,
- * authentication) are owned by the Spring AI MCP server and configured via {@code spring.ai.mcp.server.*}.
+ * Bridge-owned configuration of the Camel MCP server. Serving concerns (endpoint path, protocol, server identity)
+ * are owned by the Spring AI MCP server and configured via {@code spring.ai.mcp.server.*}.
+ * <p/>
+ * Note that {@code spring.ai.mcp.server.*} provides no authentication: the MCP endpoint is served on the
+ * application's own HTTP port and must be protected by the application, for example with a Spring Security filter
+ * chain matching the endpoint path.
  */
 @ConfigurationProperties(prefix = "camel.mcp-server")
 public class McpServerConfigurationProperties {

--- a/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/SpringAiMcpServerEngine.java
+++ b/components-starter/camel-mcp-server-starter/src/main/java/org/apache/camel/springboot/mcp/server/SpringAiMcpServerEngine.java
@@ -37,7 +37,8 @@ import org.slf4j.LoggerFactory;
  * {@link McpServerEngine} publishing tools into the Spring AI MCP server: {@code toolAdded}/{@code toolRemoved} map to
  * the auto-configured {@link McpSyncServer}'s {@code addTool}/{@code removeTool}, which emit
  * {@code notifications/tools/list_changed} to connected clients. Serving concerns (endpoint path, protocol, server
- * identity, authentication) are owned by the Spring AI MCP server configuration ({@code spring.ai.mcp.server.*}).
+ * identity) are owned by the Spring AI MCP server configuration ({@code spring.ai.mcp.server.*}), which provides
+ * no authentication - the endpoint must be protected by the application.
  */
 public class SpringAiMcpServerEngine extends ServiceSupport implements McpServerEngine {
 

--- a/docs/spring-boot/modules/ROOT/pages/starters/mcp-server.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/mcp-server.adoc
@@ -14,9 +14,39 @@ Tool semantics — tag-based opt-in (the untagged default pool is never
 exposed), flat-namespace collision refusal, per-call timeout and error
 sanitization — are owned by the runtime-agnostic `camel-mcp-server-api`
 bridge and are identical on every Camel runtime. Serving concerns (endpoint
-path, protocol, server identity, authentication) are owned by the Spring AI
-MCP server and configured via `spring.ai.mcp.server.*`; use
+path, protocol, server identity) are owned by the Spring AI MCP server and
+configured via `spring.ai.mcp.server.*`; use
 `spring.ai.mcp.server.protocol=STREAMABLE` for the streamable HTTP transport.
+
+== Securing the MCP endpoint
+
+`spring.ai.mcp.server.*` provides **no authentication**. The MCP endpoint is
+served on the application's own HTTP port, and anything that can reach it can
+list and call every exposed tool. Protecting it is the application's
+responsibility.
+
+Nothing is exposed until `camel.mcp-server.tags` is set — the untagged default
+pool is never served — so the surface is opt-in. Once tags are configured,
+secure the endpoint path, for example with a Spring Security filter chain:
+
+[source,java]
+----
+@Bean
+SecurityFilterChain mcpSecurity(HttpSecurity http) throws Exception {
+    return http.securityMatcher("/mcp/**")
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .build();
+}
+----
+
+Adjust the matcher to whatever `spring.ai.mcp.server` is configured to serve on.
+A network policy that keeps the port off untrusted networks is an alternative
+where the deployment allows it.
+
+See the camel-mcp-server component documentation for the trust boundary this
+sits in: external MCP clients are untrusted senders under the Camel security
+model.
 
 == Maven coordinates
 


### PR DESCRIPTION
`McpServerConfigurationProperties`, `SpringAiMcpServerEngine` and `intro.adoc` all said the same thing:

> Serving concerns (endpoint path, protocol, server identity, **authentication**) are owned by the Spring AI
> MCP server and configured via `spring.ai.mcp.server.*`.

`spring.ai.mcp.server.*` configures endpoint path, protocol and server identity, but it has **no authentication
property**. A reader following that sentence looks for a knob in that namespace, does not find one, and may
conclude the endpoint is covered when it is not.

### Change

Authentication is dropped from the list in all three places, and `intro.adoc` gains a **Securing the MCP
endpoint** section: an explicit statement that `spring.ai.mcp.server.*` provides no authentication, a Spring
Security `SecurityFilterChain` example matching the endpoint path, and a pointer to the network-policy
alternative. It also references the trust boundary documented for the component under CAMEL-24314 — external
MCP clients are untrusted senders.

### The default posture is fine, and unchanged

Worth stating plainly, because the finding this came from could be read as "the tool surface is exposed out of
the box": it is not. `tags` defaults to null and, as the property javadoc says, the untagged default pool is
never exposed — so no tool is served until an operator explicitly sets `camel.mcp-server.tags`. This PR
changes **no defaults**; the problem was the documentation pointing at the wrong place for the hardening step.

### One log line

When `tags` is actually set — i.e. when tools really are exposed — startup now logs one INFO line naming the
tags and noting the endpoint is not authenticated by the Spring AI server.

Deliberately **INFO, not WARN**: exposing tools is the whole point of configuring tags, so a warning would fire
on every legitimate deployment and quickly be tuned out. The issue floated failing or warning when no
`SecurityFilterChain` covers the endpoint; I did not do that, because reliably detecting which chains match the
MCP path is fragile and would produce false alarms.

### Scope

Docs and one log line. No behaviour change, no defaults touched. The regenerated
`docs/spring-boot/.../starters/mcp-server.adoc` carries the new section. Root reactor build green.