### PR TITLE
Drop JDK 21 from the PR build matrix

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17', '21', '25']
+        java: ['17', '25']
     steps:
     - uses: actions/checkout@v7
       with:


### PR DESCRIPTION
The PR build workflow runs the full incremental build once per JDK, so every push to a PR enqueues three jobs (17, 21, 25). With the current volume of open PRs the queue backs up and reviewers wait on checks.

JDK 17 is the minimum supported version (#1718) and JDK 25 is the latest LTS, so the two of them bound what a JDK 21 run would catch. This change drops 21 from the matrix, cutting every PR's CI cost by a third.

```diff
-        java: ['17', '21', '25']
+        java: ['17', '25']
```

Only `pr-build-main.yml` has a JDK matrix; the sync and SBOM workflows already run on a fixed JDK 17 and are unchanged. Existing open PRs keep the three-job matrix until they are rebased on `main`.

_Claude Code on behalf of Federico Mariani_