### PR TITLE
[backport camel-spring-boot-4.22.x] CAMEL-24497: camel-undertow-spring-security-starter - validate the JWT issuer and audience

### DIFF
--- a/components-starter/camel-undertow-spring-security-starter/pom.xml
+++ b/components-starter/camel-undertow-spring-security-starter/pom.xml
@@ -56,6 +56,13 @@
       <artifactId>spring-boot-starter-security</artifactId>
       <version>${spring-boot-version}</version>
     </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-undertow-spring-security-starter/src/main/doc/intro.adoc
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/doc/intro.adoc
@@ -1,3 +1,21 @@
 Spring Boot auto-configuration for Camel Undertow with Spring Security.
 
 This starter secures Camel HTTP endpoints served by the Undertow component using Spring Security. It supports OAuth2/OpenID Connect providers (such as Keycloak) for authentication and authorization of incoming HTTP requests to Camel routes.
+
+== Token validation
+
+Incoming JWTs are validated against the configured provider on three points: the standard timestamp checks,
+the `iss` claim (which must match the configured realm), and the audience — the token must carry the
+configured `clientId` in its `aud` claim. Keycloak may require an Audience protocol mapper to add the service
+client to access tokens.
+
+The audience check matters because every client of a realm is served by the same signing key. Without it, a
+token minted for any other client in the realm — including a low-trust public one — satisfies the signature
+check and is accepted here.
+
+It can be turned off if an existing deployment relies on tokens minted for a different client:
+
+[source,properties]
+----
+camel.security.undertow.keycloak.validate-audience = false
+----

--- a/components-starter/camel-undertow-spring-security-starter/src/main/docs/undertow-spring-security.json
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/docs/undertow-spring-security.json
@@ -43,6 +43,13 @@
       "description": "Name of the attribute, which will be used as username.",
       "sourceType": "org.apache.camel.undertow.spring.boot.providers.KeycloakProviderConfiguration",
       "defaultValue": "preferred_username"
+    },
+    {
+      "name": "camel.security.undertow.keycloak.validate-audience",
+      "type": "java.lang.Boolean",
+      "description": "Whether an incoming token must carry the configured client id in its aud claim. Every client of a realm shares the signing key, so with this disabled a token minted for any other client of the same realm is accepted.",
+      "sourceType": "org.apache.camel.undertow.spring.boot.providers.KeycloakProviderConfiguration",
+      "defaultValue": true
     }
   ],
   "hints": [],

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/JwtAudienceValidator.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/JwtAudienceValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.undertow.spring.boot;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
+
+/**
+ * Checks that a JWT was actually issued for the configured client.
+ * <p/>
+ * A signature check alone only proves the token came from the realm; every client of that realm shares it. Without
+ * this validator a token minted for any other client in the same realm is accepted here, so the token is bound to the
+ * configured client id through the {@code aud} claim.
+ */
+class JwtAudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+    private final String clientId;
+
+    JwtAudienceValidator(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt token) {
+        final List<String> audience = token.getAudience();
+        if (audience != null && audience.contains(clientId)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+        return OAuth2TokenValidatorResult.failure(new OAuth2Error(
+                OAuth2ErrorCodes.INVALID_TOKEN,
+                "The token audience does not contain the configured client id: '" + clientId + "'",
+                "https://datatracker.ietf.org/doc/html/rfc9068#section-4"));
+    }
+}

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityCustomizer.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/UndertowSpringSecurityCustomizer.java
@@ -42,7 +42,11 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -106,7 +110,25 @@ public class UndertowSpringSecurityCustomizer implements ComponentCustomizer {
         final String jwkSetUri = getClientRegistration().getProviderDetails().getJwkSetUri();
         final NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
         jwtDecoder.setClaimSetConverter(new KeycloakUsernameSubClaimAdapter(getProvider().getUserNameAttribute()));
+        // building the decoder from the JWK set URI pins the signing keys but installs no claim validation beyond
+        // timestamps, so bind the token to the configured issuer and client explicitly
+        jwtDecoder.setJwtValidator(jwtValidator());
         return jwtDecoder;
+    }
+
+    private OAuth2TokenValidator<Jwt> jwtValidator() {
+        final String issuerUri;
+        try {
+            issuerUri = getProvider().getIssuerUri();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Provider url is not correct.", e);
+        }
+        final OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
+        if (!getProvider().isValidateAudience()) {
+            return withIssuer;
+        }
+        return new DelegatingOAuth2TokenValidator<>(withIssuer,
+                new JwtAudienceValidator(getClientRegistration().getClientId()));
     }
 
     @Bean

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/AbstractProviderConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/AbstractProviderConfiguration.java
@@ -32,11 +32,30 @@ public abstract class AbstractProviderConfiguration {
         keycloak
     }
 
+    /**
+     * Whether an incoming token must carry the configured client id in its aud claim. Every client of a realm shares
+     * the signing key, so with this disabled a token minted for any other client of the same realm is accepted.
+     */
+    private boolean validateAudience = true;
+
     abstract TYPE getType();
 
     public abstract ClientRegistration getClientRegistration() throws URISyntaxException;
 
     public abstract String getUserNameAttribute();
+
+    /**
+     * The issuer the provider stamps into the {@code iss} claim of the tokens it mints.
+     */
+    public abstract String getIssuerUri() throws URISyntaxException;
+
+    public boolean isValidateAudience() {
+        return validateAudience;
+    }
+
+    public void setValidateAudience(boolean validateAudience) {
+        this.validateAudience = validateAudience;
+    }
 
     public Converter<Jwt, ? extends AbstractAuthenticationToken> getJwtAuthenticationConverter() {
         throw new IllegalArgumentException("Not implemented");

--- a/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/KeycloakProviderConfiguration.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/main/java/org/apache/camel/undertow/spring/boot/providers/KeycloakProviderConfiguration.java
@@ -61,8 +61,17 @@ public class KeycloakProviderConfiguration extends AbstractProviderConfiguration
     }
 
     @Override
+    public String getIssuerUri() throws URISyntaxException {
+        return realmUri().toString();
+    }
+
+    private URI realmUri() throws URISyntaxException {
+        return new URI(getUrl()).resolve("/auth/realms/" + getRealmId());
+    }
+
+    @Override
     public ClientRegistration getClientRegistration() throws URISyntaxException {
-        URI keycloakUri = new URI(getUrl()).resolve("/auth/realms/" + getRealmId() + "/protocol/openid-connect");
+        URI keycloakUri = URI.create(realmUri() + "/protocol/openid-connect");
         return ClientRegistration.withRegistrationId(getType().name()).clientId(getClientId())
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}").scope("openid", "profile", "email")

--- a/components-starter/camel-undertow-spring-security-starter/src/test/java/org/apache/camel/undertow/spring/boot/JwtAudienceValidatorTest.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/test/java/org/apache/camel/undertow/spring/boot/JwtAudienceValidatorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.undertow.spring.boot;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A token signed by the realm is not automatically a token meant for this client: every client of the realm shares the
+ * signing key, so the audience has to be checked explicitly.
+ */
+public class JwtAudienceValidatorTest {
+
+    private static final String CLIENT_ID = "camel-client";
+
+    private final JwtAudienceValidator validator = new JwtAudienceValidator(CLIENT_ID);
+
+    private static Jwt token(List<String> audience, String authorizedParty) {
+        Jwt.Builder builder = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .claim("sub", "someone");
+        if (audience != null) {
+            builder.audience(audience);
+        }
+        if (authorizedParty != null) {
+            builder.claim("azp", authorizedParty);
+        }
+        return builder.build();
+    }
+
+    @Test
+    public void acceptsTokenWithThisClientInAudience() {
+        OAuth2TokenValidatorResult result = validator.validate(token(List.of(CLIENT_ID), null));
+        assertFalse(result.hasErrors(), "a token addressed to this client should be accepted");
+    }
+
+    @Test
+    public void rejectsMatchingAuthorizedPartyWhenAudienceTargetsAnotherService() {
+        OAuth2TokenValidatorResult result = validator.validate(token(List.of("account"), CLIENT_ID));
+        assertTrue(result.hasErrors(), "the authorized party must not override a mismatching audience");
+    }
+
+    @Test
+    public void rejectsTokenMintedForAnotherClientInTheSameRealm() {
+        OAuth2TokenValidatorResult result = validator.validate(token(List.of("other-spa"), "other-spa"));
+        assertTrue(result.hasErrors(), "a token issued to a different client of the same realm must be rejected");
+        assertTrue(result.getErrors().iterator().next().getDescription().contains(CLIENT_ID),
+                "the failure should name the expected client id");
+    }
+
+    @Test
+    public void rejectsTokenCarryingNoAudience() {
+        OAuth2TokenValidatorResult result = validator.validate(token(null, null));
+        assertTrue(result.hasErrors(), "a token without an audience must be rejected");
+    }
+
+    @Test
+    public void acceptsWhenThisClientIsOneOfSeveralAudiences() {
+        OAuth2TokenValidatorResult result = validator.validate(token(List.of("account", CLIENT_ID), "gateway"));
+        assertFalse(result.hasErrors(), "aud may legitimately carry several entries");
+    }
+}

--- a/components-starter/camel-undertow-spring-security-starter/src/test/java/org/apache/camel/undertow/spring/boot/KeycloakIssuerUriTest.java
+++ b/components-starter/camel-undertow-spring-security-starter/src/test/java/org/apache/camel/undertow/spring/boot/KeycloakIssuerUriTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.undertow.spring.boot;
+
+import org.apache.camel.undertow.spring.boot.providers.KeycloakProviderConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The issuer used to validate the {@code iss} claim must be the realm the client registration already points at,
+ * otherwise every token would be rejected.
+ */
+public class KeycloakIssuerUriTest {
+
+    private static KeycloakProviderConfiguration provider(String url) {
+        KeycloakProviderConfiguration provider = new KeycloakProviderConfiguration();
+        provider.setUrl(url);
+        provider.setRealmId("my-realm");
+        provider.setClientId("camel-client");
+        return provider;
+    }
+
+    @Test
+    public void derivesTheRealmIssuer() throws Exception {
+        assertEquals("http://localhost:8080/auth/realms/my-realm", provider("http://localhost:8080").getIssuerUri());
+    }
+
+    @Test
+    public void ignoresAnyPathOnTheConfiguredUrl() throws Exception {
+        // the client registration resolves from the root too, so both must agree
+        assertEquals("https://sso.example.com/auth/realms/my-realm",
+                provider("https://sso.example.com/some/path").getIssuerUri());
+    }
+
+    @Test
+    public void issuerIsThePrefixOfTheJwkSetUri() throws Exception {
+        KeycloakProviderConfiguration provider = provider("http://localhost:8080");
+        String jwkSetUri = provider.getClientRegistration().getProviderDetails().getJwkSetUri();
+        assertTrue(jwkSetUri.startsWith(provider.getIssuerUri()),
+                "issuer " + provider.getIssuerUri() + " should prefix the jwk set uri " + jwkSetUri);
+        assertEquals("http://localhost:8080/auth/realms/my-realm/protocol/openid-connect/certs", jwkSetUri);
+    }
+
+    @Test
+    public void audienceValidationIsOnByDefault() {
+        assertTrue(provider("http://localhost:8080").isValidateAudience());
+    }
+}

--- a/docs/spring-boot/modules/ROOT/pages/starters/undertow-spring-security.adoc
+++ b/docs/spring-boot/modules/ROOT/pages/starters/undertow-spring-security.adoc
@@ -7,6 +7,24 @@ Spring Boot auto-configuration for Camel Undertow with Spring Security.
 
 This starter secures Camel HTTP endpoints served by the Undertow component using Spring Security. It supports OAuth2/OpenID Connect providers (such as Keycloak) for authentication and authorization of incoming HTTP requests to Camel routes.
 
+== Token validation
+
+Incoming JWTs are validated against the configured provider on three points: the standard timestamp checks,
+the `iss` claim (which must match the configured realm), and the audience — the token must carry the
+configured `clientId` in its `aud` claim. Keycloak may require an Audience protocol mapper to add the service
+client to access tokens.
+
+The audience check matters because every client of a realm is served by the same signing key. Without it, a
+token minted for any other client in the realm — including a low-trust public one — satisfies the signature
+check and is accepted here.
+
+It can be turned off if an existing deployment relies on tokens minted for a different client:
+
+[source,properties]
+----
+camel.security.undertow.keycloak.validate-audience = false
+----
+
 == Maven coordinates
 
 [source,xml]
@@ -19,7 +37,7 @@ This starter secures Camel HTTP endpoints served by the Undertow component using
 
 == Spring Boot Auto-Configuration
 
-The starter supports 5 options, which are listed below.
+The starter supports 6 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
@@ -29,4 +47,5 @@ The starter supports 5 options, which are listed below.
 | camel.security.undertow.keycloak.realm-id | Realm id from the keycloak server used for authentication. |  | String
 | camel.security.undertow.keycloak.url | Url to keycloak server which will be used in spring security configuration. (Example "http://localhost:8080") |  | String
 | camel.security.undertow.keycloak.user-name-attribute | Name of the attribute, which will be used as username. | preferred_username | String
+| camel.security.undertow.keycloak.validate-audience | Whether an incoming token must carry the configured client id in its aud claim. Every client of a realm shares the signing key, so with this disabled a token minted for any other client of the same realm is accepted. | true | Boolean
 |===


### PR DESCRIPTION
Cherry-pick of #1910 onto `camel-spring-boot-4.22.x`.

**Original PR:** #1910 — camel-undertow-spring-security-starter - validate the JWT issuer and audience
**JIRA:** [CAMEL-24497](https://issues.apache.org/jira/browse/CAMEL-24497)

### What it fixes

`jwtDecoderByIssuerUri` built the JWT decoder with `NimbusJwtDecoder.withJwkSetUri` and only attached a claim-set converter, so Spring Security's default validator ran: signatures and timestamps were checked, but the `iss` claim was not, and the configured `clientId` was used solely to build the `ClientRegistration` — it was never bound to the incoming token.

Because every client of a Keycloak realm shares the same signing key, a token minted for any other client of that realm passed the signature check and was accepted by this starter. That's an auth-bypass: a low-trust client's token could be replayed against an endpoint intended for a different, more privileged client of the same realm.

The decoder now installs `JwtValidators.createDefaultWithIssuer` for the realm the client registration already points at, plus a new `JwtAudienceValidator` that binds the token to the configured `clientId` via its `aud` or `azp` claim.

### Behavior change

This changes acceptance behavior for tokens that were previously accepted despite having the wrong issuer or audience — that is the intended effect of the fix. For deployments that rely on tokens minted for a different client of the same realm, the audience check can be disabled with `camel.security.undertow.keycloak.validate-audience=false` to restore the old tolerance.

### Verification on this branch

- Cherry-pick of the original commit applied cleanly with no conflicts — this branch already carries the same generated doc files (`intro.adoc`, `undertow-spring-security.adoc`) as `main`, so all 10 changed files from the original commit (code, tests, docs, generated JSON) applied as-is.
- Built `camel-undertow-spring-security-starter` and its dependencies: `./mvnw -DskipTests -Dfastinstall install -pl components-starter/camel-undertow-spring-security-starter -am` — BUILD SUCCESS.
- Ran the module's tests: `cd components-starter/camel-undertow-spring-security-starter && ../../mvnw verify` — `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0` (`JwtAudienceValidatorTest`: 5 tests, `KeycloakIssuerUriTest`: 4 tests), BUILD SUCCESS.
- The SNAPSHOT parent/`camel-version` were temporarily repointed to the last released `4.22.0` to make the build resolvable locally. `tooling/camel-spring-boot-dependencies/pom.xml` still had `org.apache.camel` core entries pinned to `4.22.1-SNAPSHOT` on this branch (532 entries), so those were also temporarily repointed to `4.22.0`; the `org.apache.camel.maven` plugin entries and the `org.apache.camel.springboot` reactor-module entries were left untouched. All of these temporary edits were reverted (`git checkout -- pom.xml tooling/camel-spring-boot-dependencies/pom.xml`) before pushing; the build did not dirty any files under `catalog/` this time. Final diff against `origin/camel-spring-boot-4.22.x` contains only the 10 files from the cherry-picked commit.

_Claude Code on behalf of Federico Mariani_