### PR TITLE
[backport camel-spring-boot-4.18.x] CAMEL-24593: platform-http-starter - delete multipart uploads when the exchange is done

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/docs/platform-http.adoc
+++ b/components-starter/camel-platform-http-starter/src/main/docs/platform-http.adoc
@@ -17,6 +17,27 @@ carry no matrix parameters. A request to `/greeting/John%20Doe;v=1` sets the `na
 The `CamelHttpPath` header is not affected: it reports the raw request path, with the servlet context-path
 removed.
 
+== File uploads
+
+Every accepted multipart file upload is copied out of the servlet container into the servlet temporary directory
+(`jakarta.servlet.ServletContext#TEMPDIR`), so that it can still be read after the HTTP request has completed. The
+copy is what the route sees: it is the `jakarta.activation.DataSource` of the attachment and, when the request carries
+a single file, also the `java.nio.file.Path` message body and the value of the `CamelFilePath` header.
+
+Because Camel owns that copy, it is deleted again once the exchange is done being routed, that is after the response
+has been written. A route that consumes the upload during routing - saving it with the file producer, streaming it to
+a remote system, unmarshalling it - is unaffected, since the content has already been read or copied by then.
+
+Set the following property if the application hands the temporary file over to something that reads it *after* the
+exchange has completed, in which case the application becomes responsible for deleting the file:
+
+[source,properties]
+----
+camel.component.platform-http.server.delete-uploaded-files-on-end=false
+----
+
+This mirrors the `deleteUploadedFilesOnEnd` option of the Vert.x platform-http implementation and defaults to `true`.
+
 == Undertow Access Log
 
 You can enable Undertow access log to be managed by whatever logging library you have in your camel application, you have to set the following parameters:

--- a/components-starter/camel-platform-http-starter/src/main/docs/platform-http.json
+++ b/components-starter/camel-platform-http-starter/src/main/docs/platform-http.json
@@ -12,6 +12,11 @@
       "sourceMethod": "getCustomizer()"
     },
     {
+      "name": "camel.component.platform-http.server",
+      "type": "org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpServerProperties",
+      "sourceType": "org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpServerProperties"
+    },
+    {
       "name": "camel.component.platform-http.server.undertow.accesslog",
       "type": "org.apache.camel.component.platform.http.springboot.customizer.UndertowAccessLogProperties",
       "sourceType": "org.apache.camel.component.platform.http.springboot.customizer.UndertowAccessLogProperties"
@@ -73,6 +78,13 @@
       "type": "java.lang.Boolean",
       "description": "Whether HTTP server should do preliminary validation of incoming requests, validating if Content-Type\/Accept header, matches what is allowed according to consumes\/produces configuration (if set). If validation fails HTTP Status 415\/406 is returned. The HTTP server performs this validation before Camel is involved, and as such if validation fails then Camel is never activated. Setting this option to false, allows Camel to process any incoming requests such as to do custom validation or all requests must be handled by Camel.",
       "sourceType": "org.apache.camel.component.platform.http.springboot.PlatformHttpComponentConfiguration",
+      "defaultValue": true
+    },
+    {
+      "name": "camel.component.platform-http.server.delete-uploaded-files-on-end",
+      "type": "java.lang.Boolean",
+      "description": "Whether the temporary files, that multipart file uploads are written to, are deleted when the exchange is done being routed. The uploaded file is copied out of the servlet container into the servlet temp directory so that it stays readable after the HTTP request has completed, which makes Camel the owner of that copy. Turn this off only if the route hands the file over to something that reads it after the exchange has completed - the route is then responsible for deleting the file.",
+      "sourceType": "org.apache.camel.component.platform.http.springboot.SpringBootPlatformHttpServerProperties",
       "defaultValue": true
     },
     {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -39,13 +39,15 @@ import java.util.concurrent.Executor;
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(name = { "org.apache.camel.component.servlet.springboot.PlatformHttpComponentAutoConfiguration",
         "org.apache.camel.component.servlet.springboot.PlatformHttpComponentConverter" })
-@EnableConfigurationProperties({ComponentConfigurationProperties.class,PlatformHttpComponentConfiguration.class, WebMvcProperties.class})
+@EnableConfigurationProperties({ComponentConfigurationProperties.class,PlatformHttpComponentConfiguration.class, WebMvcProperties.class,
+        SpringBootPlatformHttpServerProperties.class})
 public class SpringBootPlatformHttpAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(SpringBootPlatformHttpAutoConfiguration.class);
 
     @Bean(name = "platform-http-engine")
     @ConditionalOnMissingBean(PlatformHttpEngine.class)
-    public PlatformHttpEngine springBootPlatformHttpEngine(Environment env, List<Executor> executors) {
+    public PlatformHttpEngine springBootPlatformHttpEngine(Environment env, List<Executor> executors,
+                                                           SpringBootPlatformHttpServerProperties serverHttpProperties) {
         Executor executor;
 
         if (executors != null && !executors.isEmpty()) {
@@ -92,7 +94,7 @@ public class SpringBootPlatformHttpAutoConfiguration {
             LOG.debug("Using executor: {}", executor.getClass().getName());
         }
         int port = Integer.parseInt(env.getProperty("server.port", "8080"));
-        return new SpringBootPlatformHttpEngine(port, executor);
+        return new SpringBootPlatformHttpEngine(port, executor, serverHttpProperties.isDeleteUploadedFilesOnEnd());
     }
 
     @Bean

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBinding.java
@@ -37,6 +37,7 @@ import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.camel.http.base.HttpHelper;
 import org.apache.camel.http.common.DefaultHttpBinding;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.support.SynchronizationAdapter;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.URISupport;
@@ -57,8 +58,10 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -68,6 +71,7 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
     private static final Logger LOG = LoggerFactory.getLogger(SpringBootPlatformHttpBinding.class);
 
     private boolean streaming;
+    private boolean deleteUploadedFilesOnEnd = true;
     private static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded";
     private static final List<Method> METHODS_WITH_BODY_ALLOWED = List.of(Method.POST,
             Method.PUT, Method.PATCH, Method.DELETE);
@@ -145,6 +149,9 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
             boolean isSingleAttachment = multipartHttpServletRequest.getFileMap() != null &&
                     multipartHttpServletRequest.getFileMap().keySet().size() == 1;
             message.setHeader(Exchange.ATTACHMENTS_SIZE, multipartHttpServletRequest.getFileMap().keySet().size());
+            // the uploads are copied out of the servlet container and are therefore owned by Camel, they are
+            // deleted again when the exchange is done being routed (unless deleteUploadedFilesOnEnd is turned off)
+            final List<Path> uploadedTmpFiles = new ArrayList<>();
             multipartHttpServletRequest.getFileMap().forEach((name, multipartFile) -> {
                 try {
                     if (name != null) {
@@ -163,6 +170,7 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
 
                     Path uploadedTmpFile = Paths.get(tmpFolder.getPath(), UUID.randomUUID().toString());
                     multipartFile.transferTo(uploadedTmpFile);
+                    uploadedTmpFiles.add(uploadedTmpFile);
 
                     AttachmentMessage am = new DefaultAttachmentMessage(message);
                     File uploadedFile = uploadedTmpFile.toFile();
@@ -185,7 +193,40 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
                     throw new RuntimeException(e);
                 }
             });
+
+            if (deleteUploadedFilesOnEnd && !uploadedTmpFiles.isEmpty()) {
+                registerUploadedFilesCleanup(message, uploadedTmpFiles);
+            }
         }
+    }
+
+    /**
+     * Deletes the temporary copies of the uploaded files when the exchange is done being routed.
+     * <p/>
+     * The attachment {@code DataSource} and, for a single upload, the message body point at those
+     * files for as long as the exchange is being routed, so the files can only be deleted on completion.
+     */
+    private void registerUploadedFilesCleanup(Message message, List<Path> uploadedTmpFiles) {
+        Exchange exchange = message.getExchange();
+        if (exchange == null) {
+            LOG.debug("Cannot delete uploaded temporary files as the message is not associated with an exchange");
+            return;
+        }
+        exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
+            @Override
+            public void onDone(Exchange doneExchange) {
+                for (Path uploadedTmpFile : uploadedTmpFiles) {
+                    try {
+                        if (Files.deleteIfExists(uploadedTmpFile)) {
+                            LOG.trace("Deleted uploaded temporary file: {}", uploadedTmpFile);
+                        }
+                    } catch (IOException e) {
+                        LOG.debug("Cannot delete uploaded temporary file: {} due to: {}. This exception is ignored.",
+                                uploadedTmpFile, e.getMessage(), e);
+                    }
+                }
+            }
+        });
     }
 
     /**
@@ -222,6 +263,17 @@ public class SpringBootPlatformHttpBinding extends DefaultHttpBinding {
 
     public void setStreaming(boolean streaming) {
         this.streaming = streaming;
+    }
+
+    public boolean isDeleteUploadedFilesOnEnd() {
+        return deleteUploadedFilesOnEnd;
+    }
+
+    /**
+     * Whether the temporary copies of multipart file uploads are deleted when the exchange is done being routed.
+     */
+    public void setDeleteUploadedFilesOnEnd(boolean deleteUploadedFilesOnEnd) {
+        this.deleteUploadedFilesOnEnd = deleteUploadedFilesOnEnd;
     }
 
     public Object parseBody(HttpServletRequest request, Message message) throws IOException {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -78,6 +78,15 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
         this.binding = binding;
     }
 
+    /**
+     * Whether the temporary copies of multipart file uploads are deleted when the exchange is done being routed.
+     */
+    public void setDeleteUploadedFilesOnEnd(boolean deleteUploadedFilesOnEnd) {
+        if (binding instanceof SpringBootPlatformHttpBinding springBootBinding) {
+            springBootBinding.setDeleteUploadedFilesOnEnd(deleteUploadedFilesOnEnd);
+        }
+    }
+
     @Override
     public PlatformHttpEndpoint getEndpoint() {
         return (PlatformHttpEndpoint) super.getEndpoint();

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngine.java
@@ -27,6 +27,7 @@ public class SpringBootPlatformHttpEngine implements PlatformHttpEngine {
 
     private final int port;
     private Executor executor;
+    private boolean deleteUploadedFilesOnEnd = true;
 
     public SpringBootPlatformHttpEngine(int port) {
         this.port = port;
@@ -37,9 +38,16 @@ public class SpringBootPlatformHttpEngine implements PlatformHttpEngine {
         this.executor = executor;
     }
 
+    public SpringBootPlatformHttpEngine(int port, Executor executor, boolean deleteUploadedFilesOnEnd) {
+        this(port, executor);
+        this.deleteUploadedFilesOnEnd = deleteUploadedFilesOnEnd;
+    }
+
     @Override
     public PlatformHttpConsumer createConsumer(PlatformHttpEndpoint endpoint, Processor processor) {
-        return new SpringBootPlatformHttpConsumer(endpoint, processor, executor);
+        SpringBootPlatformHttpConsumer consumer = new SpringBootPlatformHttpConsumer(endpoint, processor, executor);
+        consumer.setDeleteUploadedFilesOnEnd(deleteUploadedFilesOnEnd);
+        return consumer;
     }
 
     @Override

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerProperties.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Spring Boot HTTP server serving the platform-http endpoints.
+ */
+@ConfigurationProperties(prefix = "camel.component.platform-http.server")
+public class SpringBootPlatformHttpServerProperties {
+
+    /**
+     * Whether the temporary files, that multipart file uploads are written to, are deleted when the exchange is done
+     * being routed. The uploaded file is copied out of the servlet container into the servlet temp directory so that
+     * it stays readable after the HTTP request has completed, which makes Camel the owner of that copy. Turn this off
+     * only if the route hands the file over to something that reads it after the exchange has completed - the route is
+     * then responsible for deleting the file.
+     */
+    private boolean deleteUploadedFilesOnEnd = true;
+
+    public boolean isDeleteUploadedFilesOnEnd() {
+        return deleteUploadedFilesOnEnd;
+    }
+
+    public void setDeleteUploadedFilesOnEnd(boolean deleteUploadedFilesOnEnd) {
+        this.deleteUploadedFilesOnEnd = deleteUploadedFilesOnEnd;
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpUploadCleanupDisabledTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpUploadCleanupDisabledTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import io.restassured.RestAssured;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the opt-out: with
+ * {@code camel.component.platform-http.server.delete-uploaded-files-on-end=false} the temporary copy of the upload
+ * survives the exchange and the route is responsible for it.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "camel.component.platform-http.server.delete-uploaded-files-on-end=false",
+        classes = { CamelAutoConfiguration.class,
+                SpringBootPlatformHttpUploadCleanupDisabledTest.class,
+                SpringBootPlatformHttpUploadCleanupDisabledTest.TestConfiguration.class,
+                PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpUploadCleanupDisabledTest {
+
+    private static final byte[] CONTENT = "upload content".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void uploadIsKeptWhenCleanupIsTurnedOff() throws IOException {
+        String uploadPath = given().multiPart("file", "invoice.txt", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header(UploadCleanupRoute.ATTACHMENT_COUNT, is("1"))
+                .header(UploadCleanupRoute.EXISTED_DURING_ROUTING, is("true"))
+                .extract()
+                .header(UploadCleanupRoute.UPLOAD_PATHS);
+
+        Path uploadedFile = Paths.get(uploadPath);
+        try {
+            // give any (unwanted) completion driven deletion time to happen before asserting the file is still there
+            await().pollDelay(Duration.ofMillis(500))
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertTrue(Files.exists(uploadedFile),
+                            "Uploaded temporary file should have been kept: " + uploadedFile));
+        } finally {
+            // the application owns the file when the cleanup is turned off, so do not leave it behind
+            Files.deleteIfExists(uploadedFile);
+        }
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .csrf(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder uploadCleanupRoute() {
+            return new UploadCleanupRoute();
+        }
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpUploadCleanupTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpUploadCleanupTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Multipart uploads are copied out of the servlet container into the servlet temp directory, which makes Camel the
+ * owner of the copy. Verifies the copy is readable while the exchange is routed and is deleted once the exchange is
+ * done, which is the default behaviour.
+ */
+@EnableAutoConfiguration
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
+        SpringBootPlatformHttpUploadCleanupTest.class,
+        SpringBootPlatformHttpUploadCleanupTest.TestConfiguration.class,
+        PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
+public class SpringBootPlatformHttpUploadCleanupTest {
+
+    private static final byte[] CONTENT = "upload content".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private Environment env;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = env.getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    @Test
+    void singleUploadIsDeletedWhenTheExchangeIsDone() {
+        ExtractableResponse<Response> response = given().multiPart("file", "invoice.txt", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header(UploadCleanupRoute.ATTACHMENT_COUNT, is("1"))
+                .header(UploadCleanupRoute.EXISTED_DURING_ROUTING, is("true"))
+                .extract();
+
+        String uploadPath = response.header(UploadCleanupRoute.UPLOAD_PATHS);
+        // the single upload is also handed to the route as the message body and as the CamelFilePath header
+        assertEquals(uploadPath, response.header(UploadCleanupRoute.FILE_PATH_HEADER));
+        assertEquals(uploadPath, response.header(UploadCleanupRoute.BODY_PATH));
+
+        Path uploadedFile = Paths.get(uploadPath);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertFalse(Files.exists(uploadedFile),
+                        "Uploaded temporary file should have been deleted: " + uploadedFile));
+    }
+
+    @Test
+    void allUploadsAreDeletedWhenTheExchangeIsDone() {
+        String uploadPaths = given().multiPart("first", "first.txt", CONTENT)
+                .multiPart("second", "second.txt", CONTENT)
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header(UploadCleanupRoute.ATTACHMENT_COUNT, is("2"))
+                .header(UploadCleanupRoute.EXISTED_DURING_ROUTING, is("true"))
+                .extract()
+                .header(UploadCleanupRoute.UPLOAD_PATHS);
+
+        String[] paths = uploadPaths.split(",");
+        assertEquals(2, paths.length, "Expected both uploads to be reported: " + uploadPaths);
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            for (String path : paths) {
+                assertFalse(Files.exists(Paths.get(path)), "Uploaded temporary file should have been deleted: " + path);
+            }
+        });
+    }
+
+    /**
+     * A multipart request that carries no file part registers no cleanup and keeps working.
+     */
+    @Test
+    void requestWithoutFilePartIsNotAffected() {
+        given().multiPart("field", "value")
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .header(UploadCleanupRoute.ATTACHMENT_COUNT, is("0"));
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .csrf(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+
+        @Bean
+        public RouteBuilder uploadCleanupRoute() {
+            return new UploadCleanupRoute();
+        }
+    }
+}

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/UploadCleanupRoute.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/UploadCleanupRoute.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.springboot;
+
+import jakarta.activation.DataHandler;
+import jakarta.activation.FileDataSource;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.attachment.AttachmentMessage;
+import org.apache.camel.builder.RouteBuilder;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Reports back, in the response headers, where the accepted multipart uploads were written to and whether they were
+ * still readable while the exchange was being routed. Used to assert the temporary file handling of
+ * {@link SpringBootPlatformHttpBinding}.
+ */
+public class UploadCleanupRoute extends RouteBuilder {
+
+    static final String UPLOAD_PATHS = "uploadPaths";
+    static final String ATTACHMENT_COUNT = "attachmentCount";
+    static final String EXISTED_DURING_ROUTING = "existedDuringRouting";
+    static final String FILE_PATH_HEADER = "filePathHeader";
+    static final String BODY_PATH = "bodyPath";
+
+    @Override
+    public void configure() {
+        from("platform-http:/upload")
+                .routeId("upload")
+                .process(exchange -> {
+                    AttachmentMessage am = exchange.getMessage(AttachmentMessage.class);
+                    StringBuilder paths = new StringBuilder();
+                    boolean existed = true;
+                    int count = 0;
+                    if (am.getAttachments() != null) {
+                        for (DataHandler dataHandler : am.getAttachments().values()) {
+                            File file = ((FileDataSource) dataHandler.getDataSource()).getFile();
+                            if (count > 0) {
+                                paths.append(',');
+                            }
+                            paths.append(file.getAbsolutePath());
+                            existed = existed && file.isFile();
+                            count++;
+                        }
+                    }
+
+                    Message message = exchange.getMessage();
+                    Object body = message.getBody();
+                    Object filePath = message.getHeader(Exchange.FILE_PATH);
+                    message.setHeader(ATTACHMENT_COUNT, String.valueOf(count));
+                    message.setHeader(UPLOAD_PATHS, paths.toString());
+                    message.setHeader(EXISTED_DURING_ROUTING, String.valueOf(existed));
+                    message.setHeader(FILE_PATH_HEADER, filePath == null ? "" : filePath.toString());
+                    message.setHeader(BODY_PATH, body instanceof Path path ? path.toAbsolutePath().toString() : "");
+                    message.setBody("ok");
+                });
+    }
+}


### PR DESCRIPTION
> **Update:** Rebased onto the now-merged CAMEL-24577 (#1958) to resolve a merge conflict introduced
> once #1958 landed on `camel-spring-boot-4.18.x` after this PR was opened. Both fixes now coexist in
> `SpringBootPlatformHttpBinding.java` (CAMEL-24577's path-variable extraction and CAMEL-24593's
> upload-cleanup registration live in separate, non-overlapping parts of the class), and the
> "Path variables" doc section (CAMEL-24577) is restored alongside the "File uploads" section this PR
> adds in `platform-http.adoc` — see the updated "Depends on" section below.

Cherry-pick of #1934 onto `camel-spring-boot-4.18.x`.

**Original PR:** #1934 — platform-http-starter - delete multipart uploads when the exchange is done
**JIRA:** [CAMEL-24593](https://issues.apache.org/jira/browse/CAMEL-24593)

### What it fixes

`SpringBootPlatformHttpBinding.populateAttachments()` copies every accepted multipart upload out of
the servlet container into the servlet temp directory, and uses that copy as the attachment
`DataSource` and, for a single upload, as the `Path` message body and the `CamelFilePath` header.
Because `MultipartFile.transferTo()` moves the container's part file, the container's own
end-of-request cleanup can no longer find it, and nothing in the starter deleted the copy either —
every accepted upload stayed on disk for the life of the process.

The copy was introduced in CAMEL-21461 so the body can be a `Path` and the attachment stays readable
after the servlet request has completed, which is a good reason to own the file — but owning it means
being responsible for removing it too. The other HTTP bindings don't have this problem:
`camel-http-common` reads the part through the container-managed file (which the container deletes),
and `camel-platform-http-vertx` already defaults `deleteUploadedFilesOnEnd` to `true`.

The binding now tracks the temp files it created for a request and registers a `Synchronization`
via `ExchangeExtension.addOnCompletion` that deletes them once the exchange is done being routed —
after the HTTP response has already been written, so nothing currently reading the files is
affected. A new opt-out property, `camel.component.platform-http.server.delete-uploaded-files-on-end`
(default `true`), mirrors the Vert.x option, for routes that hand the file to something that reads it
after the exchange completes.

This is a resource-leak fix only: no default-behavior change to existing routes, and existing public
constructors are unchanged.

### Depends on CAMEL-24496

This cherry-picks onto `camel-spring-boot-4.18.x` on top of CAMEL-24496 (#1952), merged into this
branch just before this PR was opened. It did **not** apply fully cleanly — four conflicts, all
because this branch's `SpringBootPlatformHttpAutoConfiguration`/`SpringBootPlatformHttpEngine` carry
pre-existing 4.18.x-only code (a more elaborate executor-selection strategy for virtual threads /
Spring Security executors, and `env.getProperty("server.port", ...)` instead of a `ServerProperties`
bean) that main no longer has. I resolved these by keeping this branch's existing structure and
wiring the new `SpringBootPlatformHttpServerProperties`/`deleteUploadedFilesOnEnd` plumbing through it,
rather than pulling in main's unrelated refactors:

- `SpringBootPlatformHttpAutoConfiguration.java` — kept this branch's `@Configuration`/executor-selection
  logic, added `SpringBootPlatformHttpServerProperties` to `@EnableConfigurationProperties` and threaded
  it into `springBootPlatformHttpEngine(...)`.
- `SpringBootPlatformHttpEngine.java` — kept this branch's mutable `executor` field / constructor
  chaining (no `executor == null` branch in `createConsumer`, which is a pre-existing main-only
  refactor unrelated to this fix), added the `deleteUploadedFilesOnEnd` field, the new 3-arg
  constructor, and wired `setDeleteUploadedFilesOnEnd` onto the created consumer.
- `components-starter/camel-platform-http-starter/src/main/docs/platform-http.adoc` — this PR was
  originally opened before CAMEL-24577 (#1958, "platform-http path variables follow the path Spring
  matched") was merged into `camel-spring-boot-4.18.x`, so the file conflicted twice: first against
  CAMEL-24496 (resolved by taking only the new "File uploads" section), and again after rebasing onto
  the now-merged CAMEL-24577, whose "Path variables" section landed in the same spot. Both sections
  now coexist: "Path variables" (CAMEL-24577) followed by "File uploads" (this PR).
- `docs/spring-boot/modules/ROOT/pages/starters/platform-http.adoc` — modify/delete conflict: this
  aggregated docs page no longer exists on this branch (removed as part of an earlier, unrelated docs
  restructuring), so I kept it deleted rather than resurrecting it.
- `SpringBootPlatformHttpBinding.java` and `SpringBootPlatformHttpConsumer.java` auto-merged cleanly
  against CAMEL-24496 and, after the later rebase, against CAMEL-24577 as well — they coexist correctly
  with CAMEL-24496's filename-whitelist checks (which run earlier in `populateAttachments()`, before
  this fix's cleanup registration) and with CAMEL-24577's path-variable extraction (`getMatchedPath()`),
  which lives in an entirely separate part of the class.

I also updated the two new test classes' `CamelSpringBootTest` import from
`org.apache.camel.test.spring.junit6` (main) to `org.apache.camel.test.spring.junit5` (this branch is
Spring Boot 3 / JUnit 5), matching every neighboring test in this module.

### Verification on this branch

- Cherry-pick required manual conflict resolution as described above (not a clean apply); resolution
  reviewed against both sides of the diff. Re-verified after rebasing onto the merged CAMEL-24577.
- Built with `./mvnw -DskipTests -Dfastinstall install -pl components-starter/camel-platform-http-starter -am`
  (parent/`camel-version` temporarily repointed to the released `4.18.4` for local resolution, reverted
  afterwards) — succeeded.
- Ran `../../mvnw verify` in `components-starter/camel-platform-http-starter`: 124 tests run, 1
  failure. The failure is `SpringBootPlatformHttpRequestTimeoutTest.testGetAsync`, a pre-existing,
  unrelated flake on this branch (retried 3 times by surefire, failed each time) — not caused by this
  change. Both this fix's tests (`SpringBootPlatformHttpUploadCleanupTest`,
  `SpringBootPlatformHttpUploadCleanupDisabledTest`) and CAMEL-24577's path-variable tests
  (`SpringBootPlatformHttpPathVariableTest`, `SpringBootPlatformHttpBindingPathVariableTest`) passed.
- Confirmed `git diff origin/camel-spring-boot-4.18.x --stat` only shows the 10 files touched by the
  cherry-picked commit itself (temporary pom.xml/catalog build artifacts reverted).

_Claude Code on behalf of Federico Mariani_
