### PR TITLE
CAMEL-24293: camel-zipfile-starter - Align ZipFileDataFormatTest

### DIFF
--- a/components-starter/camel-zipfile-starter/src/test/java/org/apache/camel/dataformat/zipfile/springboot/ZipFileDataFormatTest.java
+++ b/components-starter/camel-zipfile-starter/src/test/java/org/apache/camel/dataformat/zipfile/springboot/ZipFileDataFormatTest.java
@@ -354,8 +354,7 @@ public class ZipFileDataFormatTest {
                                 @Override
                                 public void process(Exchange exchange) throws Exception {
                                     ZipFile zfile = new ZipFile(new File("src/test/resources/hello.odt"));
-                                    ZipEntry entry = new ZipEntry(
-                                            (String) exchange.getIn().getHeader(Exchange.FILE_NAME));
+                                    ZipEntry entry = new ZipEntry((String) exchange.getIn().getHeader("zipFileName"));
                                     String outputDirectory = "hello_out";
                                     File file = new File(outputDirectory, entry.getName());
 


### PR DESCRIPTION
Use the full ZIP entry name supplied by CAMEL-24293 when extracting the test fixture. The CamelFileName header is intentionally sanitized to the basename.