### PR TITLE
CAMEL-24498: restore observability services bind default

### DIFF
--- a/components-starter/camel-observability-services-starter/src/main/doc/usage.adoc
+++ b/components-starter/camel-observability-services-starter/src/main/doc/usage.adoc
@@ -1,13 +1,12 @@
-Add the starter to the classpath and the endpoints below are available on a separate management listener,
-bound to loopback on port `9876`:
+Add the starter to the classpath and the endpoints below are available on a separate management listener on port `9876`:
 
 [width="100%",cols="3,5",options="header"]
 |===
 | Endpoint | Purpose
-| `http://127.0.0.1:9876/observe/health` | Aggregate health
-| `http://127.0.0.1:9876/observe/health/live` | Kubernetes liveness probe
-| `http://127.0.0.1:9876/observe/health/ready` | Kubernetes readiness probe
-| `http://127.0.0.1:9876/observe/metrics` | Prometheus scrape endpoint
+| `/observe/health` | Aggregate health
+| `/observe/health/live` | Kubernetes liveness probe
+| `/observe/health/ready` | Kubernetes readiness probe
+| `/observe/metrics` | Prometheus scrape endpoint
 |===
 
 === Injected defaults
@@ -19,7 +18,6 @@ configuration:
 |===
 | Property | Value | Notes
 | `management.server.port` | `9876` | Management endpoints run on their own listener, separate from the application port.
-| `management.server.address` | `127.0.0.1` | The listener binds to loopback. See <<Exposing the management listener>>.
 | `management.endpoints.web.exposure.include` | `health,prometheus` | Only these two endpoints are exposed.
 | `management.endpoints.web.base-path` | `/observe` | Replaces the `/actuator` base path.
 | `management.endpoints.web.path-mapping.prometheus` | `metrics` | Serves the Prometheus endpoint at `/observe/metrics`.
@@ -36,23 +34,6 @@ configuration:
 | `management.endpoint.health.group.ready.include` | `readinessState,camelReadinessState` | Contents of `/observe/health/ready`.
 | `management.endpoint.health.group.ready.show-details` | `always` | See <<Health detail exposure>>.
 |===
-
-=== Exposing the management listener
-
-The management listener binds to `127.0.0.1`, so out of the box the health and metrics endpoints are reachable
-from the same host only. This matches the Spring Boot baseline, which ships no separate management listener at
-all: opening one on every interface should be a decision you make, not one the starter makes for you.
-
-A Kubernetes deployment whose kubelet probes or Prometheus scrapers reach the pod over the network has to widen
-the bind address:
-
-[source,properties]
-----
-management.server.address = 0.0.0.0
-----
-
-Pair that with a `NetworkPolicy`, or with authentication in front of the management port, so the endpoints are
-only reachable from your probes and your scrapers.
 
 === Health detail exposure
 

--- a/components-starter/camel-observability-services-starter/src/main/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessor.java
+++ b/components-starter/camel-observability-services-starter/src/main/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessor.java
@@ -30,10 +30,9 @@ import org.springframework.core.env.MapPropertySource;
  * user-provided configuration (application.properties, environment variables, system properties, ...) overrides them
  * following the standard Spring Boot precedence rules.
  * <p>
- * The defaults stay within the Spring Boot baseline: the management listener binds to loopback, and the aggregate
- * health endpoint only shows its details to an authorized caller. The {@code live} and {@code ready} probe groups
- * keep {@code show-details=always} because they are consumed unauthenticated by the kubelet, and the indicators
- * they contain report an availability state and nothing else.
+ * The aggregate health endpoint only shows its details to an authorized caller. The {@code live} and {@code ready}
+ * probe groups keep {@code show-details=always} because they are consumed unauthenticated by the kubelet, and the
+ * indicators they contain report an availability state and nothing else.
  */
 public class ObservabilityServicesEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
@@ -43,8 +42,6 @@ public class ObservabilityServicesEnvironmentPostProcessor implements Environmen
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
         Map<String, Object> defaults = new LinkedHashMap<>();
         defaults.put("management.server.port", "9876");
-        // bind the management listener to loopback; exposing it beyond the host is a conscious step
-        defaults.put("management.server.address", "127.0.0.1");
         defaults.put("management.endpoints.web.exposure.include", "health,prometheus");
         defaults.put("management.endpoints.web.base-path", "/observe");
         defaults.put("management.endpoints.web.path-mapping.prometheus", "metrics");

--- a/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessorTest.java
+++ b/components-starter/camel-observability-services-starter/src/test/java/org/apache/camel/observability/services/springboot/ObservabilityServicesEnvironmentPostProcessorTest.java
@@ -58,9 +58,8 @@ public class ObservabilityServicesEnvironmentPostProcessorTest {
     }
 
     @Test
-    public void managementListenerBindsToLoopback() {
-        // the port alone would put a second listener on every interface
-        assertEquals("127.0.0.1", environment.getProperty("management.server.address"));
+    public void managementListenerUsesSpringBootDefaultBindAddress() {
+        assertNull(environment.getProperty("management.server.address"));
     }
 
     @Test
@@ -89,7 +88,6 @@ public class ObservabilityServicesEnvironmentPostProcessorTest {
 
         Set<String> expected = new LinkedHashSet<>(Arrays.asList(
                 "management.server.port",
-                "management.server.address",
                 "management.endpoints.web.exposure.include",
                 "management.endpoints.web.base-path",
                 "management.endpoints.web.path-mapping.prometheus",

--- a/docs/spring-boot/modules/ROOT/pages/starters/observability-services.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/observability-services.adoc
@@ -24,16 +24,15 @@ The defaults are registered as the lowest precedence property source, so anythin
 
 == Usage
 
-Add the starter to the classpath and the endpoints below are available on a separate management listener,
-bound to loopback on port `9876`:
+Add the starter to the classpath and the endpoints below are available on a separate management listener on port `9876`:
 
 [width="100%",cols="3,5",options="header"]
 |===
 | Endpoint | Purpose
-| `http://127.0.0.1:9876/observe/health` | Aggregate health
-| `http://127.0.0.1:9876/observe/health/live` | Kubernetes liveness probe
-| `http://127.0.0.1:9876/observe/health/ready` | Kubernetes readiness probe
-| `http://127.0.0.1:9876/observe/metrics` | Prometheus scrape endpoint
+| `/observe/health` | Aggregate health
+| `/observe/health/live` | Kubernetes liveness probe
+| `/observe/health/ready` | Kubernetes readiness probe
+| `/observe/metrics` | Prometheus scrape endpoint
 |===
 
 === Injected defaults
@@ -45,7 +44,6 @@ configuration:
 |===
 | Property | Value | Notes
 | `management.server.port` | `9876` | Management endpoints run on their own listener, separate from the application port.
-| `management.server.address` | `127.0.0.1` | The listener binds to loopback. See <<Exposing the management listener>>.
 | `management.endpoints.web.exposure.include` | `health,prometheus` | Only these two endpoints are exposed.
 | `management.endpoints.web.base-path` | `/observe` | Replaces the `/actuator` base path.
 | `management.endpoints.web.path-mapping.prometheus` | `metrics` | Serves the Prometheus endpoint at `/observe/metrics`.
@@ -62,23 +60,6 @@ configuration:
 | `management.endpoint.health.group.ready.include` | `readinessState,camelReadinessState` | Contents of `/observe/health/ready`.
 | `management.endpoint.health.group.ready.show-details` | `always` | See <<Health detail exposure>>.
 |===
-
-=== Exposing the management listener
-
-The management listener binds to `127.0.0.1`, so out of the box the health and metrics endpoints are reachable
-from the same host only. This matches the Spring Boot baseline, which ships no separate management listener at
-all: opening one on every interface should be a decision you make, not one the starter makes for you.
-
-A Kubernetes deployment whose kubelet probes or Prometheus scrapers reach the pod over the network has to widen
-the bind address:
-
-[source,properties]
-----
-management.server.address = 0.0.0.0
-----
-
-Pair that with a `NetworkPolicy`, or with authentication in front of the management port, so the endpoints are
-only reachable from your probes and your scrapers.
 
 === Health detail exposure
 


### PR DESCRIPTION
## Summary

- Restore the Spring Boot management listener default bind address for observability services.
- Keep the existing health-endpoint hardening.
- Add a regression test and regenerate the starter documentation.