### PR TITLE
Fix broken Javadocs badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Camel Spring Boot Support
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.camel/apache-camel.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.apache.camel/apache-camel)
-[![Javadocs](https://www.javadoc.io/badge/org.apache.camel/camel-core.svg?color=brightgreen)](https://www.javadoc.io/doc/org.apache.camel/camel-core)
+[![Javadocs](https://www.javadoc.io/badge/org.apache.camel/camel-api.svg?color=brightgreen)](https://www.javadoc.io/doc/org.apache.camel/camel-api)
 [![Stack Overflow](https://img.shields.io/:stack%20overflow-apache--camel-brightgreen.svg)](https://stackoverflow.com/questions/tagged/apache-camel)
 [![Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://camel.zulipchat.com/)
 [![Twitter](https://img.shields.io/twitter/follow/ApacheCamel.svg?label=Follow&style=social)](https://twitter.com/ApacheCamel)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Camel Spring Boot Support
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.camel/apache-camel.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.apache.camel/apache-camel)
-[![Javadocs](http://www.javadoc.io/badge/org.apache.camel/apache-camel.svg?color=brightgreen)](https://www.javadoc.io/doc/org.apache.camel/camel-core)
+[![Javadocs](https://www.javadoc.io/badge/org.apache.camel/camel-core.svg?color=brightgreen)](https://www.javadoc.io/doc/org.apache.camel/camel-core)
 [![Stack Overflow](https://img.shields.io/:stack%20overflow-apache--camel-brightgreen.svg)](https://stackoverflow.com/questions/tagged/apache-camel)
 [![Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://camel.zulipchat.com/)
 [![Twitter](https://img.shields.io/twitter/follow/ApacheCamel.svg?label=Follow&style=social)](https://twitter.com/ApacheCamel)


### PR DESCRIPTION
The badge image referenced org.apache.camel/apache-camel, while the link it wrapped pointed to a different artifact, org.apache.camel/camel-core, and used http:// instead of https://. This mismatch caused the badge/link to appear broken. 

Change
 -Aligned the badge image and link to both reference org.apache.camel/camel-core
 -Updated the URL scheme from http to https