### PR TITLE
Document LangChain4j provider starters

### DIFF
--- a/components-starter/camel-langchain4j-agent-starter/src/main/doc/configuration.adoc
+++ b/components-starter/camel-langchain4j-agent-starter/src/main/doc/configuration.adoc
@@ -1,0 +1,10 @@
+=== Providing an agent model
+
+LangChain4j provider starters can create the `ChatModel` used by an agent. Add the provider's
+`-spring-boot-starter` variant with Spring Boot 3 or its `-spring-boot4-starter` variant with
+Spring Boot 4, then inject the resulting model bean into Camel's `AgentConfiguration`.
+The provider starter does not create Camel's `Agent` or `AgentConfiguration`.
+
+See the https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot
+integration documentation] for provider configuration, and the component documentation for
+creating and configuring a Camel agent.

--- a/components-starter/camel-langchain4j-chat-starter/src/main/doc/configuration.adoc
+++ b/components-starter/camel-langchain4j-chat-starter/src/main/doc/configuration.adoc
@@ -1,0 +1,13 @@
+=== Providing a `ChatModel`
+
+The Camel starter configures the component but does not create a LangChain4j `ChatModel`.
+Add a LangChain4j provider starter to create one from application properties. Use the
+`-spring-boot-starter` variant with Spring Boot 3 or the `-spring-boot4-starter` variant
+with Spring Boot 4. For example, `langchain4j-ollama-spring-boot4-starter` creates an
+`ollamaChatModel` bean that can be referenced with
+`chatModel=#ollamaChatModel`.
+
+When exactly one `ChatModel` is available, Camel autowires it and the `chatModel` endpoint
+option can be omitted. See the
+https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot integration documentation]
+for provider starters, properties, and compatible versions.

--- a/components-starter/camel-langchain4j-embeddings-starter/src/main/doc/configuration.adoc
+++ b/components-starter/camel-langchain4j-embeddings-starter/src/main/doc/configuration.adoc
@@ -1,0 +1,12 @@
+=== Providing an `EmbeddingModel`
+
+The Camel starter configures the component but does not create an `EmbeddingModel`. Add a
+LangChain4j provider starter and configure its embedding-model properties. Use the
+`-spring-boot-starter` variant with Spring Boot 3 or the `-spring-boot4-starter` variant
+with Spring Boot 4. For example, the Ollama starter creates an `ollamaEmbeddingModel` bean,
+which can be referenced with `embeddingModel=#ollamaEmbeddingModel`.
+
+When exactly one `EmbeddingModel` is available, Camel autowires it and the `embeddingModel`
+endpoint option can be omitted. See the
+https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot integration documentation]
+for provider starters, properties, and compatible versions.

--- a/components-starter/camel-langchain4j-embeddingstore-starter/src/main/doc/configuration.adoc
+++ b/components-starter/camel-langchain4j-embeddingstore-starter/src/main/doc/configuration.adoc
@@ -1,0 +1,11 @@
+=== Providing embedding services
+
+The component requires an `EmbeddingStore` bean. It can also use an `EmbeddingModel` to
+compute embeddings from plain-text message bodies. Configure either dependency with a
+compatible LangChain4j Spring Boot starter or provide it as a Spring bean. When more than one
+bean of either type is available, reference the intended bean explicitly with `embeddingStore`
+or `embeddingModel` on the endpoint.
+
+See the https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot
+integration documentation] for provider and embedding-store starters, properties, and
+compatible versions.

--- a/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-agent.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-agent.adoc
@@ -23,6 +23,17 @@ Please refer to the above links for usage and configuration details.
 
 == Spring Boot Auto-Configuration
 
+=== Providing an agent model
+
+LangChain4j provider starters can create the `ChatModel` used by an agent. Add the provider's
+`-spring-boot-starter` variant with Spring Boot 3 or its `-spring-boot4-starter` variant with
+Spring Boot 4, then inject the resulting model bean into Camel's `AgentConfiguration`.
+The provider starter does not create Camel's `Agent` or `AgentConfiguration`.
+
+See the https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot
+integration documentation] for provider configuration, and the component documentation for
+creating and configuring a Camel agent.
+
 The starter supports 15 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]

--- a/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-chat.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-chat.adoc
@@ -23,6 +23,20 @@ Please refer to the above links for usage and configuration details.
 
 == Spring Boot Auto-Configuration
 
+=== Providing a `ChatModel`
+
+The Camel starter configures the component but does not create a LangChain4j `ChatModel`.
+Add a LangChain4j provider starter to create one from application properties. Use the
+`-spring-boot-starter` variant with Spring Boot 3 or the `-spring-boot4-starter` variant
+with Spring Boot 4. For example, `langchain4j-ollama-spring-boot4-starter` creates an
+`ollamaChatModel` bean that can be referenced with
+`chatModel=#ollamaChatModel`.
+
+When exactly one `ChatModel` is available, Camel autowires it and the `chatModel` endpoint
+option can be omitted. See the
+https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot integration documentation]
+for provider starters, properties, and compatible versions.
+
 The starter supports 6 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]

--- a/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-embeddings.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-embeddings.adoc
@@ -23,6 +23,19 @@ Please refer to the above links for usage and configuration details.
 
 == Spring Boot Auto-Configuration
 
+=== Providing an `EmbeddingModel`
+
+The Camel starter configures the component but does not create an `EmbeddingModel`. Add a
+LangChain4j provider starter and configure its embedding-model properties. Use the
+`-spring-boot-starter` variant with Spring Boot 3 or the `-spring-boot4-starter` variant
+with Spring Boot 4. For example, the Ollama starter creates an `ollamaEmbeddingModel` bean,
+which can be referenced with `embeddingModel=#ollamaEmbeddingModel`.
+
+When exactly one `EmbeddingModel` is available, Camel autowires it and the `embeddingModel`
+endpoint option can be omitted. See the
+https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot integration documentation]
+for provider starters, properties, and compatible versions.
+
 The starter supports 5 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]

--- a/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-embeddingstore.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/langchain4j-embeddingstore.adoc
@@ -23,6 +23,18 @@ Please refer to the above links for usage and configuration details.
 
 == Spring Boot Auto-Configuration
 
+=== Providing embedding services
+
+The component requires an `EmbeddingStore` bean. It can also use an `EmbeddingModel` to
+compute embeddings from plain-text message bodies. Configure either dependency with a
+compatible LangChain4j Spring Boot starter or provide it as a Spring bean. When more than one
+bean of either type is available, reference the intended bean explicitly with `embeddingStore`
+or `embeddingModel` on the endpoint.
+
+See the https://docs.langchain4j.dev/tutorials/spring-boot-integration[LangChain4j Spring Boot
+integration documentation] for provider and embedding-store starters, properties, and
+compatible versions.
+
 The starter supports 11 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]


### PR DESCRIPTION
## Summary
- document how LangChain4j provider starters supply models to the Chat, Embeddings, Embedding Store, and Agent starters
- explain Spring Boot 3 and Spring Boot 4 starter variants and explicit bean references
- link every section to the LangChain4j Spring Boot documentation