### PR TITLE
[backport camel-spring-boot-4.22.x] CAMEL-24503: camel-spring-boot - see camel properties supplied as environment variables

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -45,6 +46,7 @@ import org.springframework.core.env.Environment;
 public class CamelSecurityPolicyAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSecurityPolicyAutoConfiguration.class);
+    private static final String CAMEL_PREFIX = "camel.";
 
     @Bean
     SecurityPolicyResult camelSecurityPolicyResult(CamelContext camelContext,
@@ -111,10 +113,11 @@ public class CamelSecurityPolicyAutoConfiguration {
             ce.getPropertySources().forEach(ps -> {
                 if (ps instanceof EnumerablePropertySource<?> eps) {
                     for (String name : eps.getPropertyNames()) {
-                        if (name != null && name.startsWith("camel.") && !name.startsWith("camel.security.")) {
-                            Object value = environment.getProperty(name);
+                        String canonical = canonicalCamelName(name);
+                        if (canonical != null && !canonical.startsWith("camel.security.")) {
+                            Object value = environment.getProperty(canonical);
                             if (value != null) {
-                                properties.putIfAbsent(name, value);
+                                properties.putIfAbsent(canonical, value);
                             }
                         }
                     }
@@ -123,6 +126,28 @@ public class CamelSecurityPolicyAutoConfiguration {
         }
 
         return properties;
+    }
+
+    /**
+     * Canonicalizes a property name as its source reports it, returning <tt>null</tt> when it is not a Camel
+     * property.
+     * <p/>
+     * Property sources report names in their own form: an option set in application.properties arrives as
+     * <tt>camel.component.foo.bar</tt>, while the same option set as an environment variable arrives as
+     * <tt>CAMEL_COMPONENT_FOO_BAR</tt>. Spring's relaxed binding applies both to the same option, so both have to
+     * be recognised here - otherwise every option configured through the environment, which is the usual way to
+     * configure a containerised application, is invisible to the policy check.
+     */
+    private static String canonicalCamelName(String name) {
+        if (name == null) {
+            return null;
+        }
+        if (name.startsWith(CAMEL_PREFIX)) {
+            return name;
+        }
+        ConfigurationPropertyName adapted = ConfigurationPropertyName.adapt(name, '_');
+        String canonical = adapted.toString();
+        return canonical.startsWith(CAMEL_PREFIX) ? canonical : null;
     }
 
     private static boolean containsSensitive(CamelContext camelContext, String key, Object value) {

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/security/CamelSecurityPolicyAutoConfigurationTest.java
@@ -22,6 +22,9 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.main.SecurityPolicyResult;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import java.util.Map;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -129,6 +132,40 @@ public class CamelSecurityPolicyAutoConfigurationTest {
                     assertThat(context).hasNotFailed();
                     SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
                     assertThat(result.hasViolations()).isTrue();
+                });
+    }
+
+
+    /**
+     * The same option configured as an environment variable arrives as CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES,
+     * which never matched the "camel." prefix - so every option set through the environment, the usual way to
+     * configure a containerised application, escaped the policy check entirely.
+     */
+    @Test
+    public void policyShouldSeeInsecureOptionsSetThroughTheEnvironment() {
+        runner.withPropertyValues("camel.security.policy=warn")
+                .withInitializer(ctx -> ctx.getEnvironment().getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource("testSystemEnvironment",
+                                Map.of("CAMEL_COMPONENT_HTTP_TRUSTALLCERTIFICATES", "true"))))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isTrue();
+                    assertThat(result.getViolations())
+                            .anySatisfy(v -> assertThat(v.propertyKey()).endsWith("trustallcertificates"));
+                });
+    }
+
+    @Test
+    public void environmentVariablesUnrelatedToCamelAreIgnored() {
+        runner.withPropertyValues("camel.security.policy=warn")
+                .withInitializer(ctx -> ctx.getEnvironment().getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource("testSystemEnvironment",
+                                Map.of("SOME_OTHER_TRUSTALLCERTIFICATES", "true"))))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    SecurityPolicyResult result = context.getBean(SecurityPolicyResult.class);
+                    assertThat(result.hasViolations()).isFalse();
                 });
     }
 


### PR DESCRIPTION
Cherry-pick of #1913 onto `camel-spring-boot-4.22.x`.

**Original PR:** #1913 — camel-spring-boot - see camel properties supplied as environment variables
**JIRA:** [CAMEL-24503](https://issues.apache.org/jira/browse/CAMEL-24503)

### What it fixes

`CamelSecurityPolicyAutoConfiguration.extractCamelProperties` collected candidate properties by
matching each Spring `Environment` property name literally against the `camel.` prefix. That works
fine for properties coming from `application.properties`/YAML, but the `systemEnvironment` property
source reports names in their native form (e.g. `CAMEL_COMPONENT_FOO_BAR`), which never starts with
`camel.` — even though Spring Boot's relaxed binding still applies that value to the Camel component
regardless of how it is expressed.

The practical effect was a security-policy bypass: the `camel.security` policy check introduced in
CAMEL-23250 was blind to any Camel option supplied via environment variables, which is the standard
way to configure a containerised deployment (Docker/Kubernetes env vars, `.env` files, etc.). A
policy-violating option set that way would silently take effect on the component while going
completely unnoticed by the check.

The fix canonicalizes each reported property name with `ConfigurationPropertyName.adapt(name, '_')`
before testing the `camel.` prefix, and performs the environment lookup using that canonical name so
relaxed binding resolves it back to the actual value. `SecurityUtils.getSecurityOption` already
lowercases and strips dashes, so the canonicalized name still matches the same security option
correctly.

### Branch applicability

Confirmed camel-spring-boot-4.18.x does not carry CAMEL-23250's security-policy feature, so this fix does not
apply there — 4.22.x only.

### Verification on this branch

- Cherry-pick (`git cherry-pick -x`) applied cleanly with no conflicts; the diff touches only
  `CamelSecurityPolicyAutoConfiguration.java` and `CamelSecurityPolicyAutoConfigurationTest.java` in
  `core/camel-spring-boot`.
- Ran `CamelSecurityPolicyAutoConfigurationTest` directly: 12/12 tests passed.
- Ran the full `core/camel-spring-boot` module verify (`mvn verify`): 140 tests run, 0 failures, 0
  errors, 1 skipped (pre-existing, unrelated to this change), plus 2 passing integration tests
  (`CamelVirtualThreadsIT`). Overall `BUILD SUCCESS`.
- (Local-build-only workaround: temporarily repointed the unresolvable SNAPSHOT parent/camel-version
  to the released `4.22.0` to allow a from-scratch build; those edits were reverted before pushing —
  this PR contains only the cherry-picked commit.)

_Claude Code on behalf of Federico Mariani_