### PR TITLE
[backport camel-spring-boot-4.18.x] CAMEL-24504: camel-spring-boot - extend the String conversion guard beyond InputStream

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringTypeConverter.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringTypeConverter.java
@@ -16,11 +16,14 @@
  */
 package org.apache.camel.spring.boot;
 
+import java.io.FileReader;
 import java.io.InputStream;
+import java.io.Writer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.ZipFile;
 import org.apache.camel.Exchange;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.support.TypeConverterSupport;
@@ -53,10 +56,13 @@ public class SpringTypeConverter extends TypeConverterSupport {
             return null;
         }
 
-        // do not attempt to convert String -> InputStream (or subclasses like FileInputStream).
-        // Spring's ObjectToObjectConverter finds FileInputStream(String) constructor and treats
-        // the String value as a file path instead of data content.
-        if (value instanceof String && InputStream.class.isAssignableFrom(type)) {
+        // do not attempt to convert a String into a type whose single-String constructor interprets it as a
+        // file path rather than as data content - Spring's ObjectToObjectConverter would find
+        // FileInputStream(String), FileReader(String), FileWriter(String) or ZipFile(String) and open, or in
+        // the Writer case create, the named file. Camel's own converters handle these from a String body.
+        // java.io.File is deliberately not listed: String -> File is a documented Spring conversion where the
+        // String genuinely is a path (CAMEL-23378).
+        if (value instanceof String && isFileBackedTarget(type)) {
             return null;
         }
 
@@ -84,6 +90,13 @@ public class SpringTypeConverter extends TypeConverterSupport {
         }
 
         return null;
+    }
+
+    private boolean isFileBackedTarget(Class<?> type) {
+        return InputStream.class.isAssignableFrom(type)
+                || FileReader.class.isAssignableFrom(type)
+                || Writer.class.isAssignableFrom(type)
+                || ZipFile.class.isAssignableFrom(type);
     }
 
     private boolean isArrayOrCollection(Object value) {

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SpringTypeConverterTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SpringTypeConverterTest.java
@@ -16,11 +16,18 @@
  */
 package org.apache.camel.spring.boot;
 
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.zip.ZipFile;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -83,6 +90,38 @@ public class SpringTypeConverterTest {
     @Test
     public void testStringToInputStreamConversionIsBlocked() {
         Assertions.assertNull(converter.convertTo(InputStream.class, null, "some file content"));
+    }
+
+    @Test
+    public void testStringToFileReaderConversionIsBlocked() {
+        // FileReader(String) would open the content as a path, exactly as FileInputStream(String) did
+        Assertions.assertNull(converter.convertTo(FileReader.class, null, "some file content"));
+    }
+
+    @Test
+    public void testStringToStringReaderConversionIsStillAllowed() {
+        Assertions.assertNotNull(converter.convertTo(StringReader.class, null, "some file content"));
+    }
+
+    @Test
+    public void testStringToFileWriterConversionIsBlocked() throws Exception {
+        // FileWriter(String) would go further and create the named file
+        Path target = Files.createTempDirectory("spring-type-converter").resolve("must-not-be-created.txt");
+        Assertions.assertNull(converter.convertTo(FileWriter.class, null, target.toString()));
+        Assertions.assertFalse(Files.exists(target), "converting a String must not create a file on disk");
+    }
+
+    @Test
+    public void testStringToZipFileConversionIsBlocked() {
+        Assertions.assertNull(converter.convertTo(ZipFile.class, null, "some file content"));
+    }
+
+    @Test
+    public void testStringToFileConversionIsStillAllowed() {
+        // String -> File is a documented Spring conversion where the String really is a path, so the guard
+        // must not swallow it
+        Assertions.assertEquals(new File("/tmp/example.txt"),
+                converter.convertTo(File.class, null, "/tmp/example.txt"));
     }
 
     public static class Person {


### PR DESCRIPTION
Cherry-pick of #1912 onto `camel-spring-boot-4.18.x`.

**Original PR:** #1912 — camel-spring-boot - extend the String conversion guard beyond InputStream
**JIRA:** [CAMEL-24504](https://issues.apache.org/jira/browse/CAMEL-24504)

### What it fixes

CAMEL-23378 previously stopped `SpringTypeConverter` from converting a `String` into an `InputStream`
(or a subclass such as `FileInputStream`), because Spring's `ObjectToObjectConverter` locates the
`FileInputStream(String)` constructor and opens the value as a file path rather than treating it as
in-memory data content.

The same reasoning applies to any other target type whose single-`String` constructor interprets the
string as a path rather than as content. `FileReader` and `ZipFile` currently throw a
`ConversionFailedException` when Spring is asked to convert a `String` body, which prevents Camel's own
(correct) converters from ever getting a chance to run. `FileWriter` is worse: the conversion succeeds
and silently creates the named file on disk.

This change extends the existing guard to also cover `Reader`, `Writer`, and `ZipFile` targets, so Spring
returns `null` for those and Camel's own type converters handle the `String` body instead. `java.io.File`
is deliberately left out of the guard: `String -> File` is a documented, intentional Spring conversion
where the string genuinely represents a path (this is exactly what CAMEL-23378 was designed to preserve).

### Not a behavior change for correct usage

This only closes an implicit/unintended conversion path where a `String` message body could be silently
treated as a filesystem path by Spring's generic object conversion machinery — e.g. `Writer`/`Reader`/`ZipFile`
targets built from `File*`/`ZipFile` constructors that take a path. It does not remove any documented
Spring or Camel conversion capability; `StringReader` (and other in-memory-backed conversions) continue to
work as before, and `String -> File` is intentionally untouched.

### Verification on this branch

- Cherry-pick required resolving one conflict in
  `core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/SpringTypeConverterTest.java`: the
  import block conflicted because this branch uses
  `org.apache.camel.test.spring.junit5.CamelSpringBootTest` while the original commit (on `main`, which is
  JUnit 6) imports `org.apache.camel.test.spring.junit6.CamelSpringBootTest`. Resolved by keeping this
  branch's existing `junit5` import and adding the new `java.util.zip.ZipFile` import from the original
  commit; no test semantics/assertions were changed. The main source file
  (`SpringTypeConverter.java`) cherry-picked with no conflicts.
- Ran the full `core/camel-spring-boot` module test suite (`./mvnw verify`, after temporarily repointing
  the SNAPSHOT parent/`camel-version` to the released 4.18.4 for local resolvability, then reverted before
  pushing): 133 tests run, 0 failures, 0 errors, 5 skipped (pre-existing, unrelated skips). The specific
  `SpringTypeConverterTest` class ran 8 tests (3 pre-existing + 5 new from this change), all passing.
- Module build (`./mvnw -DskipTests -Dfastinstall install -pl core/camel-spring-boot -am`): BUILD SUCCESS.

_Claude Code on behalf of Federico Mariani_
