### PR TITLE
CAMEL-24554: camel-jolokia-starter - bind to loopback and reject non-loopback browser origins

### DIFF
--- a/components-starter/camel-jolokia-starter/src/main/doc/intro.adoc
+++ b/components-starter/camel-jolokia-starter/src/main/doc/intro.adoc
@@ -2,4 +2,6 @@ Spring Boot auto-configuration for Camel Jolokia integration.
 
 The Jolokia Starter integrates https://jolokia.org/[Jolokia] agent configuration in Spring Boot, wrapping the https://jolokia.org/reference/html/manual/spring.html[Jolokia Spring Support] with default configurations to let the application work out-of-the-box without manually declaring Jolokia servers.
 
-This starter can be considered an alternative to the https://jolokia.org/reference/html/manual/agents.html[Jolokia JVM agent]. When enabled, it exposes the Jolokia endpoint at `http://0.0.0.0:8778/jolokia`.
+This starter can be considered an alternative to the https://jolokia.org/reference/html/manual/agents.html[Jolokia JVM agent]. When enabled, it exposes the Jolokia endpoint at `http://127.0.0.1:8778/jolokia`. The agent ships no
+authenticator, so it binds to loopback by default; exposing it beyond the host is a conscious step via
+`camel.component.jolokia.server-config.host`, and should be paired with authentication or a network policy.

--- a/components-starter/camel-jolokia-starter/src/main/doc/usage.adoc
+++ b/components-starter/camel-jolokia-starter/src/main/doc/usage.adoc
@@ -13,7 +13,7 @@ camel.component.jolokia.server-config.discoveryEnabled=true
 
 To avoid exposing all JMX MBeans (see https://jolokia.org/reference/html/manual/security.html[Security] considerations), a default Jolokia https://jolokia.org/reference/html/manual/security.html#security-restrictor[Restrictor] is provided that allows only Camel related data and some basic information from Java.
 
-The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Cross-origin browser requests are rejected, so a page the user visits cannot drive the agent.
+The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Browser requests from origins outside loopback are rejected, so a remote page the user visits cannot drive the agent.
 
 If the endpoint is exposed beyond the host, put authentication or a network policy in front of it, or supply a stricter restrictor.
 

--- a/components-starter/camel-jolokia-starter/src/main/doc/usage.adoc
+++ b/components-starter/camel-jolokia-starter/src/main/doc/usage.adoc
@@ -13,6 +13,10 @@ camel.component.jolokia.server-config.discoveryEnabled=true
 
 To avoid exposing all JMX MBeans (see https://jolokia.org/reference/html/manual/security.html[Security] considerations), a default Jolokia https://jolokia.org/reference/html/manual/security.html#security-restrictor[Restrictor] is provided that allows only Camel related data and some basic information from Java.
 
+The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Cross-origin browser requests are rejected, so a page the user visits cannot drive the agent.
+
+If the endpoint is exposed beyond the host, put authentication or a network policy in front of it, or supply a stricter restrictor.
+
 You can disable the restrictor with `camel.component.jolokia.use-camel-restrictor=false` or use your own custom one with `camel.component.jolokia.server-config.restrictorClass=org.example.MyRestrictor`.
 
 An example to extend the provided restrictor:
@@ -71,7 +75,7 @@ logging.level.org.jolokia=TRACE
 
 === Kubernetes Support
 
-The starter provides default configurations for Kubernetes environments. It checks for the existence of a certification authority file at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` and, if present, initializes the server using TLS protocol and client authentication. The endpoint becomes `https://0.0.0.0:8778/jolokia`.
+The starter provides default configurations for Kubernetes environments. It checks for the existence of a certification authority file at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` and, if present, initializes the server using TLS protocol and client authentication. The endpoint becomes `https://127.0.0.1:8778/jolokia`; set `camel.component.jolokia.server-config.host` to expose it to the cluster.
 
 You can disable this behaviour with `camel.component.jolokia.kubernetes-discover=false`.
 

--- a/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfiguration.java
+++ b/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfiguration.java
@@ -84,7 +84,9 @@ public class JolokiaComponentAutoConfiguration {
 	public SpringJolokiaConfigHolder camelConfigHolder() {
 		LOG.debug("jolokia configuration from properties");
 		final SpringJolokiaConfigHolder springJolokiaConfigHolder = new SpringJolokiaConfigHolder();
-		setDefaultConfigValue("host", "0.0.0.0");
+		// bind to loopback like the Jolokia JVM agent does; the agent ships no authenticator, so exposing it
+		// beyond the host has to be a conscious step via camel.component.jolokia.server-config.host
+		setDefaultConfigValue("host", "127.0.0.1");
 		setDefaultConfigValue("autoStart", "true");
 		if (configuration.isUseCamelRestrictor()
 				&& !configuration.getServerConfig().containsKey(ConfigKey.RESTRICTOR_CLASS.getKeyValue())) {

--- a/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictor.java
+++ b/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictor.java
@@ -51,6 +51,23 @@ public class CamelRestrictor extends AllowAllRestrictor {
 	}
 
 	/**
+	 * Rejects cross-origin browser requests.
+	 * <p/>
+	 * {@link AllowAllRestrictor} permits every origin, which leaves the agent open to being driven by a page the
+	 * user happens to visit - the port being on loopback is no protection against that. A request that carries no
+	 * Origin or Referer header is not a cross-origin browser request and is still allowed, so ordinary clients such
+	 * as curl, Hawtio or the Jolokia CLI are unaffected.
+	 *
+	 * @param  pOrigin         the Origin or Referer header of the request, or <tt>null</tt> when absent
+	 * @param  pOnlyWhenStrictCheckingIsEnabled whether Jolokia asks to apply the check only in strict mode
+	 * @return                 <tt>true</tt> if the request may proceed
+	 */
+	@Override
+	public boolean isOriginAllowed(String pOrigin, boolean pOnlyWhenStrictCheckingIsEnabled) {
+		return pOrigin == null;
+	}
+
+	/**
 	 * Provides the list of allowed domains from JMX.
 	 * @return List of String, the list of the allowed domains.
 	 */

--- a/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictor.java
+++ b/components-starter/camel-jolokia-starter/src/main/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictor.java
@@ -20,10 +20,15 @@ import org.jolokia.server.core.restrictor.AllowAllRestrictor;
 
 import javax.management.ObjectName;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.function.Function;
 
 public class CamelRestrictor extends AllowAllRestrictor {
+
+	private static final String IPV6_LOOPBACK_COMPRESSED = "::1";
+	private static final String IPV6_LOOPBACK_EXPANDED = "0:0:0:0:0:0:0:1";
 
 	private final List<String> allowedDomains = List.of("org.apache.camel", "java.lang", "java.nio", "jboss.threads");
 
@@ -51,12 +56,13 @@ public class CamelRestrictor extends AllowAllRestrictor {
 	}
 
 	/**
-	 * Rejects cross-origin browser requests.
+	 * Rejects browser requests from non-loopback origins.
 	 * <p/>
-	 * {@link AllowAllRestrictor} permits every origin, which leaves the agent open to being driven by a page the
-	 * user happens to visit - the port being on loopback is no protection against that. A request that carries no
-	 * Origin or Referer header is not a cross-origin browser request and is still allowed, so ordinary clients such
-	 * as curl, Hawtio or the Jolokia CLI are unaffected.
+	 * {@link AllowAllRestrictor} permits every origin, which leaves the agent open to being driven by a remote page
+	 * the user happens to visit - the port being on loopback is no protection against that. Requests from loopback
+	 * origins are allowed so local browser clients such as Hawtio continue to work. A request that carries no Origin
+	 * or Referer header is also allowed, so ordinary non-browser clients such as curl and the Jolokia CLI are
+	 * unaffected. This follows the loopback-origin policy used by the Camel Quarkus Jolokia restrictor.
 	 *
 	 * @param  pOrigin         the Origin or Referer header of the request, or <tt>null</tt> when absent
 	 * @param  pOnlyWhenStrictCheckingIsEnabled whether Jolokia asks to apply the check only in strict mode
@@ -64,7 +70,50 @@ public class CamelRestrictor extends AllowAllRestrictor {
 	 */
 	@Override
 	public boolean isOriginAllowed(String pOrigin, boolean pOnlyWhenStrictCheckingIsEnabled) {
-		return pOrigin == null;
+		if (pOrigin == null) {
+			return true;
+		}
+
+		try {
+			return isLoopbackHost(new URI(pOrigin).getHost());
+		} catch (URISyntaxException e) {
+			return false;
+		}
+	}
+
+	private static boolean isLoopbackHost(String host) {
+		if (host == null || host.isEmpty()) {
+			return false;
+		}
+
+		if (host.startsWith("[") && host.endsWith("]")) {
+			host = host.substring(1, host.length() - 1);
+		}
+
+		if ("localhost".equalsIgnoreCase(host) || "localhost.localdomain".equalsIgnoreCase(host)) {
+			return true;
+		}
+
+		if (IPV6_LOOPBACK_COMPRESSED.equals(host) || IPV6_LOOPBACK_EXPANDED.equals(host)) {
+			return true;
+		}
+
+		String[] octets = host.split("\\.", -1);
+		if (octets.length != 4 || !"127".equals(octets[0])) {
+			return false;
+		}
+
+		try {
+			for (int i = 1; i < octets.length; i++) {
+				int octet = Integer.parseInt(octets[i]);
+				if (octet < 0 || octet > 255) {
+					return false;
+				}
+			}
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
 	}
 
 	/**

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentAutoConfigurationTest.java
@@ -76,7 +76,7 @@ public class JolokiaComponentAutoConfigurationTest extends JolokiaComponentTestB
 				.extracting("configHolder").isNotNull()
 				.extracting("config")
 				.asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
-				.containsEntry("host", "0.0.0.0")
+				.containsEntry("host", "127.0.0.1")
 				.containsEntry("autoStart", "true")
 				.containsEntry("restrictorClass", CamelRestrictor.class.getCanonicalName())
 				.containsEntry("discoveryEnabled", "true");

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentOriginTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/JolokiaComponentOriginTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jolokia.springboot;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = { CamelAutoConfiguration.class, JolokiaComponentAutoConfiguration.class },
+                  properties = "camel.component.jolokia.serverConfig.port=0")
+class JolokiaComponentOriginTest extends JolokiaComponentTestBase {
+
+    @Test
+    void allowsRequestFromTheJolokiaServersOwnOrigin() throws Exception {
+        String serverOrigin = "http://127.0.0.1:" + agent.getAddress().getPort();
+        URI endpoint = URI.create(serverOrigin + "/jolokia");
+        HttpClient client = HttpClient.newHttpClient();
+
+        HttpResponse<String> commandLineResponse = client.send(
+                HttpRequest.newBuilder(endpoint)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{\"type\":\"version\"}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(commandLineResponse.statusCode()).isEqualTo(200);
+        assertThat(commandLineResponse.body()).contains("\"status\":200");
+
+        HttpResponse<String> browserResponse = client.send(
+                HttpRequest.newBuilder(endpoint)
+                        .header("Content-Type", "application/json")
+                        .header("Origin", serverOrigin)
+                        .POST(HttpRequest.BodyPublishers.ofString("{\"type\":\"version\"}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(browserResponse.body())
+                .as("a same-origin browser request should not be rejected")
+                .contains("\"status\":200");
+    }
+}

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictorTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jolokia.springboot.restrictor;
+
+import org.junit.jupiter.api.Test;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelRestrictorTest {
+
+	private final CamelRestrictor restrictor = new CamelRestrictor();
+
+	private static ObjectName name(String value) throws MalformedObjectNameException {
+		return new ObjectName(value);
+	}
+
+	@Test
+	void rejectsCrossOriginBrowserRequests() {
+		// AllowAllRestrictor permits every origin, which lets a page the user visits drive the agent -
+		// binding to loopback is no protection against that
+		assertFalse(restrictor.isOriginAllowed("http://evil.example.com", false));
+		assertFalse(restrictor.isOriginAllowed("http://evil.example.com", true));
+	}
+
+	@Test
+	void allowsRequestsCarryingNoOrigin() {
+		// curl, Hawtio and the Jolokia CLI send no Origin or Referer header
+		assertTrue(restrictor.isOriginAllowed(null, false));
+		assertTrue(restrictor.isOriginAllowed(null, true));
+	}
+
+	@Test
+	void stillLimitsMBeansToTheAllowedDomains() throws Exception {
+		assertTrue(restrictor.isAttributeReadAllowed(name("org.apache.camel:type=context"), "CamelId"));
+		assertFalse(restrictor.isAttributeReadAllowed(name("com.example:type=Secret"), "value"));
+		assertTrue(restrictor.isObjectNameHidden(name("com.example:type=Secret")));
+	}
+
+	@Test
+	void managementOfCamelMBeansRemainsPossible() throws Exception {
+		// the starter exists to manage Camel through Jolokia, so operations on the Camel domain stay allowed;
+		// that capability is why the agent binds to loopback by default
+		assertTrue(restrictor.isOperationAllowed(name("org.apache.camel:type=context"), "stop"));
+		assertFalse(restrictor.isOperationAllowed(name("com.example:type=Secret"), "reveal"));
+	}
+}

--- a/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictorTest.java
+++ b/components-starter/camel-jolokia-starter/src/test/java/org/apache/camel/component/jolokia/springboot/restrictor/CamelRestrictorTest.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CamelRestrictorTest {
 
@@ -36,29 +35,45 @@ class CamelRestrictorTest {
 	void rejectsCrossOriginBrowserRequests() {
 		// AllowAllRestrictor permits every origin, which lets a page the user visits drive the agent -
 		// binding to loopback is no protection against that
-		assertFalse(restrictor.isOriginAllowed("http://evil.example.com", false));
-		assertFalse(restrictor.isOriginAllowed("http://evil.example.com", true));
+		assertThat(restrictor.isOriginAllowed("http://evil.example.com", false)).isFalse();
+		assertThat(restrictor.isOriginAllowed("http://evil.example.com", true)).isFalse();
+	}
+
+	@Test
+	void allowsLoopbackBrowserOrigins() {
+		assertThat(restrictor.isOriginAllowed("http://localhost:8080", false)).isTrue();
+		assertThat(restrictor.isOriginAllowed("http://127.0.0.1:8778", false)).isTrue();
+		assertThat(restrictor.isOriginAllowed("http://127.255.255.255:8778", false)).isTrue();
+		assertThat(restrictor.isOriginAllowed("http://[::1]:8778", false)).isTrue();
+		assertThat(restrictor.isOriginAllowed("http://[0:0:0:0:0:0:0:1]:8778", true)).isTrue();
+	}
+
+	@Test
+	void rejectsMalformedAndNonLoopbackOrigins() {
+		assertThat(restrictor.isOriginAllowed("not a URI", false)).isFalse();
+		assertThat(restrictor.isOriginAllowed("http://localhost.example.com", false)).isFalse();
+		assertThat(restrictor.isOriginAllowed("http://128.0.0.1:8778", false)).isFalse();
 	}
 
 	@Test
 	void allowsRequestsCarryingNoOrigin() {
-		// curl, Hawtio and the Jolokia CLI send no Origin or Referer header
-		assertTrue(restrictor.isOriginAllowed(null, false));
-		assertTrue(restrictor.isOriginAllowed(null, true));
+		// curl and the Jolokia CLI send no Origin or Referer header
+		assertThat(restrictor.isOriginAllowed(null, false)).isTrue();
+		assertThat(restrictor.isOriginAllowed(null, true)).isTrue();
 	}
 
 	@Test
 	void stillLimitsMBeansToTheAllowedDomains() throws Exception {
-		assertTrue(restrictor.isAttributeReadAllowed(name("org.apache.camel:type=context"), "CamelId"));
-		assertFalse(restrictor.isAttributeReadAllowed(name("com.example:type=Secret"), "value"));
-		assertTrue(restrictor.isObjectNameHidden(name("com.example:type=Secret")));
+		assertThat(restrictor.isAttributeReadAllowed(name("org.apache.camel:type=context"), "CamelId")).isTrue();
+		assertThat(restrictor.isAttributeReadAllowed(name("com.example:type=Secret"), "value")).isFalse();
+		assertThat(restrictor.isObjectNameHidden(name("com.example:type=Secret"))).isTrue();
 	}
 
 	@Test
 	void managementOfCamelMBeansRemainsPossible() throws Exception {
 		// the starter exists to manage Camel through Jolokia, so operations on the Camel domain stay allowed;
 		// that capability is why the agent binds to loopback by default
-		assertTrue(restrictor.isOperationAllowed(name("org.apache.camel:type=context"), "stop"));
-		assertFalse(restrictor.isOperationAllowed(name("com.example:type=Secret"), "reveal"));
+		assertThat(restrictor.isOperationAllowed(name("org.apache.camel:type=context"), "stop")).isTrue();
+		assertThat(restrictor.isOperationAllowed(name("com.example:type=Secret"), "reveal")).isFalse();
 	}
 }

--- a/docs/spring-boot/modules/ROOT/pages/starters/jolokia.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/jolokia.adoc
@@ -38,7 +38,7 @@ camel.component.jolokia.server-config.discoveryEnabled=true
 
 To avoid exposing all JMX MBeans (see https://jolokia.org/reference/html/manual/security.html[Security] considerations), a default Jolokia https://jolokia.org/reference/html/manual/security.html#security-restrictor[Restrictor] is provided that allows only Camel related data and some basic information from Java.
 
-The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Cross-origin browser requests are rejected, so a page the user visits cannot drive the agent.
+The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Browser requests from origins outside loopback are rejected, so a remote page the user visits cannot drive the agent.
 
 If the endpoint is exposed beyond the host, put authentication or a network policy in front of it, or supply a stricter restrictor.
 

--- a/docs/spring-boot/modules/ROOT/pages/starters/jolokia.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/jolokia.adoc
@@ -7,7 +7,9 @@ Spring Boot auto-configuration for Camel Jolokia integration.
 
 The Jolokia Starter integrates https://jolokia.org/[Jolokia] agent configuration in Spring Boot, wrapping the https://jolokia.org/reference/html/manual/spring.html[Jolokia Spring Support] with default configurations to let the application work out-of-the-box without manually declaring Jolokia servers.
 
-This starter can be considered an alternative to the https://jolokia.org/reference/html/manual/agents.html[Jolokia JVM agent]. When enabled, it exposes the Jolokia endpoint at `http://0.0.0.0:8778/jolokia`.
+This starter can be considered an alternative to the https://jolokia.org/reference/html/manual/agents.html[Jolokia JVM agent]. When enabled, it exposes the Jolokia endpoint at `http://127.0.0.1:8778/jolokia`. The agent ships no
+authenticator, so it binds to loopback by default; exposing it beyond the host is a conscious step via
+`camel.component.jolokia.server-config.host`, and should be paired with authentication or a network policy.
 
 == Maven coordinates
 
@@ -35,6 +37,10 @@ camel.component.jolokia.server-config.discoveryEnabled=true
 === Security Restrictor
 
 To avoid exposing all JMX MBeans (see https://jolokia.org/reference/html/manual/security.html[Security] considerations), a default Jolokia https://jolokia.org/reference/html/manual/security.html#security-restrictor[Restrictor] is provided that allows only Camel related data and some basic information from Java.
+
+The restrictor limits which MBeans are reachable, not what may be done to them: within the allowed domains, reading and writing attributes and invoking operations are all permitted, since managing Camel through Jolokia (starting and stopping routes from Hawtio, for example) is what the starter is for. That capability is why the agent binds to loopback by default. Cross-origin browser requests are rejected, so a page the user visits cannot drive the agent.
+
+If the endpoint is exposed beyond the host, put authentication or a network policy in front of it, or supply a stricter restrictor.
 
 You can disable the restrictor with `camel.component.jolokia.use-camel-restrictor=false` or use your own custom one with `camel.component.jolokia.server-config.restrictorClass=org.example.MyRestrictor`.
 
@@ -94,7 +100,7 @@ logging.level.org.jolokia=TRACE
 
 === Kubernetes Support
 
-The starter provides default configurations for Kubernetes environments. It checks for the existence of a certification authority file at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` and, if present, initializes the server using TLS protocol and client authentication. The endpoint becomes `https://0.0.0.0:8778/jolokia`.
+The starter provides default configurations for Kubernetes environments. It checks for the existence of a certification authority file at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` and, if present, initializes the server using TLS protocol and client authentication. The endpoint becomes `https://127.0.0.1:8778/jolokia`; set `camel.component.jolokia.server-config.host` to expose it to the cluster.
 
 You can disable this behaviour with `camel.component.jolokia.kubernetes-discover=false`.
 


### PR DESCRIPTION
Two shipped defaults in this starter were broader than the library it wraps.

### Bind to loopback by default

Adding the starter starts the Jolokia agent automatically. Previously, the starter also hard-defaulted the bind address to `0.0.0.0`, exposing an unauthenticated plain HTTP management endpoint on every interface outside the Kubernetes TLS configuration.

The host now defaults to `127.0.0.1`, matching the Jolokia JVM agent. Exposing it beyond the host requires an explicit `camel.component.jolokia.server-config.host` setting and should be paired with authentication or a network policy.

### Reject remote browser origins

`CamelRestrictor` previously inherited `AllowAllRestrictor.isOriginAllowed`, allowing a remote page visited by the user to drive the loopback agent.

The restrictor now:

- allows requests without `Origin` or `Referer`, preserving non-browser clients;
- allows syntactically valid loopback origins (`localhost`, IPv4 `127.0.0.0/8`, and IPv6 loopback), preserving local browser clients such as Hawtio;
- rejects malformed and non-loopback origins;
- performs lexical address checks without DNS resolution, avoiding DNS-rebinding exposure.

This implementation is aligned with the Camel Quarkus Jolokia restrictor's loopback-origin policy.

### Management capabilities remain unchanged

The restrictor limits which MBean domains are reachable, not what may be done within those domains. Reading and writing attributes and invoking operations remain permitted because managing Camel through Jolokia is the starter's primary use case. Users needing a stricter policy can provide a custom `restrictorClass`.

### Behaviour change

Remote and Kubernetes deployments that relied on the previous wildcard bind must configure `camel.component.jolokia.server-config.host`. This shipped-default change also requires an entry in the Camel 4.23 upgrade guide.

### Tests

- Added unit coverage for absent, malformed, remote, IPv4 loopback, and IPv6 loopback origins.
- Added an HTTP-level regression test proving that a same-origin browser POST succeeds through the real Jolokia server.
- Preserved the MBean-domain and operation-management guard cases.
- Converted the touched test assertions to AssertJ.
- `mvn verify` in `camel-jolokia-starter`: 24 tests, 0 failures, 0 errors, 0 skipped.

_Codex on behalf of Croway_
