### PR TITLE
CAMEL-24531: extract a shared early-resolution properties parser

### DIFF
--- a/components-starter/camel-aws-secrets-manager-starter/src/main/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParser.java
+++ b/components-starter/camel-aws-secrets-manager-starter/src/main/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParser.java
@@ -18,16 +18,10 @@ package org.apache.camel.component.aws.secretsmanager.springboot;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.aws.secretsmanager.SecretsManagerPropertiesFunction;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -35,87 +29,49 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
-import java.util.Properties;
-
-public class SpringBootAwsSecretsManagerPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootAwsSecretsManagerPropertiesParser.class);
+public class SpringBootAwsSecretsManagerPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.aws-secrets-manager.early-resolve-properties";
+    }
+
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-aws-secrets-manager-properties";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
         SecretsManagerClient client;
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.aws-secrets-manager.early-resolve-properties"))) {
-            String accessKey = environment.getProperty("camel.vault.aws.accessKey");
-            String secretKey = environment.getProperty("camel.vault.aws.secretKey");
-            String region = environment.getProperty("camel.vault.aws.region");
-            boolean useDefaultCredentialsProvider = Boolean.parseBoolean(environment.getProperty("camel.vault.aws.defaultCredentialsProvider"));
-            boolean useProfileCredentialsProvider = Boolean.parseBoolean(environment.getProperty("camel.vault.aws.profileCredentialsProvider"));
-            String profileName = environment.getProperty("camel.vault.aws.profileName");
-            if (ObjectHelper.isNotEmpty(accessKey) && ObjectHelper.isNotEmpty(secretKey) && ObjectHelper.isNotEmpty(region)) {
-                SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
-                AwsBasicCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
-                clientBuilder = clientBuilder.credentialsProvider(StaticCredentialsProvider.create(cred));
-                clientBuilder.region(Region.of(region));
-                client = clientBuilder.build();
-            } else if (useDefaultCredentialsProvider && ObjectHelper.isNotEmpty(region)) {
-                SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
-                clientBuilder.region(Region.of(region));
-                client = clientBuilder.build();
-            } else if (useProfileCredentialsProvider && ObjectHelper.isNotEmpty(profileName)) {
-                SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
-                clientBuilder.credentialsProvider(ProfileCredentialsProvider.create(profileName));
-                clientBuilder.region(Region.of(region));
-                client = clientBuilder.build();
-            } else {
-                throw new RuntimeCamelException(
-                        "Using the AWS Secrets Manager Properties Function requires setting AWS credentials as application properties or environment variables");
-            }
-            SecretsManagerPropertiesFunction secretsManagerPropertiesFunction = new SecretsManagerPropertiesFunction(client);
-
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{aws:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = secretsManagerPropertiesFunction.apply(stringValue
-                                        .replace("{{aws:", "")
-                                        .replace("}}", ""));
-                                props.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-aws-secrets-manager-properties", props));
+        String accessKey = environment.getProperty("camel.vault.aws.accessKey");
+        String secretKey = environment.getProperty("camel.vault.aws.secretKey");
+        String region = environment.getProperty("camel.vault.aws.region");
+        boolean useDefaultCredentialsProvider
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.aws.defaultCredentialsProvider"));
+        boolean useProfileCredentialsProvider
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.aws.profileCredentialsProvider"));
+        String profileName = environment.getProperty("camel.vault.aws.profileName");
+        if (ObjectHelper.isNotEmpty(accessKey) && ObjectHelper.isNotEmpty(secretKey)
+                && ObjectHelper.isNotEmpty(region)) {
+            SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
+            AwsBasicCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
+            clientBuilder = clientBuilder.credentialsProvider(StaticCredentialsProvider.create(cred));
+            clientBuilder.region(Region.of(region));
+            client = clientBuilder.build();
+        } else if (useDefaultCredentialsProvider && ObjectHelper.isNotEmpty(region)) {
+            SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
+            clientBuilder.region(Region.of(region));
+            client = clientBuilder.build();
+        } else if (useProfileCredentialsProvider && ObjectHelper.isNotEmpty(profileName)) {
+            SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
+            clientBuilder.credentialsProvider(ProfileCredentialsProvider.create(profileName));
+            clientBuilder.region(Region.of(region));
+            client = clientBuilder.build();
+        } else {
+            throw new RuntimeCamelException(
+                    "Using the AWS Secrets Manager Properties Function requires setting AWS credentials as application properties or environment variables");
         }
+        return new SecretsManagerPropertiesFunction(client);
     }
 }

--- a/components-starter/camel-aws-secrets-manager-starter/src/test/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParserTest.java
+++ b/components-starter/camel-aws-secrets-manager-starter/src/test/java/org/apache/camel/component/aws/secretsmanager/springboot/SpringBootAwsSecretsManagerPropertiesParserTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.secretsmanager.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpringBootAwsSecretsManagerPropertiesParserTest {
+
+    private final SpringBootAwsSecretsManagerPropertiesParser parser
+            = new SpringBootAwsSecretsManagerPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.aws-secrets-manager.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-aws-secrets-manager-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+}

--- a/components-starter/camel-azure-key-vault-starter/src/main/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParser.java
+++ b/components-starter/camel-azure-key-vault-starter/src/main/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParser.java
@@ -24,106 +24,63 @@ import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.azure.key.vault.KeyVaultPropertiesFunction;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 
-import java.util.Properties;
-
-public class SpringBootAzureKeyVaultPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootAzureKeyVaultPropertiesParser.class);
+public class SpringBootAzureKeyVaultPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.azure-key-vault.early-resolve-properties";
+    }
+
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-azure-key-vault-properties";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
         SecretClient client;
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.azure-key-vault.early-resolve-properties"))) {
-            String vaultName = environment.getProperty("camel.vault.azure.vaultName");
-            String clientId = environment.getProperty("camel.vault.azure.clientId");
-            String clientSecret = environment.getProperty("camel.vault.azure.clientSecret");
-            String tenantId = environment.getProperty("camel.vault.azure.tenantId");
-            boolean azureIdentityEnabled = Boolean.parseBoolean(System.getenv("CAMEL_VAULT_AZURE_IDENTITY_ENABLED"));
-            if (ObjectHelper.isNotEmpty(vaultName) && ObjectHelper.isNotEmpty(clientId) && ObjectHelper.isNotEmpty(clientSecret)
-                    && ObjectHelper.isNotEmpty(tenantId) && !azureIdentityEnabled) {
-                String keyVaultUri = "https://" + vaultName + ".vault.azure.net";
+        String vaultName = environment.getProperty("camel.vault.azure.vaultName");
+        String clientId = environment.getProperty("camel.vault.azure.clientId");
+        String clientSecret = environment.getProperty("camel.vault.azure.clientSecret");
+        String tenantId = environment.getProperty("camel.vault.azure.tenantId");
+        boolean azureIdentityEnabled = Boolean.parseBoolean(System.getenv("CAMEL_VAULT_AZURE_IDENTITY_ENABLED"));
+        if (ObjectHelper.isNotEmpty(vaultName) && ObjectHelper.isNotEmpty(clientId)
+                && ObjectHelper.isNotEmpty(clientSecret)
+                && ObjectHelper.isNotEmpty(tenantId) && !azureIdentityEnabled) {
+            String keyVaultUri = "https://" + vaultName + ".vault.azure.net";
 
-                // Credential
-                ClientSecretCredential credential = new ClientSecretCredentialBuilder()
-                        .tenantId(tenantId)
-                        .clientId(clientId)
-                        .clientSecret(clientSecret)
-                        .build();
+            // Credential
+            ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+                    .tenantId(tenantId)
+                    .clientId(clientId)
+                    .clientSecret(clientSecret)
+                    .build();
 
-                // Build Client
-                client = new SecretClientBuilder()
-                        .vaultUrl(keyVaultUri)
-                        .credential(credential)
-                        .buildClient();
-            } else if (ObjectHelper.isNotEmpty(vaultName) && azureIdentityEnabled) {
-                String keyVaultUri = "https://" + vaultName + ".vault.azure.net";
+            // Build Client
+            client = new SecretClientBuilder()
+                    .vaultUrl(keyVaultUri)
+                    .credential(credential)
+                    .buildClient();
+        } else if (ObjectHelper.isNotEmpty(vaultName) && azureIdentityEnabled) {
+            String keyVaultUri = "https://" + vaultName + ".vault.azure.net";
 
-                // Credential
-                TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+            // Credential
+            TokenCredential credential = new DefaultAzureCredentialBuilder().build();
 
-                // Build Client
-                client = new SecretClientBuilder()
-                        .vaultUrl(keyVaultUri)
-                        .credential(credential)
-                        .buildClient();
-            } else {
-                throw new RuntimeCamelException(
-                        "Using the Azure Key Vault Properties Function requires setting Azure credentials as application properties or environment variables or enable the Azure Identity Authentication mechanism");
-            }
-            KeyVaultPropertiesFunction keyVaultPropertiesFunction = new KeyVaultPropertiesFunction(client);
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{azure:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = keyVaultPropertiesFunction.apply(stringValue
-                                        .replace("{{azure:", "")
-                                        .replace("}}", ""));
-                                props.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-azure-key-vault-properties", props));
+            // Build Client
+            client = new SecretClientBuilder()
+                    .vaultUrl(keyVaultUri)
+                    .credential(credential)
+                    .buildClient();
+        } else {
+            throw new RuntimeCamelException(
+                    "Using the Azure Key Vault Properties Function requires setting Azure credentials as application properties or environment variables or enable the Azure Identity Authentication mechanism");
         }
+        return new KeyVaultPropertiesFunction(client);
     }
 }

--- a/components-starter/camel-azure-key-vault-starter/src/test/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParserTest.java
+++ b/components-starter/camel-azure-key-vault-starter/src/test/java/org/apache/camel/component/azure/key/vault/springboot/SpringBootAzureKeyVaultPropertiesParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.key.vault.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpringBootAzureKeyVaultPropertiesParserTest {
+
+    private final SpringBootAzureKeyVaultPropertiesParser parser = new SpringBootAzureKeyVaultPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.azure-key-vault.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-azure-key-vault-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+}

--- a/components-starter/camel-cyberark-vault-starter/src/main/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParser.java
+++ b/components-starter/camel-cyberark-vault-starter/src/main/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParser.java
@@ -20,100 +20,53 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.cyberark.vault.CyberArkVaultPropertiesFunction;
 import org.apache.camel.component.cyberark.vault.client.ConjurClient;
 import org.apache.camel.component.cyberark.vault.client.ConjurClientFactory;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 
-import java.util.Properties;
-
-public class SpringBootCyberArkVaultPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootCyberArkVaultPropertiesParser.class);
+public class SpringBootCyberArkVaultPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
-        ConjurClient client;
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.cyberark-vault.early-resolve-properties"))) {
-            String url = environment.getProperty("camel.vault.cyberark.url");
-            String account = environment.getProperty("camel.vault.cyberark.account");
-            String username = environment.getProperty("camel.vault.cyberark.username");
-            String password = environment.getProperty("camel.vault.cyberark.password");
-            String apiKey = environment.getProperty("camel.vault.cyberark.apiKey");
-            String authToken = environment.getProperty("camel.vault.cyberark.authToken");
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.cyberark-vault.early-resolve-properties";
+    }
 
-            if (ObjectHelper.isNotEmpty(url) && ObjectHelper.isNotEmpty(account)) {
-                // Create Conjur client based on authentication method
-                if (ObjectHelper.isNotEmpty(authToken)) {
-                    // Use pre-authenticated token
-                    client = ConjurClientFactory.createWithToken(url, account, authToken);
-                } else if (ObjectHelper.isNotEmpty(apiKey) && ObjectHelper.isNotEmpty(username)) {
-                    // Use API key authentication
-                    client = ConjurClientFactory.createWithApiKey(url, account, username, apiKey);
-                } else if (ObjectHelper.isNotEmpty(username) && ObjectHelper.isNotEmpty(password)) {
-                    // Use username/password authentication
-                    client = ConjurClientFactory.createWithCredentials(url, account, username, password);
-                } else {
-                    throw new RuntimeCamelException(
-                            "Using the CyberArk Conjur Vault Properties Function requires authentication credentials (authToken, apiKey, or username/password)");
-                }
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-cyberark-vault-properties";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
+        ConjurClient client;
+        String url = environment.getProperty("camel.vault.cyberark.url");
+        String account = environment.getProperty("camel.vault.cyberark.account");
+        String username = environment.getProperty("camel.vault.cyberark.username");
+        String password = environment.getProperty("camel.vault.cyberark.password");
+        String apiKey = environment.getProperty("camel.vault.cyberark.apiKey");
+        String authToken = environment.getProperty("camel.vault.cyberark.authToken");
+
+        if (ObjectHelper.isNotEmpty(url) && ObjectHelper.isNotEmpty(account)) {
+            // Create Conjur client based on authentication method
+            if (ObjectHelper.isNotEmpty(authToken)) {
+                // Use pre-authenticated token
+                client = ConjurClientFactory.createWithToken(url, account, authToken);
+            } else if (ObjectHelper.isNotEmpty(apiKey) && ObjectHelper.isNotEmpty(username)) {
+                // Use API key authentication
+                client = ConjurClientFactory.createWithApiKey(url, account, username, apiKey);
+            } else if (ObjectHelper.isNotEmpty(username) && ObjectHelper.isNotEmpty(password)) {
+                // Use username/password authentication
+                client = ConjurClientFactory.createWithCredentials(url, account, username, password);
             } else {
                 throw new RuntimeCamelException(
-                        "Using the CyberArk Conjur Vault Properties Function requires setting URL and account as application properties or environment variables");
+                        "Using the CyberArk Conjur Vault Properties Function requires authentication credentials (authToken, apiKey, or username/password)");
             }
-
-            CyberArkVaultPropertiesFunction cyberArkVaultPropertiesFunction = new CyberArkVaultPropertiesFunction(client);
-
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{cyberark:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = cyberArkVaultPropertiesFunction.apply(stringValue
-                                        .replace("{{cyberark:", "")
-                                        .replace("}}", ""));
-                                props.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-cyberark-vault-properties", props));
+        } else {
+            throw new RuntimeCamelException(
+                    "Using the CyberArk Conjur Vault Properties Function requires setting URL and account as application properties or environment variables");
         }
+
+        return new CyberArkVaultPropertiesFunction(client);
     }
 }

--- a/components-starter/camel-cyberark-vault-starter/src/test/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParserTest.java
+++ b/components-starter/camel-cyberark-vault-starter/src/test/java/org/apache/camel/component/cyberark/vault/springboot/SpringBootCyberArkVaultPropertiesParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cyberark.vault.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpringBootCyberArkVaultPropertiesParserTest {
+
+    private final SpringBootCyberArkVaultPropertiesParser parser = new SpringBootCyberArkVaultPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.cyberark-vault.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-cyberark-vault-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+}

--- a/components-starter/camel-google-secret-manager-starter/src/main/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParser.java
+++ b/components-starter/camel-google-secret-manager-starter/src/main/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParser.java
@@ -20,86 +20,42 @@ import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.google.secret.manager.GoogleSecretManagerPropertiesFunction;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 
 import java.io.IOException;
-import java.util.Properties;
 
-public class SpringBootGoogleSecretManagerPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootGoogleSecretManagerPropertiesParser.class);
+public class SpringBootGoogleSecretManagerPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.google-secret-manager.early-resolve-properties";
+    }
+
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-google-secret-manager-properties";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
         SecretManagerServiceClient client;
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        String projectId;
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.google-secret-manager.early-resolve-properties"))) {
-            projectId = environment.getProperty("camel.vault.gcp.projectId");
-            boolean useDefaultInstance = Boolean.parseBoolean(environment.getProperty("camel.vault.gcp.useDefaultInstance"));
-            if (useDefaultInstance && ObjectHelper.isNotEmpty(projectId)) {
-                SecretManagerServiceSettings settings = null;
-                try {
-                    settings = SecretManagerServiceSettings.newBuilder().build();
-                    client = SecretManagerServiceClient.create(settings);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            } else {
-                throw new RuntimeCamelException(
-                        "Using the GCP Secret Manager Properties Function in Spring Boot early resolver mode requires setting GCP project Id as application properties and use default instance option to true");
+        String projectId = environment.getProperty("camel.vault.gcp.projectId");
+        boolean useDefaultInstance
+                = Boolean.parseBoolean(environment.getProperty("camel.vault.gcp.useDefaultInstance"));
+        if (useDefaultInstance && ObjectHelper.isNotEmpty(projectId)) {
+            try {
+                SecretManagerServiceSettings settings = SecretManagerServiceSettings.newBuilder().build();
+                client = SecretManagerServiceClient.create(settings);
+            } catch (IOException e) {
+                throw new RuntimeCamelException(e);
             }
-            GoogleSecretManagerPropertiesFunction secretsManagerPropertiesFunction = new GoogleSecretManagerPropertiesFunction(client, projectId);
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{gcp:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = secretsManagerPropertiesFunction.apply(stringValue
-                                        .replace("{{gcp:", "")
-                                        .replace("}}", ""));
-                                props.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-google-secret-manager-properties", props));
+        } else {
+            throw new RuntimeCamelException(
+                    "Using the GCP Secret Manager Properties Function in Spring Boot early resolver mode requires setting GCP project Id as application properties and use default instance option to true");
         }
+        return new GoogleSecretManagerPropertiesFunction(client, projectId);
     }
 }

--- a/components-starter/camel-google-secret-manager-starter/src/test/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParserTest.java
+++ b/components-starter/camel-google-secret-manager-starter/src/test/java/org/apache/camel/component/google/secret/manager/springboot/SpringBootGoogleSecretManagerPropertiesParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.secret.manager.springboot;
+
+import org.apache.camel.RuntimeCamelException;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SpringBootGoogleSecretManagerPropertiesParserTest {
+
+    private final SpringBootGoogleSecretManagerPropertiesParser parser
+            = new SpringBootGoogleSecretManagerPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.google-secret-manager.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-google-secret-manager-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+
+    /**
+     * The integration test in this module sets {@code camel.vault.gcp.*} through {@code System.setProperty},
+     * and Surefire reuses the JVM across test classes. Dropping the system property sources keeps this test
+     * independent of execution order.
+     */
+    private static StandardEnvironment isolatedEnvironment() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().remove(StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME);
+        environment.getPropertySources().remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
+        return environment;
+    }
+
+    @Test
+    public void missingConfigurationFailsAsACamelException() {
+        assertThrows(RuntimeCamelException.class,
+                () -> parser.createPropertiesFunction(isolatedEnvironment()),
+                "configuration problems must surface as RuntimeCamelException so operators and callers can "
+                        + "treat them as one category");
+    }
+}

--- a/components-starter/camel-hashicorp-vault-starter/src/main/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParser.java
+++ b/components-starter/camel-hashicorp-vault-starter/src/main/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParser.java
@@ -18,93 +18,57 @@ package org.apache.camel.component.hashicorp.vault.springboot;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.hashicorp.vault.HashicorpVaultPropertiesFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
+import org.apache.camel.util.ObjectHelper;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.core.VaultTemplate;
 
-import java.util.Objects;
-import java.util.Properties;
-
-public class SpringBootHashicorpVaultPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootHashicorpVaultPropertiesParser.class);
+public class SpringBootHashicorpVaultPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.hashicorp-vault.early-resolve-properties"))) {
-            Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.token"), "Hashicorp Vault token is required");
-            Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.host"), "Hashicorp Vault host is required");
-            Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.port"), "Hashicorp Vault port is required");
-            Objects.requireNonNull(environment.getProperty("camel.vault.hashicorp.scheme"), "Hashicorp Vault scheme is required");
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.hashicorp-vault.early-resolve-properties";
+    }
 
-            String token = environment.getProperty("camel.vault.hashicorp.token");
-            String host = environment.getProperty("camel.vault.hashicorp.host");
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-hashicorp-vault-properties";
+    }
 
-            int port = Integer.parseInt(environment.getProperty("camel.vault.hashicorp.port"));
-            String scheme = environment.getProperty("camel.vault.hashicorp.scheme");
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
+        String token = required(environment, "camel.vault.hashicorp.token", "Hashicorp Vault token is required");
+        String host = required(environment, "camel.vault.hashicorp.host", "Hashicorp Vault host is required");
+        String portValue = required(environment, "camel.vault.hashicorp.port", "Hashicorp Vault port is required");
+        String scheme = required(environment, "camel.vault.hashicorp.scheme", "Hashicorp Vault scheme is required");
 
-            VaultEndpoint vaultEndpoint = new VaultEndpoint();
-            vaultEndpoint.setHost(host);
-            vaultEndpoint.setPort(port);
-            vaultEndpoint.setScheme(scheme);
-
-            VaultTemplate client = new VaultTemplate(
-                    vaultEndpoint,
-                    new TokenAuthentication(token));
-            HashicorpVaultPropertiesFunction hashicorpVaultPropertiesFunction = new HashicorpVaultPropertiesFunction(client);
-
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{hashicorp:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                props.put(key, hashicorpVaultPropertiesFunction.apply(stringValue
-                                        .replace("{{hashicorp:", "")
-                                        .replace("}}", "")));
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-camel-hashicorp-vault-properties", props));
+        int port;
+        try {
+            port = Integer.parseInt(portValue);
+        } catch (NumberFormatException e) {
+            throw new RuntimeCamelException(
+                    "camel.vault.hashicorp.port must be a number but was: " + portValue, e);
         }
+
+        VaultEndpoint vaultEndpoint = new VaultEndpoint();
+        vaultEndpoint.setHost(host);
+        vaultEndpoint.setPort(port);
+        vaultEndpoint.setScheme(scheme);
+
+        VaultTemplate client = new VaultTemplate(
+                vaultEndpoint,
+                new TokenAuthentication(token));
+        return new HashicorpVaultPropertiesFunction(client);
+    }
+
+    private static String required(ConfigurableEnvironment environment, String key, String message) {
+        String value = environment.getProperty(key);
+        if (ObjectHelper.isEmpty(value)) {
+            throw new RuntimeCamelException(message + " (set " + key + ")");
+        }
+        return value;
     }
 }

--- a/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParserTest.java
+++ b/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParserTest.java
@@ -16,14 +16,16 @@
  */
 package org.apache.camel.component.hashicorp.vault.springboot;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.apache.camel.RuntimeCamelException;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,6 +73,36 @@ public class SpringBootHashicorpVaultPropertiesParserTest {
     }
 
     @Test
+    public void missingHostFailsAsACamelExceptionNamingTheProperty() {
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.createPropertiesFunction(environmentWith(Map.of(
+                        "camel.vault.hashicorp.token", "a-token"))),
+                "a missing setting is an operator error, not a programming defect, so it must not surface "
+                        + "as NullPointerException");
+
+        assertTrue(thrown.getMessage().contains("host"),
+                "the failure must name the missing setting, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("camel.vault.hashicorp.host"),
+                "the failure must name the missing property, was: " + thrown.getMessage());
+    }
+
+    @Test
+    public void missingSchemeFailsAsACamelExceptionNamingTheProperty() {
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.createPropertiesFunction(environmentWith(Map.of(
+                        "camel.vault.hashicorp.token", "a-token",
+                        "camel.vault.hashicorp.host", "127.0.0.1",
+                        "camel.vault.hashicorp.port", "8200"))),
+                "a missing setting is an operator error, not a programming defect, so it must not surface "
+                        + "as NullPointerException");
+
+        assertTrue(thrown.getMessage().contains("scheme"),
+                "the failure must name the missing setting, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("camel.vault.hashicorp.scheme"),
+                "the failure must name the missing property, was: " + thrown.getMessage());
+    }
+
+    @Test
     public void nonNumericPortFailsAsACamelExceptionNamingTheProperty() {
         RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
                 () -> parser.createPropertiesFunction(environmentWith(Map.of(
@@ -82,5 +114,7 @@ public class SpringBootHashicorpVaultPropertiesParserTest {
 
         assertTrue(thrown.getMessage().contains("camel.vault.hashicorp.port"),
                 "the failure must name the malformed property, was: " + thrown.getMessage());
+        assertInstanceOf(NumberFormatException.class, thrown.getCause(),
+                "the cause must be preserved so the original NumberFormatException is not lost");
     }
 }

--- a/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParserTest.java
+++ b/components-starter/camel-hashicorp-vault-starter/src/test/java/org/apache/camel/component/hashicorp/vault/springboot/SpringBootHashicorpVaultPropertiesParserTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hashicorp.vault.springboot;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.camel.RuntimeCamelException;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SpringBootHashicorpVaultPropertiesParserTest {
+
+    private final SpringBootHashicorpVaultPropertiesParser parser = new SpringBootHashicorpVaultPropertiesParser();
+
+    /**
+     * The integration tests in this module set {@code camel.vault.hashicorp.*} through
+     * {@code System.setProperty}, and Surefire reuses the JVM across test classes. Dropping the system
+     * property sources keeps these tests independent of execution order.
+     */
+    private static StandardEnvironment environmentWith(Map<String, ?> properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().remove(StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME);
+        environment.getPropertySources().remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
+        environment.getPropertySources()
+                .addFirst(new MapPropertySource("test-properties", new LinkedHashMap<>(properties)));
+        return environment;
+    }
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.hashicorp-vault.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-hashicorp-vault-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+
+    @Test
+    public void missingTokenFailsAsACamelExceptionNamingTheProperty() {
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.createPropertiesFunction(environmentWith(Map.of())),
+                "a missing setting is an operator error, not a programming defect, so it must not surface "
+                        + "as NullPointerException");
+
+        assertTrue(thrown.getMessage().contains("token"),
+                "the failure must name the missing setting, was: " + thrown.getMessage());
+    }
+
+    @Test
+    public void nonNumericPortFailsAsACamelExceptionNamingTheProperty() {
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.createPropertiesFunction(environmentWith(Map.of(
+                        "camel.vault.hashicorp.token", "a-token",
+                        "camel.vault.hashicorp.host", "127.0.0.1",
+                        "camel.vault.hashicorp.port", "not-a-number",
+                        "camel.vault.hashicorp.scheme", "http"))),
+                "a bare NumberFormatException never says which property was malformed");
+
+        assertTrue(thrown.getMessage().contains("camel.vault.hashicorp.port"),
+                "the failure must name the malformed property, was: " + thrown.getMessage());
+    }
+}

--- a/components-starter/camel-ibm-secrets-manager-starter/src/main/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParser.java
+++ b/components-starter/camel-ibm-secrets-manager-starter/src/main/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParser.java
@@ -20,84 +20,38 @@ import com.ibm.cloud.sdk.core.security.IamAuthenticator;
 import com.ibm.cloud.secrets_manager_sdk.secrets_manager.v2.SecretsManager;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.ibm.secrets.manager.IBMSecretsManagerPropertiesFunction;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 
-import java.util.Properties;
-
-public class IBMSecretsManagerVaultPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(IBMSecretsManagerVaultPropertiesParser.class);
+public class IBMSecretsManagerVaultPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.ibm-secrets-manager.early-resolve-properties";
+    }
+
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-ibm-secrets-manager-properties";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
         SecretsManager client;
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
-        String token;
-        String serviceUrl;
-        if (Boolean.parseBoolean(environment.getProperty("camel.component.ibm-secrets-manager.early-resolve-properties"))) {
-            token = environment.getProperty("camel.vault.ibm.token");
-            serviceUrl = environment.getProperty("camel.vault.ibm.serviceUrl");
-            if (ObjectHelper.isNotEmpty(token) && ObjectHelper.isNotEmpty(serviceUrl)) {
-                IamAuthenticator iamAuthenticator = new IamAuthenticator.Builder()
-                        .apikey(token)
-                        .build();
-                client = new SecretsManager("Camel Secrets Manager Service for Properties", iamAuthenticator);
-                client.setServiceUrl(serviceUrl);
-            } else {
-                throw new RuntimeCamelException(
-                        "Using the IBM Secrets Manager Properties Function requires setting IBM Credentials and service url as application properties or environment variables");
-            }
-            IBMSecretsManagerPropertiesFunction secretsManagerPropertiesFunction = new IBMSecretsManagerPropertiesFunction(client);
-            final Properties props = new Properties();
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue &&
-                                originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-                        if (stringValue != null &&
-                                stringValue.startsWith("{{ibm:") &&
-                                stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = secretsManagerPropertiesFunction.apply(stringValue
-                                        .replace("{{ibm:", "")
-                                        .replace("}}", ""));
-                                props.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from the vault; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from the vault. Startup is aborted so "
-                                                            + "that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-            environment.getPropertySources().addFirst(new PropertiesPropertySource("overridden-ibm-secrets-manager-properties", props));
+        String token = environment.getProperty("camel.vault.ibm.token");
+        String serviceUrl = environment.getProperty("camel.vault.ibm.serviceUrl");
+        if (ObjectHelper.isNotEmpty(token) && ObjectHelper.isNotEmpty(serviceUrl)) {
+            IamAuthenticator iamAuthenticator = new IamAuthenticator.Builder()
+                    .apikey(token)
+                    .build();
+            client = new SecretsManager("Camel Secrets Manager Service for Properties", iamAuthenticator);
+            client.setServiceUrl(serviceUrl);
+        } else {
+            throw new RuntimeCamelException(
+                    "Using the IBM Secrets Manager Properties Function requires setting IBM Credentials and service url as application properties or environment variables");
         }
+        return new IBMSecretsManagerPropertiesFunction(client);
     }
 }

--- a/components-starter/camel-ibm-secrets-manager-starter/src/test/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParserTest.java
+++ b/components-starter/camel-ibm-secrets-manager-starter/src/test/java/org/apache/camel/component/ibm/secrets/manager/springboot/IBMSecretsManagerVaultPropertiesParserTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ibm.secrets.manager.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IBMSecretsManagerVaultPropertiesParserTest {
+
+    private final IBMSecretsManagerVaultPropertiesParser parser = new IBMSecretsManagerVaultPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.ibm-secrets-manager.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameKeepsItsHistoricalSpelling() {
+        assertEquals("overridden-ibm-secrets-manager-properties",
+                parser.getOverridePropertySourceName(),
+                "this name lacks the camel- segment the other starters use; it is observable through "
+                        + "/actuator/env so it must not be normalised");
+    }
+}

--- a/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/main/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParser.java
@@ -16,72 +16,33 @@
  */
 package org.apache.camel.component.spring.cloud.config.springboot;
 
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.spring.cloud.config.SpringCloudConfigPropertiesFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.context.ApplicationListener;
+import org.apache.camel.spi.PropertiesFunction;
+import org.apache.camel.spring.boot.AbstractEarlyResolutionPropertiesParser;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
 
-import java.util.Properties;
-
-public class SpringBootCloudConfigPropertiesParser implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpringBootCloudConfigPropertiesParser.class);
+public class SpringBootCloudConfigPropertiesParser extends AbstractEarlyResolutionPropertiesParser {
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
-        Properties properties = new Properties();
-        ConfigurableEnvironment environment = event.getEnvironment();
-        // an unresolved placeholder would otherwise stay in the property value and become the effective
-        // configuration value, so resolution failures abort startup unless the operator opts back in
-        final boolean ignoreResolutionFailures
-                = Boolean.parseBoolean(environment.getProperty("camel.vault.ignore-resolution-failures"));
+    protected String getEarlyResolutionProperty() {
+        return "camel.component.spring-cloud-config.early-resolve-properties";
+    }
 
-        if (Boolean.parseBoolean(
-                environment.getProperty("camel.component.spring-cloud-config.early-resolve-properties"))) {
-            SpringCloudConfigPropertiesFunction springCloudConfigPropertiesFunction = new SpringCloudConfigPropertiesFunction();
-            springCloudConfigPropertiesFunction.setEnvironment(environment);
-            for (PropertySource mutablePropertySources : event.getEnvironment().getPropertySources()) {
-                if (mutablePropertySources instanceof MapPropertySource mapPropertySource) {
-                    mapPropertySource.getSource().forEach((key, value) -> {
-                        String stringValue = null;
-                        if ((value instanceof OriginTrackedValue originTrackedValue
-                                && originTrackedValue.getValue() instanceof String v)) {
-                            stringValue = v;
-                        } else if (value instanceof String v) {
-                            stringValue = v;
-                        }
-                        if (stringValue != null && stringValue.startsWith("{{spring-config:")
-                                && stringValue.endsWith("}}")) {
-                            LOG.debug("decrypting and overriding property {}", key);
-                            try {
-                                String element = springCloudConfigPropertiesFunction
-                                        .apply(stringValue.replace("{{spring-config:", "").replace("}}", ""));
-                                properties.put(key, element);
-                            } catch (Exception e) {
-                                if (ignoreResolutionFailures) {
-                                    LOG.warn("Failed to resolve property {} from Spring Cloud Config; the placeholder is left "
-                                             + "unresolved because camel.vault.ignore-resolution-failures is enabled", key, e);
-                                } else {
-                                    throw new RuntimeCamelException(
-                                            "Failed to resolve property " + key + " from Spring Cloud Config. Startup is aborted "
-                                                            + "so that the unresolved placeholder cannot become the effective "
-                                                            + "value; set camel.vault.ignore-resolution-failures=true to "
-                                                            + "continue anyway.",
-                                            e);
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-            environment.getPropertySources()
-                    .addFirst(new PropertiesPropertySource("overridden-camel-spring-config-properties", properties));
-        }
+    @Override
+    protected String getOverridePropertySourceName() {
+        return "overridden-camel-spring-config-properties";
+    }
+
+    @Override
+    protected String getSourceDescription() {
+        return "Spring Cloud Config";
+    }
+
+    @Override
+    protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
+        SpringCloudConfigPropertiesFunction springCloudConfigPropertiesFunction
+                = new SpringCloudConfigPropertiesFunction();
+        springCloudConfigPropertiesFunction.setEnvironment(environment);
+        return springCloudConfigPropertiesFunction;
     }
 }

--- a/components-starter/camel-spring-cloud-config-starter/src/test/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParserTest.java
+++ b/components-starter/camel-spring-cloud-config-starter/src/test/java/org/apache/camel/component/spring/cloud/config/springboot/SpringBootCloudConfigPropertiesParserTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.spring.cloud.config.springboot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpringBootCloudConfigPropertiesParserTest {
+
+    private final SpringBootCloudConfigPropertiesParser parser = new SpringBootCloudConfigPropertiesParser();
+
+    @Test
+    public void guardPropertyIsUnchanged() {
+        assertEquals("camel.component.spring-cloud-config.early-resolve-properties",
+                parser.getEarlyResolutionProperty(),
+                "a wrong guard key silently disables early resolution, leaving placeholders as literal values");
+    }
+
+    @Test
+    public void overridePropertySourceNameIsUnchanged() {
+        assertEquals("overridden-camel-spring-config-properties",
+                parser.getOverridePropertySourceName(),
+                "the property source name is observable through /actuator/env");
+    }
+
+    @Test
+    public void diagnosticsNameSpringCloudConfigRatherThanAVault() {
+        assertEquals("Spring Cloud Config", parser.getSourceDescription(),
+                "this starter reads a config server, so calling it a vault would misdirect the operator");
+    }
+}

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.util.Properties;
+import org.apache.camel.spi.PropertiesFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertiesPropertySource;
+
+/**
+ * Base class for the early-resolution listeners used by the Camel vault and secrets starters.
+ * <p/>
+ * These listeners run on {@link ApplicationEnvironmentPreparedEvent}, before the application context exists, so
+ * they cannot use dependency injection or conditional auto-configuration. This class owns the parts that are the
+ * same for every component: reading the guard property, walking the property sources, matching placeholders,
+ * resolving them and registering the resolved values. Subclasses contribute only the component-specific client
+ * construction and naming.
+ * <p/>
+ * Early resolution deliberately handles only property values that consist entirely of a single placeholder.
+ * Values with an embedded placeholder, such as {@code jdbc://{{aws:host}}/db}, are left for Camel's normal
+ * property parser.
+ */
+public abstract class AbstractEarlyResolutionPropertiesParser
+        implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+    /**
+     * Lets an operator tolerate resolution failures instead of aborting startup.
+     */
+    public static final String IGNORE_RESOLUTION_FAILURES = "camel.vault.ignore-resolution-failures";
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractEarlyResolutionPropertiesParser.class);
+
+    /**
+     * The property that enables early resolution for this component, for example
+     * {@code camel.component.aws-secrets-manager.early-resolve-properties}.
+     */
+    protected abstract String getEarlyResolutionProperty();
+
+    /**
+     * The name of the property source holding the resolved values, for example
+     * {@code overridden-camel-aws-secrets-manager-properties}. These names are observable through
+     * {@code /actuator/env}, so they must not change.
+     */
+    protected abstract String getOverridePropertySourceName();
+
+    /**
+     * Builds the component client and its resolver. Called only after the guard property is enabled, so that
+     * client construction and its configuration validation never run for applications that did not opt in.
+     */
+    protected abstract PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment);
+
+    /**
+     * Wording used in diagnostics to name where a value was being resolved from.
+     */
+    protected String getSourceDescription() {
+        return "the vault";
+    }
+
+    @Override
+    public final void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+        ConfigurableEnvironment environment = event.getEnvironment();
+        if (!Boolean.parseBoolean(environment.getProperty(getEarlyResolutionProperty()))) {
+            return;
+        }
+
+        PropertiesFunction propertiesFunction = createPropertiesFunction(environment);
+        LOG.debug("Early resolving properties using the {} function", propertiesFunction.getName());
+
+        final Properties props = new Properties();
+
+        environment.getPropertySources()
+                .addFirst(new PropertiesPropertySource(getOverridePropertySourceName(), props));
+    }
+}

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.spring.boot;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.PropertiesFunction;
@@ -40,9 +40,10 @@ import org.springframework.core.env.PropertySource;
  * resolving them and registering the resolved values. Subclasses contribute only the component-specific client
  * construction and naming.
  * <p/>
- * Early resolution deliberately handles only property values that consist entirely of a single placeholder.
- * Values with an embedded placeholder, such as {@code jdbc://{{aws:host}}/db}, are left for Camel's normal
- * property parser.
+ * A property value is an early-resolution candidate only when it starts with <code>{{&lt;functionName&gt;:</code>
+ * and ends with <code>}}</code>; everything in between is passed to the properties function verbatim. A value
+ * that concatenates two placeholders, such as {@code {{aws:user}}:{{aws:pass}}}, satisfies both conditions and
+ * is therefore not handled correctly; this is a known limitation, not a supported use case.
  */
 public abstract class AbstractEarlyResolutionPropertiesParser
         implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
@@ -99,8 +100,7 @@ public abstract class AbstractEarlyResolutionPropertiesParser
 
         final String prefix = "{{" + propertiesFunction.getName() + ":";
         final Properties props = new Properties();
-        final List<String> failedKeys = new ArrayList<>();
-        final List<RuntimeCamelException> failures = new ArrayList<>();
+        final Map<String, RuntimeCamelException> failures = new LinkedHashMap<>();
 
         for (PropertySource<?> propertySource : environment.getPropertySources()) {
             if (propertySource instanceof MapPropertySource mapPropertySource) {
@@ -109,19 +109,24 @@ public abstract class AbstractEarlyResolutionPropertiesParser
                     if (stringValue != null && stringValue.startsWith(prefix) && stringValue.endsWith(SUFFIX)) {
                         String remainder = stringValue.substring(prefix.length(),
                                 stringValue.length() - SUFFIX.length());
-                        LOG.debug("decrypting and overriding property {}", key);
+                        LOG.debug("Resolving and overriding property {}", key);
                         try {
-                            props.put(key, propertiesFunction.apply(remainder));
+                            String resolved = propertiesFunction.apply(remainder);
+                            if (resolved == null) {
+                                throw new RuntimeCamelException(
+                                        "The " + propertiesFunction.getName()
+                                                + " properties function returned no value for " + remainder);
+                            }
+                            props.put(key, resolved);
                         } catch (Exception e) {
                             if (ignoreResolutionFailures) {
                                 LOG.warn("Failed to resolve property {} from {}; the placeholder is left "
                                          + "unresolved because {} is enabled",
                                         key, getSourceDescription(), IGNORE_RESOLUTION_FAILURES, e);
                             } else {
-                                failedKeys.add(key);
-                                failures.add(new RuntimeCamelException(
+                                failures.put(key, new RuntimeCamelException(
                                         "Failed to resolve property " + key + " from " + getSourceDescription()
-                                                              + ".",
+                                                + ".",
                                         e));
                             }
                         }
@@ -133,11 +138,11 @@ public abstract class AbstractEarlyResolutionPropertiesParser
         if (!failures.isEmpty()) {
             RuntimeCamelException aggregated = new RuntimeCamelException(
                     "Failed to resolve " + failures.size() + " property placeholder(s) from "
-                                          + getSourceDescription() + ": " + String.join(", ", failedKeys)
-                                          + ". Startup is aborted so that the unresolved placeholders cannot "
-                                          + "become the effective values; set " + IGNORE_RESOLUTION_FAILURES
-                                          + "=true to continue anyway.");
-            failures.forEach(aggregated::addSuppressed);
+                            + getSourceDescription() + ": " + String.join(", ", failures.keySet())
+                            + ". Startup is aborted so that the unresolved placeholders cannot "
+                            + "become the effective values; set " + IGNORE_RESOLUTION_FAILURES
+                            + "=true to continue anyway.");
+            failures.values().forEach(aggregated::addSuppressed);
             throw aggregated;
         }
 

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
@@ -16,7 +16,10 @@
  */
 package org.apache.camel.spring.boot;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.PropertiesFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,11 +89,18 @@ public abstract class AbstractEarlyResolutionPropertiesParser
             return;
         }
 
+        // an unresolved placeholder would otherwise stay in the property value and become the effective
+        // secret, so resolution failures abort startup unless the operator opts back into the old behaviour
+        final boolean ignoreResolutionFailures
+                = Boolean.parseBoolean(environment.getProperty(IGNORE_RESOLUTION_FAILURES));
+
         PropertiesFunction propertiesFunction = createPropertiesFunction(environment);
         LOG.debug("Early resolving properties using the {} function", propertiesFunction.getName());
 
         final String prefix = "{{" + propertiesFunction.getName() + ":";
         final Properties props = new Properties();
+        final List<String> failedKeys = new ArrayList<>();
+        final List<RuntimeCamelException> failures = new ArrayList<>();
 
         for (PropertySource<?> propertySource : environment.getPropertySources()) {
             if (propertySource instanceof MapPropertySource mapPropertySource) {
@@ -100,10 +110,35 @@ public abstract class AbstractEarlyResolutionPropertiesParser
                         String remainder = stringValue.substring(prefix.length(),
                                 stringValue.length() - SUFFIX.length());
                         LOG.debug("decrypting and overriding property {}", key);
-                        props.put(key, propertiesFunction.apply(remainder));
+                        try {
+                            props.put(key, propertiesFunction.apply(remainder));
+                        } catch (Exception e) {
+                            if (ignoreResolutionFailures) {
+                                LOG.warn("Failed to resolve property {} from {}; the placeholder is left "
+                                         + "unresolved because {} is enabled",
+                                        key, getSourceDescription(), IGNORE_RESOLUTION_FAILURES, e);
+                            } else {
+                                failedKeys.add(key);
+                                failures.add(new RuntimeCamelException(
+                                        "Failed to resolve property " + key + " from " + getSourceDescription()
+                                                              + ".",
+                                        e));
+                            }
+                        }
                     }
                 });
             }
+        }
+
+        if (!failures.isEmpty()) {
+            RuntimeCamelException aggregated = new RuntimeCamelException(
+                    "Failed to resolve " + failures.size() + " property placeholder(s) from "
+                                          + getSourceDescription() + ": " + String.join(", ", failedKeys)
+                                          + ". Startup is aborted so that the unresolved placeholders cannot "
+                                          + "become the effective values; set " + IGNORE_RESOLUTION_FAILURES
+                                          + "=true to continue anyway.");
+            failures.forEach(aggregated::addSuppressed);
+            throw aggregated;
         }
 
         environment.getPropertySources()

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParser.java
@@ -21,9 +21,12 @@ import org.apache.camel.spi.PropertiesFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.origin.OriginTrackedValue;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
 
 /**
  * Base class for the early-resolution listeners used by the Camel vault and secrets starters.
@@ -45,6 +48,8 @@ public abstract class AbstractEarlyResolutionPropertiesParser
      * Lets an operator tolerate resolution failures instead of aborting startup.
      */
     public static final String IGNORE_RESOLUTION_FAILURES = "camel.vault.ignore-resolution-failures";
+
+    private static final String SUFFIX = "}}";
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEarlyResolutionPropertiesParser.class);
 
@@ -84,9 +89,35 @@ public abstract class AbstractEarlyResolutionPropertiesParser
         PropertiesFunction propertiesFunction = createPropertiesFunction(environment);
         LOG.debug("Early resolving properties using the {} function", propertiesFunction.getName());
 
+        final String prefix = "{{" + propertiesFunction.getName() + ":";
         final Properties props = new Properties();
+
+        for (PropertySource<?> propertySource : environment.getPropertySources()) {
+            if (propertySource instanceof MapPropertySource mapPropertySource) {
+                mapPropertySource.getSource().forEach((key, value) -> {
+                    String stringValue = asString(value);
+                    if (stringValue != null && stringValue.startsWith(prefix) && stringValue.endsWith(SUFFIX)) {
+                        String remainder = stringValue.substring(prefix.length(),
+                                stringValue.length() - SUFFIX.length());
+                        LOG.debug("decrypting and overriding property {}", key);
+                        props.put(key, propertiesFunction.apply(remainder));
+                    }
+                });
+            }
+        }
 
         environment.getPropertySources()
                 .addFirst(new PropertiesPropertySource(getOverridePropertySourceName(), props));
+    }
+
+    private static String asString(Object value) {
+        if (value instanceof OriginTrackedValue originTrackedValue
+                && originTrackedValue.getValue() instanceof String v) {
+            return v;
+        }
+        if (value instanceof String v) {
+            return v;
+        }
+        return null;
     }
 }

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.camel.spi.PropertiesFunction;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.bootstrap.DefaultBootstrapContext;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class AbstractEarlyResolutionPropertiesParserTest {
+
+    private static final String GUARD = "camel.component.test-vault.early-resolve-properties";
+    private static final String OVERRIDE_SOURCE = "overridden-camel-test-vault-properties";
+
+    /**
+     * Records every key the parser asks the environment for, so that the order in which the guard and the
+     * opt-out flag are read can be asserted.
+     */
+    private static final class RecordingEnvironment extends StandardEnvironment {
+        private final List<String> queried = new ArrayList<>();
+
+        @Override
+        public String getProperty(String key) {
+            queried.add(key);
+            return super.getProperty(key);
+        }
+    }
+
+    /**
+     * Stands in for a vault client. Records what it was asked to resolve and fails for a configured set of
+     * remainders, so no container or network is needed.
+     */
+    private static final class StubPropertiesFunction implements PropertiesFunction {
+        private final Map<String, String> values;
+        private final Set<String> failing;
+        private final List<String> applied = new ArrayList<>();
+
+        StubPropertiesFunction(Map<String, String> values, Set<String> failing) {
+            this.values = values;
+            this.failing = failing;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public String apply(String remainder) {
+            applied.add(remainder);
+            if (failing.contains(remainder)) {
+                throw new IllegalStateException("cannot resolve " + remainder);
+            }
+            return values.get(remainder);
+        }
+    }
+
+    private static final class TestParser extends AbstractEarlyResolutionPropertiesParser {
+        private final StubPropertiesFunction function;
+        private int factoryCalls;
+
+        TestParser(StubPropertiesFunction function) {
+            this.function = function;
+        }
+
+        @Override
+        protected String getEarlyResolutionProperty() {
+            return GUARD;
+        }
+
+        @Override
+        protected String getOverridePropertySourceName() {
+            return OVERRIDE_SOURCE;
+        }
+
+        @Override
+        protected PropertiesFunction createPropertiesFunction(ConfigurableEnvironment environment) {
+            factoryCalls++;
+            return function;
+        }
+    }
+
+    private static ApplicationEnvironmentPreparedEvent eventFor(ConfigurableEnvironment environment) {
+        return new ApplicationEnvironmentPreparedEvent(
+                new DefaultBootstrapContext(), new SpringApplication(), new String[0], environment);
+    }
+
+    /**
+     * Accepts {@code Map<String, ?>} so that both {@code Map.of("k", "v")} (which infers
+     * {@code Map<String, String>}) and maps holding an OriginTrackedValue can be passed.
+     */
+    private static RecordingEnvironment environmentWith(Map<String, ?> properties) {
+        RecordingEnvironment environment = new RecordingEnvironment();
+        environment.getPropertySources()
+                .addFirst(new MapPropertySource("test-properties", new LinkedHashMap<>(properties)));
+        return environment;
+    }
+
+    @Test
+    public void guardDisabledDoesNotBuildTheClient() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                "my.secret", "{{test:some/secret}}"));
+        TestParser parser = new TestParser(new StubPropertiesFunction(Map.of(), Set.of()));
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals(0, parser.factoryCalls,
+                "building a vault client while early resolution is disabled would abort startup for every "
+                        + "application that never opted in");
+        assertNull(environment.getPropertySources().get(OVERRIDE_SOURCE),
+                "no override property source may be added when early resolution is disabled");
+    }
+
+    @Test
+    public void guardEnabledBuildsTheClientAndAddsTheOverrideSource() {
+        RecordingEnvironment environment = environmentWith(Map.of(GUARD, "true"));
+        TestParser parser = new TestParser(new StubPropertiesFunction(Map.of(), Set.of()));
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals(1, parser.factoryCalls, "the client is built exactly once per event");
+        assertNotNull(environment.getPropertySources().get(OVERRIDE_SOURCE),
+                "the override source must be registered so later property resolution sees it");
+    }
+}

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
@@ -228,6 +228,8 @@ public class AbstractEarlyResolutionPropertiesParserTest {
 
         parser.onApplicationEvent(eventFor(environment));
 
+        assertTrue(environment.queried.contains(GUARD),
+                "the guard property must be queried so that the ordering below is actually exercised");
         assertFalse(environment.queried.contains(
                 AbstractEarlyResolutionPropertiesParser.IGNORE_RESOLUTION_FAILURES),
                 "the opt-out flag is only meaningful once early resolution is enabled, so it must not be "
@@ -258,6 +260,23 @@ public class AbstractEarlyResolutionPropertiesParserTest {
                 "each individual failure is attached so its cause survives");
         assertEquals(2, function.applied.size(),
                 "aborting on the first failure would hide the remaining broken placeholders from the operator");
+    }
+
+    @Test
+    public void nullResolutionResultIsTreatedAsAFailure() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "my.secret", "{{test:missing/subkey}}"));
+        TestParser parser = new TestParser(new StubPropertiesFunction(Map.of(), Set.of()));
+
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.onApplicationEvent(eventFor(environment)));
+
+        assertTrue(thrown.getMessage().contains("my.secret"),
+                "a null result is a resolution failure like any other, so it must name the property, was: "
+                        + thrown.getMessage());
+        assertNull(environment.getPropertySources().get(OVERRIDE_SOURCE),
+                "a null resolution result must abort startup rather than silently storing no value");
     }
 
     @Test

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.PropertiesFunction;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
@@ -31,9 +32,13 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractEarlyResolutionPropertiesParserTest {
 
@@ -213,5 +218,76 @@ public class AbstractEarlyResolutionPropertiesParserTest {
 
         assertEquals("pazzword", environment.getProperty("my.secret"),
                 "values loaded from application.properties arrive wrapped in OriginTrackedValue");
+    }
+
+    @Test
+    public void guardDisabledDoesNotReadTheIgnoreFlag() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                "my.secret", "{{test:some/secret}}"));
+        TestParser parser = new TestParser(new StubPropertiesFunction(Map.of(), Set.of()));
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertFalse(environment.queried.contains(
+                AbstractEarlyResolutionPropertiesParser.IGNORE_RESOLUTION_FAILURES),
+                "the opt-out flag is only meaningful once early resolution is enabled, so it must not be "
+                        + "evaluated before the guard");
+    }
+
+    @Test
+    public void failClosedReportsEveryFailingPropertyTogether() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "first.secret", "{{test:missing/one}}",
+                "second.secret", "{{test:missing/two}}"));
+        StubPropertiesFunction function = new StubPropertiesFunction(
+                Map.of(), Set.of("missing/one", "missing/two"));
+        TestParser parser = new TestParser(function);
+
+        RuntimeCamelException thrown = assertThrows(RuntimeCamelException.class,
+                () -> parser.onApplicationEvent(eventFor(environment)));
+
+        assertTrue(thrown.getMessage().contains("first.secret"),
+                "the failure must name every property that could not be resolved, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("second.secret"),
+                "the failure must name every property that could not be resolved, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains(
+                AbstractEarlyResolutionPropertiesParser.IGNORE_RESOLUTION_FAILURES),
+                "the failure must point at the opt-out property, was: " + thrown.getMessage());
+        assertEquals(2, thrown.getSuppressed().length,
+                "each individual failure is attached so its cause survives");
+        assertEquals(2, function.applied.size(),
+                "aborting on the first failure would hide the remaining broken placeholders from the operator");
+    }
+
+    @Test
+    public void failClosedDoesNotRegisterAnOverrideSource() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "my.secret", "{{test:missing}}"));
+        TestParser parser = new TestParser(new StubPropertiesFunction(Map.of(), Set.of("missing")));
+
+        assertThrows(RuntimeCamelException.class, () -> parser.onApplicationEvent(eventFor(environment)));
+
+        assertNull(environment.getPropertySources().get(OVERRIDE_SOURCE),
+                "a partially populated override source must not be left behind after an aborted startup");
+    }
+
+    @Test
+    public void ignoreResolutionFailuresKeepsStartupGoing() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                AbstractEarlyResolutionPropertiesParser.IGNORE_RESOLUTION_FAILURES, "true",
+                "good.secret", "{{test:present}}",
+                "bad.secret", "{{test:missing}}"));
+        TestParser parser = new TestParser(
+                new StubPropertiesFunction(Map.of("present", "resolved"), Set.of("missing")));
+
+        assertDoesNotThrow(() -> parser.onApplicationEvent(eventFor(environment)));
+
+        assertEquals("resolved", environment.getProperty("good.secret"),
+                "a failure elsewhere must not discard the values that did resolve");
+        assertEquals("{{test:missing}}", environment.getProperty("bad.secret"),
+                "in tolerant mode the unresolved placeholder is deliberately left in place");
     }
 }

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/AbstractEarlyResolutionPropertiesParserTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.bootstrap.DefaultBootstrapContext;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.origin.OriginTrackedValue;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
@@ -148,5 +149,69 @@ public class AbstractEarlyResolutionPropertiesParserTest {
         assertEquals(1, parser.factoryCalls, "the client is built exactly once per event");
         assertNotNull(environment.getPropertySources().get(OVERRIDE_SOURCE),
                 "the override source must be registered so later property resolution sees it");
+    }
+
+    @Test
+    public void resolvesWholeValuePlaceholders() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "my.secret", "{{test:database/password}}"));
+        TestParser parser = new TestParser(
+                new StubPropertiesFunction(Map.of("database/password", "pazzword"), Set.of()));
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals("pazzword", environment.getProperty("my.secret"),
+                "the resolved value must take effect, because the placeholder text is not a usable secret");
+    }
+
+    @Test
+    public void leavesNonMatchingValuesAlone() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "embedded.placeholder", "jdbc://{{test:host}}/db",
+                "foreign.prefix", "{{other:host}}",
+                "plain.value", "just-a-string"));
+        StubPropertiesFunction function = new StubPropertiesFunction(Map.of("host", "resolved-host"), Set.of());
+        TestParser parser = new TestParser(function);
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals(List.of(), function.applied,
+                "early resolution deliberately handles only values that are entirely one placeholder; "
+                        + "embedded placeholders belong to Camel's normal property parser");
+        assertEquals("jdbc://{{test:host}}/db", environment.getProperty("embedded.placeholder"));
+        assertEquals("{{other:host}}", environment.getProperty("foreign.prefix"));
+        assertEquals("just-a-string", environment.getProperty("plain.value"));
+    }
+
+    @Test
+    public void stripsOnlyTheLeadingPrefixAndTrailingDelimiters() {
+        RecordingEnvironment environment = environmentWith(Map.of(
+                GUARD, "true",
+                "my.secret", "{{test:a}}b}}"));
+        StubPropertiesFunction function = new StubPropertiesFunction(Map.of("a}}b", "resolved"), Set.of());
+        TestParser parser = new TestParser(function);
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals(List.of("a}}b"), function.applied,
+                "a global replace of the delimiters would corrupt a remainder that itself contains them");
+        assertEquals("resolved", environment.getProperty("my.secret"));
+    }
+
+    @Test
+    public void resolvesOriginTrackedValues() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(GUARD, "true");
+        properties.put("my.secret", OriginTrackedValue.of("{{test:database/password}}"));
+        RecordingEnvironment environment = environmentWith(properties);
+        TestParser parser = new TestParser(
+                new StubPropertiesFunction(Map.of("database/password", "pazzword"), Set.of()));
+
+        parser.onApplicationEvent(eventFor(environment));
+
+        assertEquals("pazzword", environment.getProperty("my.secret"),
+                "values loaded from application.properties arrive wrapped in OriginTrackedValue");
     }
 }


### PR DESCRIPTION
## What this does

Seven vault and secrets starters each carried a near-identical `ApplicationListener<ApplicationEnvironmentPreparedEvent>` that resolved `{{<prefix>:...}}` placeholders before the `ApplicationContext` exists. The bodies were roughly 108 lines each and differed only in the guard property, the override property source name, and how the `PropertiesFunction` is constructed.

This extracts the shared lifecycle into `AbstractEarlyResolutionPropertiesParser` in `core/camel-spring-boot` and reduces each starter to three small overrides.

| Starter | Listener | Guard property |
| --- | --- | --- |
| camel-aws-secrets-manager | `SpringBootAwsSecretsManagerPropertiesParser` | `camel.component.aws-secrets-manager.early-resolve-properties` |
| camel-azure-key-vault | `SpringBootAzureKeyVaultPropertiesParser` | `camel.component.azure-key-vault.early-resolve-properties` |
| camel-cyberark-vault | `SpringBootCyberArkVaultPropertiesParser` | `camel.component.cyberark-vault.early-resolve-properties` |
| camel-google-secret-manager | `SpringBootGoogleSecretManagerPropertiesParser` | `camel.component.google-secret-manager.early-resolve-properties` |
| camel-hashicorp-vault | `SpringBootHashicorpVaultPropertiesParser` | `camel.component.hashicorp-vault.early-resolve-properties` |
| camel-ibm-secrets-manager | `IBMSecretsManagerVaultPropertiesParser` | `camel.component.ibm-secrets-manager.early-resolve-properties` |
| camel-spring-cloud-config | `SpringBootCloudConfigPropertiesParser` | `camel.component.spring-cloud-config.early-resolve-properties` |

The base class declares three abstract methods (`getEarlyResolutionProperty()`, `getOverridePropertySourceName()`, `createPropertiesFunction(ConfigurableEnvironment)`), one overridable `getSourceDescription()`, and a `final` `onApplicationEvent`.

Every override property source name is preserved byte for byte, including `camel-ibm-secrets-manager-starter`'s asymmetric `overridden-ibm-secrets-manager-properties`, which lacks the `camel-` segment the other six use. That asymmetry is pre-existing and renaming it would break anyone looking that source up by name.

## Behaviour changes

Most of this is a pure extraction, but three things do change. They are called out here so they can be reviewed as decisions rather than discovered as surprises.

**1. Exception normalization.** Two starters previously threw exception types that signal a programming defect rather than an operator configuration error, and that slip past any `catch (RuntimeCamelException)` handler.

| Path | Before | After |
| --- | --- | --- |
| Google client creation | `RuntimeException` wrapping `IOException` | `RuntimeCamelException`, cause chained |
| Hashicorp missing token, host, port, scheme | `NullPointerException` via `Objects.requireNonNull` | `RuntimeCamelException`, original message plus the property key |
| Hashicorp non-numeric port | `NumberFormatException` naming no property | `RuntimeCamelException` naming `camel.vault.hashicorp.port`, cause chained |

No message became less specific. `Objects.requireNonNull`'s messages were already good (for example "Hashicorp Vault token is required") and they survive verbatim with the property key appended. The port case is the one that was genuinely unhelpful before, since `Integer.parseInt` reports `For input string: "..."` without ever naming the property the operator got wrong.

**2. Blank values are now rejected for the four Hashicorp settings.** The new `required()` helper uses `ObjectHelper.isEmpty`, so `camel.vault.hashicorp.port=` now fails with "port is required (set camel.vault.hashicorp.port)" instead of reaching `Integer.parseInt` and dying on an empty string. An empty scheme now fails in the parser rather than deeper inside `VaultEndpoint`.

**3. Placeholder unwrapping is now exact.** The old code did `value.replace("{{aws:", "").replace("}}", "")`, a global replace that would corrupt a secret path legitimately containing `}}`. The shared version uses `substring` against the known delimiter lengths. There is a test pinning this: `{{test:a}}b}}` must yield the remainder `a}}b`, which the old code turned into the empty string.

A related simplification: the placeholder prefix is no longer hardcoded per starter. `PropertiesFunction.getName()` already returns exactly the prefix token (`aws`, `azure`, `gcp`, and so on), so the base class derives `"{{" + fn.getName() + ":"` itself. The prefix can no longer drift out of sync with the function that resolves it.

## Deliberately out of scope

- **Property source precedence (CAMEL-24532).** Iteration order and last-write-wins semantics are preserved exactly. That defect is tracked separately and assigned to another contributor.
- **Concatenated placeholders.** A value such as `uri={{aws:user}}:{{aws:pass}}` satisfies both `startsWith` and `endsWith`, so it is unwrapped into a garbage remainder and fails. This behaviour is unchanged from before this PR and from before #1900, so it is not a regression, but the class javadoc now documents the limitation instead of claiming such values are left alone. Worth its own ticket.
- **Environment variables and relaxed binding.** `SystemEnvironmentPropertySource` extends `MapPropertySource`, so a placeholder in `MY_SECRET` is resolved and stored under the literal key `MY_SECRET`, while Spring's relaxed binding then resolves `my.secret` from the environment source rather than the exact-match override source. The unresolved placeholder stays effective with no error. This arrives from #1900 unchanged by this refactor and fixing it means changing property source semantics. Flagging it because it is security relevant and deserves its own ticket.

## Testing

`mvn -o verify` passes in all 8 affected modules with zero failures and zero errors.

- `core/camel-spring-boot`: 156 tests plus 2 integration tests. 11 of those are new, covering the shared class: the guard, flag-read ordering, whole-value matching, `OriginTrackedValue` unwrapping, exact delimiter stripping, failure aggregation with causes attached via `addSuppressed`, no override source registered on failure, tolerant mode, and a null resolution result.
- Each starter gains a contract test asserting its guard property and override property source name as exact literals. These seven tests are intentionally near-identical rather than factored into a shared helper: a wrong guard key fails **open**, meaning early resolution silently never runs and the placeholder stays in the property value as the effective secret. A parameterized helper would compare a typo against itself.
- `camel-hashicorp-vault-starter`'s `EarlyResolvedPropertiesTest` ran end to end against a real Testcontainers Vault and passed.

Two coverage gaps worth stating plainly rather than leaving to be found:

- The Google `IOException` to `RuntimeCamelException` change has no test. Forcing `SecretManagerServiceClient.create` to throw requires credential environment manipulation, and the alternatives drag live GCP into a unit test. Verified by inspection.
- The remaining `EarlyResolvedPropertiesTest` classes are guarded by `@EnabledIfSystemProperty` and `@EnabledIfEnvironmentVariable` and skip without live cloud credentials. That is pre-existing. The behavioural safety net for this refactor is the shared class's own test suite in `core/camel-spring-boot`, which runs everywhere.

No new dependencies, no POM changes, and therefore no regenerated code. 16 files changed.

## Note on sequencing

This originally stacked on #1900. That PR has since merged, and this branch has been rebased directly onto `main`, so it no longer depends on anything unmerged.

---

_Claude Code on behalf of Adriano Machado._
