### PR TITLE
CAMEL-24512: camel-spring-boot - keep each failing health check's error message

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelHealthHelper.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelHealthHelper.java
@@ -61,7 +61,11 @@ final class CamelHealthHelper {
 
             result.getError().ifPresent(error -> {
                 if (error.getMessage() != null) {
+                    // the top-level key is kept for compatibility, but it is a single slot on a builder shared
+                    // by every check, so with more than one DOWN check the last one wins; the check-scoped copy
+                    // is the one that stays addressable per check
                     builder.withDetail("error.message", error.getMessage());
+                    data.put("error.message", error.getMessage());
                 }
                 final StringWriter stackTraceWriter = new StringWriter();
                 try (final PrintWriter pw = new PrintWriter(stackTraceWriter, true)) {

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/actuate/health/CamelHealthHelperMultipleFailuresTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/actuate/health/CamelHealthHelperMultipleFailuresTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.boot.actuate.health;
+
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.health.HealthCheckResultBuilder;
+import org.apache.camel.impl.health.AbstractHealthCheck;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The indicator applies every health check result to one {@link Health.Builder}, so a detail written at the top level
+ * is a single slot shared by all of them. Each failing check has to keep its own message addressable.
+ */
+public class CamelHealthHelperMultipleFailuresTest {
+
+    private static final class TestHealthCheck extends AbstractHealthCheck {
+        private TestHealthCheck(String id) {
+            super("test", id);
+        }
+
+        @Override
+        protected void doCall(HealthCheckResultBuilder builder, Map<String, Object> options) {
+            builder.down();
+        }
+    }
+
+    private static HealthCheck.Result downResult(String id, Throwable error) {
+        return HealthCheckResultBuilder.on(new TestHealthCheck(id)).down().error(error).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> checkData(Health health, String id) {
+        Object data = health.getDetails().get(id + ".data");
+        assertNotNull(data, "expected per-check data for " + id + ", details were: " + health.getDetails());
+        assertInstanceOf(Map.class, data);
+        return (Map<String, String>) data;
+    }
+
+    @Test
+    public void eachFailingCheckKeepsItsOwnMessage() {
+        Health.Builder builder = new Health.Builder();
+
+        CamelHealthHelper.applyHealthDetail(builder,
+                downResult("first", new IllegalArgumentException("first-message")), "default");
+        CamelHealthHelper.applyHealthDetail(builder,
+                downResult("second", new IllegalStateException("second-message")), "default");
+
+        Health health = builder.build();
+
+        assertEquals("first-message", checkData(health, "first").get("error.message"),
+                "the first check's message must survive a later failing check");
+        assertEquals("second-message", checkData(health, "second").get("error.message"));
+    }
+
+    @Test
+    public void topLevelErrorMessageIsStillReported() {
+        Health.Builder builder = new Health.Builder();
+
+        CamelHealthHelper.applyHealthDetail(builder,
+                downResult("only", new IllegalStateException("the-message")), "default");
+
+        assertEquals("the-message", builder.build().getDetails().get("error.message"),
+                "the top-level key is kept for compatibility");
+    }
+}


### PR DESCRIPTION
`CamelHealthCheckIndicator.doHealthCheck` loops over every health check result and passes the same
`Health.Builder` to `CamelHealthHelper.applyHealthDetail`. The error message was written only as a flat
top-level detail:

```java
builder.withDetail("error.message", error.getMessage());
```

`Health.Builder.withDetail` is a `Map.put`, so that key is a single slot shared by every check. With two DOWN
checks the actuator response carried only the second message:

```
error.message=second-message
first.data={...}
second.data={...}
```

The per-check `<id>.data` maps stay separate, so the fix is to put the message there too. The top-level key is
kept as it was, for compatibility.

Found by @luigidemasi while reviewing CAMEL-24499; it pre-dates that change and is independent of it.

### Scope

Deliberately confined to `error.message`. #1929 (CAMEL-24592) changes the stack-trace gating in the same
method, and @Croway scoped that PR to leave this alone — doing the same in reverse here, so the two should
apply cleanly in either order.

### Tests

`CamelHealthHelperMultipleFailuresTest`:

- `eachFailingCheckKeepsItsOwnMessage` — two DOWN results with distinct messages, asserting each is retrievable
  under its own check id
- `topLevelErrorMessageIsStillReported` — the compatibility guard on the flat key

Verified meaningful: the first fails against `main` (`expected <first-message> but was <null>`), the second
passes either way. Full `core/camel-spring-boot` suite: 163 tests, 0 failures.

### Note on the root build

The full reactor currently fails on `camel-hivemq-starter`, unrelated to this change:
`org.apache.camel:camel-hivemq:4.23.0-SNAPSHOT` is not on apache.snapshots yet (main's HEAD is the commit that
added the starter). 171 modules build, `core/camel-spring-boot` among them, before the reactor stops there.
Same publishing-lag shape as `camel-toon` a few days ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165HC1XCB3h6mMii6wbZneG