### PR TITLE
camel-platform-http-starter: the Cookie request header is no longer echoed on the response

### DIFF
--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
@@ -42,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 import static io.restassured.RestAssured.given;
 import static io.restassured.matcher.RestAssuredMatchers.detailedCookie;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableAutoConfiguration
@@ -231,15 +231,19 @@ public class SpringBootPlatformHttpCookiesTest {
                 .body(equalTo("replace"));
     }
 
+    /**
+     * The Cookie request header must not be echoed back on the response, whatever its casing: platform-http suppresses
+     * the common request headers case-insensitively since CAMEL-24453.
+     */
     @Test
-    public void echoCookie() {
+    public void cookieRequestHeaderIsNotEchoed() {
         given()
                 .header("cookie", "echo=cookie")
                 .when()
                 .get("/echo")
                 .then()
                 .statusCode(200)
-                .header("cookie", startsWith("echo=cookie"))
+                .header("cookie", nullValue())
                 .body(equalTo("echo"));
     }
 


### PR DESCRIPTION
`SpringBootPlatformHttpCookiesTest.echoCookie` asserted that a lowercase `cookie` request header is echoed back on the response of the `/echo` route.

`PlatformHttpEndpoint` wraps the endpoint's `HeaderFilterStrategy` so that common request headers, `Cookie` among them, are never copied from the request to the response (CAMEL-20638). Until recently that lookup compared names exactly against the canonically capitalised set, so the lowercase spelling slipped through and the assertion held only because of that gap. Since CAMEL-24453 (apache/camel#25831) the comparison is case-insensitive, the lowercase header is suppressed as well, and the test has been failing against the current `camel-platform-http` snapshot on every platform-http PR (see #1932 and #1934).

### What changes

The test is renamed to `cookieRequestHeaderIsNotEchoed` and now asserts the contract the endpoint enforces: the response carries no `cookie` header. No main code changes.

### Tests

`mvn test -pl components-starter/camel-platform-http-starter -Dtest=SpringBootPlatformHttpCookiesTest`: 9 tests, 0 failures.

_Claude Code on behalf of Federico Mariani_
