### PR TITLE
[backport camel-spring-boot-4.18.x] CAMEL-24502: Least privilege for the sync workflows and pin the Maven wrapper downloads

### DIFF
--- a/.github/workflows/automatic-sync-main.yml
+++ b/.github/workflows/automatic-sync-main.yml
@@ -21,21 +21,28 @@ on:
   schedule:
     # Run at midnight every day
     - cron:  '0 0 * * *'
+
+# No grants by default, every job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
   build:
     name: Sync Camel Spring Boot Main Branch
     if: github.repository == 'apache/camel-spring-boot'
     runs-on: ubuntu-latest
+    # Builds apache/camel and camel-spring-boot, so it must not hold any write grant.
+    permissions:
+      contents: read
     steps:
       - name: Checkout Camel project
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: apache/camel
           persist-credentials: false
           ref: main
           path: camel
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: 'temurin'
           java-version: 17
@@ -44,15 +51,60 @@ jobs:
         run: ./mvnw -V --no-transfer-progress -Dquickly clean install
         working-directory: ${{ github.workspace }}/camel
       - name: Checkout Camel-spring-boot project
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           persist-credentials: false
           fetch-depth: 0
       - name: Build Camel-spring-boot Project
         run: ./mvnw -V --no-transfer-progress clean install -DskipTests
+      - name: Collect regenerated sources
+        # Capture the regenerated tree as a patch: it carries additions, modifications
+        # and deletions, ignores build output via .gitignore, and excludes the nested
+        # apache/camel checkout.
+        run: |
+          git add --all -- ':!camel'
+          git diff --cached --binary > "${RUNNER_TEMP}/sync.patch"
+          git reset --quiet
+          echo "Patch size: $(wc -c < "${RUNNER_TEMP}/sync.patch") bytes"
+      - name: Upload regenerated sources
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: regenerated-sources
+          path: ${{ runner.temp }}/sync.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  create-pull-request:
+    name: Create Sync Pull Request
+    needs: build
+    if: github.repository == 'apache/camel-spring-boot'
+    runs-on: ubuntu-latest
+    # Only this job, which runs no third party build, holds the write grants.
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Camel-spring-boot project
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Download regenerated sources
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: regenerated-sources
+          path: ${{ runner.temp }}/sync
+      - name: Apply regenerated sources
+        run: |
+          if [ -s "${RUNNER_TEMP}/sync/sync.patch" ]; then
+            git apply --3way --whitespace=nowarn "${RUNNER_TEMP}/sync/sync.patch"
+          else
+            echo "Nothing was regenerated, no changes to apply"
+          fi
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -22,22 +22,28 @@ on:
     # Every 24 hours
   - cron: '30 17 * * 0'
   workflow_dispatch:
-  
+
+# No grants by default, every job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
   build:
     name: Sync Camel Spring Boot Main Branch
     if: github.repository == 'apache/camel-spring-boot'
     runs-on: ubuntu-latest
+    # Builds apache/camel and camel-spring-boot, so it must not hold any write grant.
+    permissions:
+      contents: read
     steps:
       - name: Checkout Camel project
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: apache/camel
           persist-credentials: false
           ref: main
           path: camel
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: 'temurin'
           java-version: 17
@@ -46,15 +52,60 @@ jobs:
         run: ./mvnw -B -V --no-transfer-progress -Dquickly install
         working-directory: ${{ github.workspace }}/camel
       - name: Checkout Camel-spring-boot project
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: main
           persist-credentials: false
           fetch-depth: 0
       - name: Build Camel-spring-boot Project for generating SBOM
         run: ./mvnw -V --no-transfer-progress clean install -DskipTests -Psbom
+      - name: Collect regenerated sources
+        # Capture the regenerated tree as a patch: it carries additions, modifications
+        # and deletions, ignores build output via .gitignore, and excludes the nested
+        # apache/camel checkout.
+        run: |
+          git add --all -- ':!camel'
+          git diff --cached --binary > "${RUNNER_TEMP}/sync.patch"
+          git reset --quiet
+          echo "Patch size: $(wc -c < "${RUNNER_TEMP}/sync.patch") bytes"
+      - name: Upload regenerated sources
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: regenerated-sources
+          path: ${{ runner.temp }}/sync.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  create-pull-request:
+    name: Create Sync Pull Request
+    needs: build
+    if: github.repository == 'apache/camel-spring-boot'
+    runs-on: ubuntu-latest
+    # Only this job, which runs no third party build, holds the write grants.
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Camel-spring-boot project
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Download regenerated sources
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: regenerated-sources
+          path: ${{ runner.temp }}/sync
+      - name: Apply regenerated sources
+        run: |
+          if [ -s "${RUNNER_TEMP}/sync/sync.patch" ]; then
+            git apply --3way --whitespace=nowarn "${RUNNER_TEMP}/sync/sync.patch"
+          else
+            echo "Nothing was regenerated, no changes to apply"
+          fi
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,6 @@
 wrapperVersion=3.3.4
 distributionType=bin
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+distributionSha256Sum=0d7125e8c91097b36edb990ea5934e6c68b4440eef4ea96510a0f6815e7eeadb
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
+wrapperSha256Sum=4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1


### PR DESCRIPTION
Adapts #1930 for `camel-spring-boot-4.18.x`.

**Original PR:** #1930 — Least privilege for the sync workflows and pin the Maven wrapper downloads
**JIRA:** [CAMEL-24502](https://issues.apache.org/jira/browse/CAMEL-24502)

### What applies on this branch

Both `automatic-sync-main.yml` and `generate-sbom-main.yml` exist on this branch, as leftover
copies from before the branch was cut — they still check out and target `main` (`ref: main`,
`base: main`), not `camel-spring-boot-4.18.x`. That pre-existing quirk is a separate,
non-security concern and is left untouched here; this PR only addresses the permission gap.

Because the two files had diverged from `main`'s (older `actions/checkout`, `actions/setup-java`
and `peter-evans/create-pull-request` tags), a straight `git cherry-pick -x` of the original
commit conflicted on both workflow files. I aborted the cherry-pick and hand-applied the same
pattern instead, keeping this branch's existing action version tags (no version bumps):

- `permissions: {}` declared at the workflow level on both files.
- The single job in each is split into `build` (`contents: read` — checks out and builds
  `apache/camel` then `camel-spring-boot`, so it must not hold any write grant, and uploads the
  regenerated diff as a build artifact) and `create-pull-request` (`contents: write`,
  `pull-requests: write` — downloads and applies the artifact, then calls
  `peter-evans/create-pull-request`; it runs no third-party build code).
- Every `uses:` reference in both files is pinned to a full commit SHA with the existing version
  tag kept as a trailing comment.

Worth noting for reviewers: `automatic-sync-main.yml` only has a `schedule` trigger, and GitHub
only fires scheduled workflows from the copy on the repository's default branch, so this file is
currently unreachable from a non-default branch like this one. `generate-sbom-main.yml` also
declares `workflow_dispatch`, so it *can* be manually dispatched against this branch and was a
real, reachable instance of the permission gap this ticket fixes. Both are hardened here for
consistency and defense in depth, even though one of them is presently dead code.

### Maven wrapper pinning

`.mvn/wrapper/maven-wrapper.properties` on this branch points at the exact same
`distributionUrl` (`apache-maven-3.9.11-bin.zip`) and `wrapperUrl`
(`maven-wrapper-3.3.4.jar`) as `main`'s pre-fix file. I independently downloaded both artifacts,
computed their SHA-256 sums with `shasum -a 256`, and cross-checked them against the `.sha1`
files published alongside them on repo.maven.apache.org — they match main's committed values.
Added `distributionSha256Sum` and `wrapperSha256Sum` in the same format as `main`.

### Verification

- Both modified workflow YAML files parse cleanly (`ruby -ryaml -e 'YAML.load_file(...)'`, PyYAML
  wasn't available in this environment).
- No Java or Maven module was touched, so no `mvn` build/test run was needed for this ticket.

_Claude Code on behalf of Federico Mariani_